### PR TITLE
Content-type set to application/x-www-form-urlencoded for POST

### DIFF
--- a/src/main/coffeescript/view/OperationView.coffee
+++ b/src/main/coffeescript/view/OperationView.coffee
@@ -86,7 +86,7 @@ class OperationView extends Backbone.View
         complete: (data) =>
           @showCompleteStatus(data)
 
-      obj.contentType = "application/json" if (obj.type.toLowerCase() == "put" or obj.type.toLowerCase() == "patch")
+      obj.contentType = "application/json" if (obj.type.toLowerCase() == "post" or obj.type.toLowerCase() == "put" or obj.type.toLowerCase() == "patch")
     
       jQuery.ajax(obj)
       false


### PR DESCRIPTION
When POSTing to a REST API, the content-type is set to application/x-www-form-urlencoded, not to application/json.
