### PR TITLE
Improve main CSS to given long texts/large objects some more space

### DIFF
--- a/dist/css/screen.css
+++ b/dist/css/screen.css
@@ -131,15 +131,15 @@ h3 {
     margin-top: 10px;
 }
 
-input.parameter {
-    width: 300px;
+input.parameter,
+.body-textarea {
+    width: 95%;
+    min-width: 250px;
     border: 1px solid #aaa;
 }
 
 .body-textarea {
-    width: 300px;
     height: 100px;
-    border: 1px solid #aaa;
 }
 
 p {
@@ -1674,6 +1674,11 @@ body ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operatio
     clear: both;
 }
 
+.operation-params .model-signature .signature-container {
+    max-height: 350px;
+    overflow-y: auto;
+}
+
 .model-signature .signature-nav a:hover {
     text-decoration: underline;
     color: black;
@@ -1735,7 +1740,8 @@ pre code {
 }
 
 .swagger-ui-wrap {
-  max-width: 960px;
+  width: 85%;
+  max-width: 1400px;
   margin-left: auto;
   margin-right: auto;
 }

--- a/dist/index.html
+++ b/dist/index.html
@@ -19,7 +19,7 @@
     <script type="text/javascript">
 	$(function () {
 	    window.swaggerUi = new SwaggerUi({
-                discoveryUrl:"http://petstore.swagger.wordnik.com/api/api-docs",
+                discoveryUrl:"http://petstore.swagger.wordnik.com/api/api-docs.json",
                 apiKey:"special-key",
                 dom_id:"swagger-ui-container",
                 supportHeaderParams: false,

--- a/src/main/html/css/screen.css
+++ b/src/main/html/css/screen.css
@@ -131,15 +131,15 @@ h3 {
     margin-top: 10px;
 }
 
-input.parameter {
-    width: 300px;
+input.parameter,
+.body-textarea {
+    width: 95%;
+    min-width: 250px;
     border: 1px solid #aaa;
 }
 
 .body-textarea {
-    width: 300px;
     height: 100px;
-    border: 1px solid #aaa;
 }
 
 p {
@@ -1674,6 +1674,11 @@ body ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operatio
     clear: both;
 }
 
+.operation-params .model-signature .signature-container {
+    max-height: 350px;
+    overflow-y: auto;
+}
+
 .model-signature .signature-nav a:hover {
     text-decoration: underline;
     color: black;
@@ -1735,7 +1740,8 @@ pre code {
 }
 
 .swagger-ui-wrap {
-  max-width: 960px;
+  width: 85%;
+  max-width: 1400px;
   margin-left: auto;
   margin-right: auto;
 }


### PR DESCRIPTION
The narrow container makes large texts and big objects a bit unreadable, especially with the new 'parameter type' column added. This change gives some more space, when available.