### PR TITLE
Add new column to show paramType

### DIFF
--- a/src/main/template/operation.handlebars
+++ b/src/main/template/operation.handlebars
@@ -34,10 +34,11 @@
                     <table class='fullwidth'>
                         <thead>
                         <tr>
-                            <th style="width: 100px; max-width: 100px" >Parameter</th>
+                            <th style="width: 100px; max-width: 100px">Parameter</th>
                             <th style="width: 310px; max-width: 310px">Value</th>
                             <th style="width: 200px; max-width: 200px">Description</th>
-                            <th style="width: 320px; max-width: 330px">Data Type</th>
+                            <th style="width: 100px; max-width: 100px">Parameter Type</th>
+                            <th style="width: 220px; max-width: 230px">Data Type</th>
                         </tr>
                         </thead>
                         <tbody class="operation-params">

--- a/src/main/template/param.handlebars
+++ b/src/main/template/param.handlebars
@@ -23,6 +23,7 @@
 
 </td>
 <td>{{{description}}}</td>
+<td>{{{paramType}}}</td>
 <td>
 	<span class="model-signature"></span>
 </td>

--- a/src/main/template/param_list.handlebars
+++ b/src/main/template/param_list.handlebars
@@ -18,4 +18,5 @@
     </select>
 </td>
 <td>{{{description}}}</td>
+<td>{{{paramType}}}</td>
 <td><span class="model-signature"></span></td>

--- a/src/main/template/param_readonly.handlebars
+++ b/src/main/template/param_readonly.handlebars
@@ -11,4 +11,5 @@
     {{/if}}
 </td>
 <td>{{{description}}}</td>
+<td>{{{paramType}}}</td>
 <td><span class="model-signature"></span></td>

--- a/src/main/template/param_readonly_required.handlebars
+++ b/src/main/template/param_readonly_required.handlebars
@@ -11,4 +11,5 @@
     {{/if}}
 </td>
 <td>{{{description}}}</td>
+<td>{{{paramType}}}</td>
 <td><span class="model-signature"></span></td>

--- a/src/main/template/param_required.handlebars
+++ b/src/main/template/param_required.handlebars
@@ -27,4 +27,5 @@
 <td>
 	<strong>{{{description}}}</strong>
 </td>
+<td>{{{paramType}}}</td>
 <td><span class="model-signature"></span></td>


### PR DESCRIPTION
This change adds a new column to display the paramType of parmeters.

This is useful to help users distinguish between header parameters and query string parameters etc.
