### PR TITLE
Fixes Issue  #68 in a generic way for any param with any regex

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -572,8 +572,8 @@
         param = _ref[_i];
         if (param.paramType === 'path') {
           if (args[param.name]) {
-            url = url.replace(/{id.*/, '{id}');
-            url = url.replace("{" + param.name + "}", encodeURIComponent(args[param.name]));
+            reg = new RegExp('\{'+param.name+'[^\}]*\}', 'gi');
+            url = url.replace(reg, encodeURIComponent(args[param.name]));
             delete args[param.name];
           } else {
             throw "" + param.name + " is a required path param.";


### PR DESCRIPTION
At the moment, only id param is considered in the fix; with this, all regex in any param should be ignored.
