### PR TITLE
setting content type to JSON for http PATCH

### DIFF
--- a/src/main/coffeescript/view/OperationView.coffee
+++ b/src/main/coffeescript/view/OperationView.coffee
@@ -78,7 +78,7 @@ class OperationView extends Backbone.View
         complete: (data) =>
           @showCompleteStatus(data)
 
-      obj.contentType = "application/json" if (obj.type.toLowerCase() == "post" or obj.type.toLowerCase() == "put")
+      obj.contentType = "application/json" if (obj.type.toLowerCase() == "post" or obj.type.toLowerCase() == "put" or obj.type.toLowerCase() == "patch")
     
       jQuery.ajax(obj)
       false


### PR DESCRIPTION
Updating OperationView.coffee to add JSON content type for PATCH 
similar to POST and PUT so that the newly added PATCH support  (refer to issue #64) works fine
