### PR TITLE
swagger ui will print out enum values now

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -487,6 +487,10 @@
         if (this.values != null) {
           this.valuesString = "'" + this.values.join("' or '") + "'";
         }
+      } else if (obj.enum != null) {
+        this.valueType = "string";
+        this.values = obj.enum;
+        this.valueString = "'" + this.values.join("' or '") + "'";
       }
     }
 


### PR DESCRIPTION
The enum syntax of swagger 1.2 spec was not showing up on swagger-ui, this will add it the same way allowableValues is displayed.
