### PR TITLE
Maven and Windows support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ reports/*
 swagger-ui.sublime-workspace
 .idea
 .project
+target/

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,63 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+	<groupId>org.sonatype.oss</groupId>
+	<artifactId>oss-parent</artifactId>
+	<version>5</version>
+    </parent>
+  
+    <groupId>com.wordnik</groupId>
+    <artifactId>swagger-ui</artifactId>
+    <version>1.1.5-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>Swagger UI</name>
+	
+    <build>		
+	<finalName>${project.artifactId}-${project.version}</finalName>	
+	<plugins>
+	    <plugin>
+		<groupId>org.codehaus.mojo</groupId>
+		<artifactId>exec-maven-plugin</artifactId>
+		<version>1.1</version>
+		<executions>
+		    <execution>
+			<phase>process-resources</phase>
+			<goals>
+			    <goal>exec</goal>
+			</goals>
+		    </execution>
+		</executions>
+		<configuration>
+		    <executable>cake</executable>
+		    <!-- optional -->
+		    <workingDirectory>${basedir}</workingDirectory>
+		    <arguments>
+			<argument>dist</argument>							
+		    </arguments>
+		</configuration>
+	    </plugin>		
+	    <plugin>
+		<artifactId>maven-assembly-plugin</artifactId>
+		<version>2.3</version>
+		<executions>
+		    <execution>
+			<id>make-config-zip</id>
+			<phase>package</phase>
+			<goals>
+			    <goal>single</goal>
+			</goals>
+			<configuration>
+			    <appendAssemblyId>false</appendAssemblyId>
+			    <finalName>${project.build.finalName}</finalName>
+			    <descriptors>
+				<descriptor>src/assemble/assemble-config.xml</descriptor>
+			    </descriptors>
+			</configuration>
+		    </execution>
+		</executions>
+	    </plugin>	    
+	</plugins>		
+    </build>
+</project>

--- a/src/assemble/assemble-config.xml
+++ b/src/assemble/assemble-config.xml
@@ -1,0 +1,21 @@
+<assembly
+	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+	<id>release</id>
+	<formats>
+		<format>zip</format>
+	</formats>
+	<includeBaseDirectory>false</includeBaseDirectory>
+	<fileSets>		
+		<fileSet>
+			<directory>${basedir}/target</directory>
+			<outputDirectory>/</outputDirectory>
+			<useDefaultExcludes>true</useDefaultExcludes>
+			<excludes>
+				<exclude>*.zip</exclude>
+			</excludes>
+		</fileSet>		
+	</fileSets>	
+</assembly>
+  


### PR DESCRIPTION
1. Added maven pom.xml to package using cake and output as zip archive
2. Changed Cakefile to use "target" instead of "dist" folder to follow
   maven standard
3. Updated Cakefile to call windows commands when linux equivalent fails
4. Does not require cygwin to build anymore

The pom.xml file does not include any repository or source control information. You can add that if you'd like but I didn't want to tie to my fork.
