### PR TITLE
fix broken link to jquery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ version.properties
 reports/*
 .sass-cache
 swagger-ui.sublime-workspace
+.idea

--- a/src/main/html/index.html
+++ b/src/main/html/index.html
@@ -3,7 +3,7 @@
     <title>Swagger UI</title>
     <link href='http://fonts.googleapis.com/css?family=Droid+Sans:400,700' rel='stylesheet' type='text/css'/>
     <link href='css/screen.css' media='screen' rel='stylesheet' type='text/css'/>
-    <script src='lib/jquery-1.8.0.js' type='text/javascript'></script>
+    <script src='lib/jquery-1.8.0.min.js' type='text/javascript'></script>
     <script src='lib/jquery.slideto.min.js' type='text/javascript'></script>
     <script src='lib/jquery.wiggle.min.js' type='text/javascript'></script>
     <script src='lib/jquery.ba-bbq.min.js' type='text/javascript'></script>


### PR DESCRIPTION
refer to jquery-1.8.0.min.js because jquery-1.8.0.js is not available in lib
(also added .idea to .gitignore)
