### PR TITLE
Allow Callbacks for headers

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -593,6 +593,9 @@
         _ref1 = this.resource.api.headers;
         for (name in _ref1) {
           value = _ref1[name];
+          if (typeof value === 'function') {
+            value = value(this.resource.api);
+          }
           matchingParams[name] = value;
         }
       }


### PR DESCRIPTION
I had to support a API which uses Basic-Auth for its Authentification, the easiest was to check if the given value is a function and if so, evalute it. I decided to pass the SwaggerApi Instance which contains the api_key - not sure if you'd like to pass something else?

Usage for that would be:

```
window.swaggerUi = new SwaggerUi({
    headers: {
      "Authorization": function( swaggerApi )
      {
        return 'Basic ' + btoa( swaggerApi.api_key + ':' );
      }
    }
});
```

Or something similar (depending mainly on the use of `btoa`)
