### PR TITLE
Adding operation number to create a unique href for the <a/> tag.

### DIFF
--- a/src/main/coffeescript/view/OperationView.coffee
+++ b/src/main/coffeescript/view/OperationView.coffee
@@ -146,5 +146,5 @@ class OperationView extends Backbone.View
     hljs.highlightBlock($('.response_body', $(@el))[0])
 
   toggleOperationContent: ->
-    elem = $('#' + @model.resourceName + "_" + @model.nickname + "_" + @model.httpMethod + "_content");
+    elem = $('#' + @model.resourceName + "_" + @model.nickname + "_" + @model.httpMethod + "_" + @model.number + "_content");
     if elem.is(':visible') then Docs.collapseOperation(elem) else Docs.expandOperation(elem)

--- a/src/main/coffeescript/view/ResourceView.coffee
+++ b/src/main/coffeescript/view/ResourceView.coffee
@@ -4,11 +4,18 @@ class ResourceView extends Backbone.View
   render: ->
     $(@el).html(Handlebars.templates.resource(@model))
 
+    @number = 0
+
     # Render each operation
     @addOperation operation for operation in @model.operationsArray
     @
 
   addOperation: (operation) ->
+
+    operation.number = @number
+
     # Render an operation and add it to operations li
     operationView = new OperationView({model: operation, tagName: 'li', className: 'endpoint'})
     $('.endpoints', $(@el)).append operationView.render().el
+
+    @number++

--- a/src/main/template/operation.handlebars
+++ b/src/main/template/operation.handlebars
@@ -1,22 +1,22 @@
 
     <ul class='operations' >
-        <li class='{{httpMethod}} operation' id='{{resourceName}}_{{nickname}}_{{httpMethod}}'>
+      <li class='{{httpMethod}} operation' id='{{resourceName}}_{{nickname}}_{{httpMethod}}_{{number}}'>
             <div class='heading'>
                 <h3>
                   <span class='http_method'>
-                    <a href='#!/{{resourceName}}/{{nickname}}_{{httpMethod}}' class="toggleOperation">{{httpMethod}}</a>
+                    <a href='#!/{{resourceName}}/{{nickname}}_{{httpMethod}}_{{number}}' class="toggleOperation">{{httpMethod}}</a>
                   </span>
                   <span class='path'>
-                    <a href='#!/{{resourceName}}/{{nickname}}_{{httpMethod}}' class="toggleOperation">{{path}}</a>
+                    <a href='#!/{{resourceName}}/{{nickname}}_{{httpMethod}}_{{number}}' class="toggleOperation">{{path}}</a>
                   </span>
                 </h3>
                 <ul class='options'>
                     <li>
-                        <a href='#!/{{resourceName}}/{{nickname}}_{{httpMethod}}' class="toggleOperation">{{{summary}}}</a>
+                    <a href='#!/{{resourceName}}/{{nickname}}_{{httpMethod}}_{{number}}' class="toggleOperation">{{{summary}}}</a>
                     </li>
                 </ul>
             </div>
-            <div class='content' id='{{resourceName}}_{{nickname}}_{{httpMethod}}_content' style='display:none'>
+            <div class='content' id='{{resourceName}}_{{nickname}}_{{httpMethod}}_{{number}}_content' style='display:none'>
                 {{#if notes}}
                 <h4>Implementation Notes</h4>
                 <p>{{{notes}}}</p>


### PR DESCRIPTION
In some cases, identifying an operation with resource name, nickname and HTTP Method is not enough. An extra identifier should be added to differentiate among same operations but with differente parameters. So in order to do that, a new field was introduced: `number`. This makes each operation unique even if they differ by the arguments.
