### PR TITLE
Prevent %2F (forward slash) in path component of URIs

### DIFF
--- a/dist/lib/swagger.js
+++ b/dist/lib/swagger.js
@@ -626,6 +626,7 @@
           }
         }
       }
+      url = url.replace(/%2[Ff]/g, "%252F");
       if (includeApiKey && (this.resource.api.api_key != null) && this.resource.api.api_key.length > 0) {
         args[this.apiKeyName] = this.resource.api.api_key;
       }


### PR DESCRIPTION
Path variables are currently encoded such that forward slashes become %2F. This is disallowed by Apache unless the [AllowEncodedSlashes](http://httpd.apache.org/docs/2.2/mod/core.html#allowencodedslashes) directive is specifically enabled.

Encoding forward slashes to %252F (i.e., double encoding the percent sign portion of %2F) allows the generated URI to work properly with Apache without enabling AllowEncodedSlashes.