### PR TITLE
Problem sending parameters via POST

### DIFF
--- a/src/main/coffeescript/view/OperationView.coffee
+++ b/src/main/coffeescript/view/OperationView.coffee
@@ -78,7 +78,7 @@ class OperationView extends Backbone.View
         complete: (data) =>
           @showCompleteStatus(data)
 
-      obj.contentType = "application/json" if (obj.type.toLowerCase() == "post" or obj.type.toLowerCase() == "put" or obj.type.toLowerCase() == "patch")
+      obj.contentType = "application/json" if (obj.type.toLowerCase() == "put" or obj.type.toLowerCase() == "patch")
     
       jQuery.ajax(obj)
       false


### PR DESCRIPTION
Jquery seems to fail posting data as POST params if contentType is overwritten. At least in chrome
