### PR TITLE
Add escaping for illegal CSS-selectors.

### DIFF
--- a/build/index.html
+++ b/build/index.html
@@ -27,7 +27,7 @@
     <script type="text/x-jquery-tmpl" id="resourceTemplate"><li class='resource' id='resource_${name}'>
       <div class='heading'>
         <h2>
-          <a href='#!/${name}' onclick="Docs.toggleEndpointListForResource('${name}');">${path}</a>
+          <a href='#!/${name}' onclick="Docs.toggleEndpointListForResource('${name}');">${name}</a>
         </h2>
         <ul class='options'>
           <li>
@@ -159,7 +159,7 @@
     </script>
     <div id='content_message'>
       Enter the base URL of the API that you wish to explore, or try
-      <a onclick="$('#input_baseUrl').val('http://petstore.swagger.wordnik.com/api/resources.json'); apiSelectionController.showApi(); return false;" href="#">petstore.swagger.wordnik.com/api/resources.json</a>
+      <a href="#" onclick="$('#input_baseUrl').val('http://petstore.swagger.wordnik.com/api/resources.json'); apiSelectionController.showApi(); return false;">petstore.swagger.wordnik.com/api/resources.json</a>
     </div>
     <p id='colophon' style='display:none'>
       Sexy API documentation from

--- a/build/javascripts/app.js
+++ b/build/javascripts/app.js
@@ -2262,6 +2262,7 @@ var Docs = {
 	},
 
 	toggleOperationContent: function(dom_id) {
+		dom_id = dom_id.replace(/([^a-zA-Z0-9\-\_])/g, "\\$1");
 		var elem = $('#' + dom_id);
 		(elem.is(':visible')) ? Docs.collapseOperation(elem) : Docs.expandOperation(elem);
 	}

--- a/build/javascripts/doc.js
+++ b/build/javascripts/doc.js
@@ -156,6 +156,7 @@ var Docs = {
 	},
 
 	toggleOperationContent: function(dom_id) {
+		dom_id = dom_id.replace(/([^a-zA-Z0-9\-\_])/g, "\\$1");
 		var elem = $('#' + dom_id);
 		(elem.is(':visible')) ? Docs.collapseOperation(elem) : Docs.expandOperation(elem);
 	}

--- a/build/javascripts/swagger-service.js
+++ b/build/javascripts/swagger-service.js
@@ -175,7 +175,7 @@ function SwaggerService(discoveryUrl, _apiKey, statusCallback) {
       return "{" + this.path_json + "| " + this.nickname + paramsString + ": " + this.summary + "}";
     },
 
