### PR TITLE
toggleOperationContent needs to escape resource name

### DIFF
--- a/src/main/coffeescript/view/OperationView.coffee
+++ b/src/main/coffeescript/view/OperationView.coffee
@@ -260,5 +260,5 @@ class OperationView extends Backbone.View
     hljs.highlightBlock($('.response_body', $(@el))[0])
 
   toggleOperationContent: ->
-    elem = $('#' + @model.resourceName + "_" + @model.nickname + "_" + @model.httpMethod + "_" + @model.number + "_content")
+    elem = $('#' + Docs.escapeResourceName(@model.resourceName) + "_" + @model.nickname + "_" + @model.httpMethod + "_" + @model.number + "_content")
     if elem.is(':visible') then Docs.collapseOperation(elem) else Docs.expandOperation(elem)


### PR DESCRIPTION
Expanding single operation does not work due to failing to escape the resource name before querying for the appropriate node
