### PR TITLE
Reflect the 'required' attribute in @ApiModelProperty when rendering data models

### DIFF
--- a/dist/lib/swagger.js
+++ b/dist/lib/swagger.js
@@ -456,6 +456,13 @@
             }
           }
         }
+        if (obj.required != null) {
+          for (var i = 0; i < obj.required.length; i++) {
+            if (propertyName === obj.required[i]) {
+              obj.properties[propertyName].required = true;
+            }
+          }   
+  		}
         this.properties.push(new SwaggerModelProperty(propertyName, obj.properties[propertyName]));
       }
     }

--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -456,6 +456,13 @@
             }
           }
         }
+        if (obj.required != null) {
+          for (var i = 0; i < obj.required.length; i++) {
+            if (propertyName === obj.required[i]) {
+              obj.properties[propertyName].required = true;
+            }
+          }   
+  		}
         this.properties.push(new SwaggerModelProperty(propertyName, obj.properties[propertyName]));
       }
     }


### PR DESCRIPTION
All class attributes in a model view are presented as optional (the '@ApiModelProperty.required is not reflected).