-    invocationUrl: function(formValues) {
+    invocationData: function(formValues) {
       var formValuesMap = new Object();
       for (var i = 0; i < formValues.length; i++) {
         var formValue = formValues[i];
@@ -189,21 +189,23 @@ function SwaggerService(discoveryUrl, _apiKey, statusCallback) {
       var url = $.tmpl(urlTemplate, formValuesMap)[0].data;
       // log("url with path params = " + url);
 
-      var queryParams = apiKeySuffix;
+      var queryParams = {};
+      if (apiKey) {
+        apiKey = jQuery.trim(apiKey);
+        if (apiKey.length > 0)
+          queryParams['api_key'] = apiKey;
+      }
       this.parameters.each(function(param) {
         var paramValue = jQuery.trim(formValuesMap[param.name]);
         if (param.paramType == "query" && paramValue.length > 0) {
-          queryParams += queryParams.length > 0 ? "&": "?";
-          queryParams += param.name;
-          queryParams += "=";
-          queryParams += formValuesMap[param.name];
+          queryParams[param.name] = formValuesMap[param.name];
         }
       });
 
-      url = this.baseUrl + url + queryParams;
+      url = this.baseUrl + url;
       // log("final url with query params and base url = " + url);
 
-      return url;
+      return {url: url, queryParams: queryParams};
     }
 
   });

--- a/build/stylesheets/screen.css
+++ b/build/stylesheets/screen.css
@@ -89,18 +89,16 @@ div.heading_with_menu {
     display: block;
     clear: none;
     float: left;
-    -moz-box-sizing: border-box;
     -webkit-box-sizing: border-box;
-    -ms-box-sizing: border-box;
+    -moz-box-sizing: border-box;
     box-sizing: border-box;
     width: 60%; }
   div.heading_with_menu ul {
     display: block;
     clear: none;
     float: right;
-    -moz-box-sizing: border-box;
     -webkit-box-sizing: border-box;
-    -ms-box-sizing: border-box;
+    -moz-box-sizing: border-box;
     box-sizing: border-box;
     margin-top: 10px; }
 
@@ -318,11 +316,10 @@ body {
           font-size: 0.9em;
           color: white;
           background-color: #547f00;
-          -moz-border-radius: 4px;
           -webkit-border-radius: 4px;
-          -o-border-radius: 4px;
+          -moz-border-radius: 4px;
           -ms-border-radius: 4px;
-          -khtml-border-radius: 4px;
+          -o-border-radius: 4px;
           border-radius: 4px; }
           body #header form#api_selector .input a#explore:hover {
             background-color: #547f00; }
@@ -436,11 +433,10 @@ body {
                 font-size: 0.7em;
                 text-align: center;
                 padding: 7px 0 4px 0;
-                -moz-border-radius: 2px;
                 -webkit-border-radius: 2px;
-                -o-border-radius: 2px;
+                -moz-border-radius: 2px;
                 -ms-border-radius: 2px;
-                -khtml-border-radius: 2px;
+                -o-border-radius: 2px;
                 border-radius: 2px; }
               body ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.get div.heading h3 span.path {
                 padding-left: 10px; }
@@ -487,15 +483,13 @@ body {
           padding: 10px;
           -moz-border-radius-bottomleft: 6px;
           -webkit-border-bottom-left-radius: 6px;
-          -o-border-bottom-left-radius: 6px;
           -ms-border-bottom-left-radius: 6px;
-          -khtml-border-bottom-left-radius: 6px;
+          -o-border-bottom-left-radius: 6px;
           border-bottom-left-radius: 6px;
           -moz-border-radius-bottomright: 6px;
           -webkit-border-bottom-right-radius: 6px;
-          -o-border-bottom-right-radius: 6px;
           -ms-border-bottom-right-radius: 6px;
-          -khtml-border-bottom-right-radius: 6px;
+          -o-border-bottom-right-radius: 6px;
           border-bottom-right-radius: 6px;
           margin: 0 0 20px 0; }
           body ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.get div.content h4 {
@@ -575,11 +569,10 @@ body {
                 font-size: 0.7em;
                 text-align: center;
                 padding: 7px 0 4px 0;
-                -moz-border-radius: 2px;
                 -webkit-border-radius: 2px;
-                -o-border-radius: 2px;
+                -moz-border-radius: 2px;
                 -ms-border-radius: 2px;
-                -khtml-border-radius: 2px;
+                -o-border-radius: 2px;
                 border-radius: 2px; }
               body ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.post div.heading h3 span.path {
                 padding-left: 10px; }
@@ -626,15 +619,13 @@ body {
           padding: 10px;
           -moz-border-radius-bottomleft: 6px;
           -webkit-border-bottom-left-radius: 6px;
-          -o-border-bottom-left-radius: 6px;
           -ms-border-bottom-left-radius: 6px;
-          -khtml-border-bottom-left-radius: 6px;
+          -o-border-bottom-left-radius: 6px;
           border-bottom-left-radius: 6px;
           -moz-border-radius-bottomright: 6px;
           -webkit-border-bottom-right-radius: 6px;
-          -o-border-bottom-right-radius: 6px;
           -ms-border-bottom-right-radius: 6px;
-          -khtml-border-bottom-right-radius: 6px;
+          -o-border-bottom-right-radius: 6px;
           border-bottom-right-radius: 6px;
           margin: 0 0 20px 0; }
           body ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.post div.content h4 {
@@ -714,11 +705,10 @@ body {
                 font-size: 0.7em;
                 text-align: center;
                 padding: 7px 0 4px 0;
-                -moz-border-radius: 2px;
                 -webkit-border-radius: 2px;
-                -o-border-radius: 2px;
+                -moz-border-radius: 2px;
                 -ms-border-radius: 2px;
-                -khtml-border-radius: 2px;
+                -o-border-radius: 2px;
                 border-radius: 2px; }
               body ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.put div.heading h3 span.path {
                 padding-left: 10px; }
@@ -765,15 +755,13 @@ body {
           padding: 10px;
           -moz-border-radius-bottomleft: 6px;
           -webkit-border-bottom-left-radius: 6px;
-          -o-border-bottom-left-radius: 6px;
           -ms-border-bottom-left-radius: 6px;
-          -khtml-border-bottom-left-radius: 6px;
+          -o-border-bottom-left-radius: 6px;
           border-bottom-left-radius: 6px;
           -moz-border-radius-bottomright: 6px;
           -webkit-border-bottom-right-radius: 6px;
-          -o-border-bottom-right-radius: 6px;
           -ms-border-bottom-right-radius: 6px;
-          -khtml-border-bottom-right-radius: 6px;
+          -o-border-bottom-right-radius: 6px;
           border-bottom-right-radius: 6px;
           margin: 0 0 20px 0; }
           body ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.put div.content h4 {
@@ -853,11 +841,10 @@ body {
                 font-size: 0.7em;
                 text-align: center;
                 padding: 7px 0 4px 0;
-                -moz-border-radius: 2px;
                 -webkit-border-radius: 2px;
-                -o-border-radius: 2px;
+                -moz-border-radius: 2px;
                 -ms-border-radius: 2px;
-                -khtml-border-radius: 2px;
+                -o-border-radius: 2px;
                 border-radius: 2px; }
               body ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.delete div.heading h3 span.path {
                 padding-left: 10px; }
@@ -904,15 +891,13 @@ body {
           padding: 10px;
           -moz-border-radius-bottomleft: 6px;
           -webkit-border-bottom-left-radius: 6px;
-          -o-border-bottom-left-radius: 6px;
           -ms-border-bottom-left-radius: 6px;
-          -khtml-border-bottom-left-radius: 6px;
+          -o-border-bottom-left-radius: 6px;
           border-bottom-left-radius: 6px;
           -moz-border-radius-bottomright: 6px;
           -webkit-border-bottom-right-radius: 6px;
-          -o-border-bottom-right-radius: 6px;
           -ms-border-bottom-right-radius: 6px;
-          -khtml-border-bottom-right-radius: 6px;
+          -o-border-bottom-right-radius: 6px;
           border-bottom-right-radius: 6px;
           margin: 0 0 20px 0; }
           body ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.delete div.content h4 {

--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -5,7 +5,7 @@
   %li.resource{:id => "resource_${name}"}
     .heading
       %h2
-        %a{:href => "#!/${name}", :onclick => "Docs.toggleEndpointListForResource('${name}');"} ${path}
+        %a{:href => "#!/${name}", :onclick => "Docs.toggleEndpointListForResource('${name}');"} ${name}
       %ul.options
         %li
           %a{:href => "#!/${name}", :id => "endpointListTogger_${name}", :onclick => "Docs.toggleEndpointListForResource('${name}');"} Show/Hide

--- a/source/javascripts/doc.js
+++ b/source/javascripts/doc.js
@@ -156,6 +156,7 @@ var Docs = {
 	},
 
 	toggleOperationContent: function(dom_id) {
+		dom_id = dom_id.replace(/([^a-zA-Z0-9\-\_])/g, "\\$1");
 		var elem = $('#' + dom_id);
 		(elem.is(':visible')) ? Docs.collapseOperation(elem) : Docs.expandOperation(elem);
 	}

--- a/source/javascripts/swagger-ui.js
+++ b/source/javascripts/swagger-ui.js
@@ -189,7 +189,8 @@ jQuery(function($) {
     },
 
     renderApi: function(api) {
-      var resourceApisContainer = "#" + this.apiResource.name + "_endpoint_list";
+      var name = this.apiResource.name.replace(/([^a-zA-Z0-9\-\_])/g, "\\$1");
+      var resourceApisContainer = "#" + name + "_endpoint_list";
       ApiController.init({
         item: api,
         container: resourceApisContainer
@@ -219,7 +220,8 @@ jQuery(function($) {
     },
 
     renderOperation: function(operation) {
-      var operationsContainer = "#" + this.api.name + "_endpoint_operations";
+      var name = this.api.name.replace(/([^a-zA-Z0-9\-\_])/g, "\\$1");
+      var operationsContainer = "#" + name + "_endpoint_operations";
       OperationController.init({
         item: operation,
         container: operationsContainer
@@ -269,8 +271,7 @@ jQuery(function($) {
 
       this.operation = this.item;
       this.isGetOperation = (this.operation.httpMethodLowercase == "get");
-      this.elementScope = "#" + this.operation.apiName + "_" + this.operation.nickname + "_" + this.operation.httpMethod;
-
+      this.elementScope = "#" + this.operation.apiName.replace(/([^a-zA-Z0-9\-\_])/g, "\\$1") + "_" + this.operation.nickname + "_" + this.operation.httpMethod;
       this.renderParams();
     },
 


### PR DESCRIPTION
Escape illegal CSS-selectors to support resources like

/user/{userId}/friends

Since Swagger generates IDs with {}-characters, jquery won't select them without escaping.
