### PR TITLE
fixed: Resources with a dot in their nickname did not expand

### DIFF
--- a/src/main/javascript/doc.js
+++ b/src/main/javascript/doc.js
@@ -102,6 +102,7 @@ var Docs = {
 
                 // Expand operation
 				var li_dom_id = fragments.join('_');
+				li_dom_id = li_dom_id.replace('.', '\\.');
 				var li_content_dom_id = li_dom_id + "_content";
 
 //                log("li_dom_id " + li_dom_id);


### PR DESCRIPTION
Dots in id's need to be escaped otherwise jQuery is not able to find them.
