### PR TITLE
Allow better file upload support when used with grape-swagger

### DIFF
--- a/src/main/coffeescript/view/ParameterView.coffee
+++ b/src/main/coffeescript/view/ParameterView.coffee
@@ -2,8 +2,8 @@ class ParameterView extends Backbone.View
   initialize: ->
 
   render: ->
-    @model.isBody = true if @model.paramType == 'body'
-    @model.isFile = true if @model.dataType == 'file'
+    @model.isBody = true if @model.paramType.toLowerCase() == 'body'
+    @model.isFile = true if @model.dataType.toLowerCase() == 'file'
 
     template = @template()
     $(@el).html(template(@model))


### PR DESCRIPTION
When defining a file parameter definition in grape-swagger it is required to use :type => File. This causes the generated swagger documentation to return a capitalized File causing a generic text input to be rendered and not the expected file input. This change automatically lowercases the dataType when determining if the parameter is a file.