### PR TITLE
Added regex to replace / with _ in resource name

### DIFF
--- a/source/javascripts/swagger-service.js
+++ b/source/javascripts/swagger-service.js
@@ -65,7 +65,7 @@ function SwaggerService(baseUrl, _apiKey, statusCallback) {
       this.path_xml = this.path.replace("{format}", "xml");
       this.baseUrl = apiHost;
       //execluded 9 letters to remove .{format} from name
-      this.name = this.path.substr(1, this.path.length - formatString.length - 1);
+      this.name = this.path.substr(1, this.path.length - formatString.length - 1).replace(/\//g, "_");
       this.apiList = Api.sub();
       this.modelList = ApiModel.sub();
     },


### PR DESCRIPTION
I found an issue with the Swagger UI with resources with forward slashes in their path.  For instance, if you have a resource bound to a nested URI path, such as /widgets/widget, the Swagger UI cannot handle this, as forward slashes are not allowed in DOM ID values (it causes the click handlers to expand the widgets on the UI to not work).  Therefore, I applied a simple fix to replace all instances of '/' with '_' to get the UI working again.
