### PR TITLE
in swagger JSON, if paramType = body, and there is "items" - parameter type is absent, so get items.type instead.

### DIFF
--- a/dist/lib/swagger.js
+++ b/dist/lib/swagger.js
@@ -635,7 +635,7 @@
       for (_i = 0, _len = _ref1.length; _i < _len; _i++) {
         parameter = _ref1[_i];
         parameter.name = parameter.name || parameter.type || parameter.dataType;
-        type = parameter.type || parameter.dataType;
+        type = parameter.type || parameter.dataType || parameter.items.type;
         if (type.toLowerCase() === 'boolean') {
           parameter.allowableValues = {};
           parameter.allowableValues.values = ["true", "false"];

--- a/dist/swagger-ui.js
+++ b/dist/swagger-ui.js
@@ -1508,7 +1508,7 @@ helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
       _ref5 = this.model.parameters;
       for (_i = 0, _len = _ref5.length; _i < _len; _i++) {
         param = _ref5[_i];
-        type = param.type || param.dataType;
+        type = param.type || param.dataType || param.items.type;
         if (type.toLowerCase() === 'file') {
           if (!contentTypeModel.consumes) {
             console.log("set content type ");
@@ -1810,7 +1810,7 @@ helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
 
     ParameterView.prototype.render = function() {
       var contentTypeModel, isParam, parameterContentTypeView, responseContentTypeView, signatureModel, signatureView, template, type;
-      type = this.model.type || this.model.dataType;
+      type = this.model.type || this.model.dataType || this.model.items.type;
       if (this.model.paramType === 'body') {
         this.model.isBody = true;
       }

--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -635,7 +635,7 @@
       for (_i = 0, _len = _ref1.length; _i < _len; _i++) {
         parameter = _ref1[_i];
         parameter.name = parameter.name || parameter.type || parameter.dataType;
-        type = parameter.type || parameter.dataType;
+        type = parameter.type || parameter.dataType || parameter.items.type;
         if (type.toLowerCase() === 'boolean') {
           parameter.allowableValues = {};
           parameter.allowableValues.values = ["true", "false"];


### PR DESCRIPTION
Hi
Could you please check it out and merge/fix is appropriate. thanks!

the problem occurs when we have a body parameter of type Map in a web method.
Here is sample piece of JSON output:
...
{
"name":"body",
"description":"Tag map [name, value]",
"required":true,
"allowMultiple":false,
"items":{
"type":"string"
},
"paramType":"body"
}
...

swagger-ui code tries to access 'type' or 'dataType' property of the parameter descriptor entity, which is missing.
