### PR TITLE
don't set contentType for empty body

### DIFF
--- a/src/main/coffeescript/view/OperationView.coffee
+++ b/src/main/coffeescript/view/OperationView.coffee
@@ -153,6 +153,9 @@ class OperationView extends Backbone.View
       if paramContentTypeField
         obj.contentType = paramContentTypeField
 
+      if not obj.data
+        obj.contentType = false
+
       responseContentTypeField = $('.content > .content-type > div > select[name=contentType]', $(@el)).val()
       if responseContentTypeField
         obj.headers = if obj.headers? then obj.headers else {}


### PR DESCRIPTION
When content-type is set to a non-standard value,
CORS requires a preflight request that needs to be handled
by the destination server.
We shouldn't require that, when no body is sent at all
and the content-type is irrelevant anyways.
