### PR TITLE
Some LESS work - operation type colors and fonts extracted to variables, divided spec.less to separated mixin files

### DIFF
--- a/dist/css/screen.css
+++ b/dist/css/screen.css
@@ -636,7 +636,7 @@ table {
 .swagger-ui-wrap ul#resources li.resource div.heading h2 a:hover {
   color: black;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation {
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations {
   float: none;
   clear: both;
   overflow: hidden;
@@ -644,7 +644,7 @@ table {
   margin: 0 0 10px;
   padding: 0;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.heading {
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations div.heading {
   float: none;
   clear: both;
   overflow: hidden;
@@ -652,7 +652,7 @@ table {
   margin: 0;
   padding: 0;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.heading h3 {
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations div.heading h3 {
   display: block;
   clear: none;
   float: left;
@@ -662,17 +662,17 @@ table {
   line-height: 1.1em;
   color: black;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.heading h3 span.path {
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations div.heading h3 span.path {
   padding-left: 10px;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.heading h3 span.path a {
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations div.heading h3 span.path a {
   color: black;
   text-decoration: none;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.heading h3 span.path a:hover {
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations div.heading h3 span.path a:hover {
   text-decoration: underline;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.heading h3 span.http_method a {
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations div.heading h3 span.http_method a {
   text-transform: uppercase;
   text-decoration: none;
   color: white;
@@ -688,11 +688,11 @@ table {
   -khtml-border-radius: 2px;
   border-radius: 2px;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.heading h3 span {
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations div.heading h3 span {
   margin: 0;
   padding: 0;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.heading ul.options {
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations div.heading ul.options {
   overflow: hidden;
   padding: 0;
   display: block;
@@ -700,17 +700,17 @@ table {
   float: right;
   margin: 6px 10px 0 0;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.heading ul.options li {
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations div.heading ul.options li {
   float: left;
   clear: none;
   margin: 0;
   padding: 2px 10px;
   font-size: 0.9em;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.heading ul.options li a {
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations div.heading ul.options li a {
   text-decoration: none;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.content {
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations div.content {
   border-top: none;
   padding: 10px;
   -moz-border-radius-bottomleft: 6px;
@@ -727,43 +727,67 @@ table {
   border-bottom-right-radius: 6px;
   margin: 0 0 20px;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.content h4 {
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations div.content h4 {
   font-size: 1.1em;
   margin: 0;
   padding: 15px 0 5px;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.content div.sandbox_header {
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations div.content div.sandbox_header {
   float: none;
   clear: both;
   overflow: hidden;
   display: block;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.content div.sandbox_header a {
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations div.content div.sandbox_header a {
   padding: 4px 0 0 10px;
   display: inline-block;
   font-size: 0.9em;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.content div.sandbox_header img {
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations div.content div.sandbox_header img {
   display: block;
   clear: none;
   float: right;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.content div.sandbox_header input.submit {
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations div.content div.sandbox_header input.submit {
   display: block;
   clear: none;
   float: left;
   padding: 6px 8px;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.content form input[type='text'].error {
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations div.content form input[type='text'].error {
   outline: 2px solid black;
   outline-color: #cc0000;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.content div.response div.block pre {
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations div.content div.response div.block pre {
   font-family: "Anonymous Pro", "Menlo", "Consolas", "Bitstream Vera Sans Mono", "Courier New", monospace;
   padding: 10px;
   font-size: 0.9em;
   max-height: 400px;
   overflow-y: auto;
+}
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.get div.heading {
+  background-color: #e7f0f7;
+  border: 1px solid #c3d9ec;
+}
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.get div.heading h3 span.http_method a {
+  background-color: #0f6ab4;
+}
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.get div.heading ul.options li {
+  border-right: 1px solid #c3d9ec;
+  color: #0f6ab4;
+}
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.get div.heading ul.options li a {
+  color: #0f6ab4;
+}
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.get div.content {
+  background-color: #ebf3f9;
+  border: 1px solid #c3d9ec;
+}
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.get div.content h4 {
+  color: #0f6ab4;
+}
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.get div.content div.sandbox_header a {
+  color: #6fa5d2;
 }
 .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.put div.heading {
   background-color: #f9f2e9;
@@ -773,8 +797,7 @@ table {
   background-color: #c5862b;
 }
 .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.put div.heading ul.options li {
-  border-right: 1px solid #dddddd;
-  border-right-color: #f0e0ca;
+  border-right: 1px solid #f0e0ca;
   color: #c5862b;
 }
 .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.put div.heading ul.options li a {
@@ -790,60 +813,6 @@ table {
 .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.put div.content div.sandbox_header a {
   color: #dcb67f;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.head div.heading {
-  background-color: #fcffcd;
-  border: 1px solid black;
-  border-color: #ffd20f;
-}
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.head div.heading h3 span.http_method a {
-  text-transform: uppercase;
-  background-color: #ffd20f;
-}
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.head div.heading ul.options li {
-  border-right: 1px solid #dddddd;
-  border-right-color: #ffd20f;
-  color: #ffd20f;
-}
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.head div.heading ul.options li a {
-  color: #ffd20f;
-}
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.head div.content {
-  background-color: #fcffcd;
-  border: 1px solid black;
-  border-color: #ffd20f;
-}
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.head div.content h4 {
-  color: #ffd20f;
-}
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.head div.content div.sandbox_header a {
-  color: #6fc992;
-}
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.delete div.heading {
-  background-color: #f5e8e8;
-  border: 1px solid #e8c6c7;
-}
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.delete div.heading h3 span.http_method a {
-  text-transform: uppercase;
-  background-color: #a41e22;
-}
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.delete div.heading ul.options li {
-  border-right: 1px solid #dddddd;
-  border-right-color: #e8c6c7;
-  color: #a41e22;
-}
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.delete div.heading ul.options li a {
-  color: #a41e22;
-}
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.delete div.content {
-  background-color: #f7eded;
-  border: 1px solid #e8c6c7;
-}
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.delete div.content h4 {
-  color: #a41e22;
-}
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.delete div.content div.sandbox_header a {
-  color: #c8787a;
-}
 .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.post div.heading {
   background-color: #e7f6ec;
   border: 1px solid #c3e8d1;
@@ -852,8 +821,7 @@ table {
   background-color: #10a54a;
 }
 .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.post div.heading ul.options li {
-  border-right: 1px solid #dddddd;
-  border-right-color: #c3e8d1;
+  border-right: 1px solid #c3e8d1;
   color: #10a54a;
 }
 .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.post div.heading ul.options li a {
@@ -869,55 +837,77 @@ table {
 .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.post div.content div.sandbox_header a {
   color: #6fc992;
 }
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.delete div.heading {
+  background-color: #f5e8e8;
+  border: 1px solid #e8c6c7;
+}
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.delete div.heading h3 span.http_method a {
+  background-color: #a41e22;
+}
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.delete div.heading ul.options li {
+  border-right: 1px solid #e8c6c7;
+  color: #a41e22;
+}
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.delete div.heading ul.options li a {
+  color: #a41e22;
+}
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.delete div.content {
+  background-color: #f7eded;
+  border: 1px solid #e8c6c7;
+}
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.delete div.content h4 {
+  color: #a41e22;
+}
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.delete div.content div.sandbox_header a {
+  color: #c8787a;
+}
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.head div.heading {
+  background-color: #fcffcd;
+  border: 1px solid #ffd20f;
+}
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.head div.heading h3 span.http_method a {
+  background-color: #ffd20f;
+}
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.head div.heading ul.options li {
+  border-right: 1px solid #ffd20f;
+  color: #ffd20f;
+}
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.head div.heading ul.options li a {
+  color: #ffd20f;
+}
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.head div.content {
+  background-color: #fcffcd;
+  border: 1px solid #ffd20f;
+}
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.head div.content h4 {
+  color: #ffd20f;
+}
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.head div.content div.sandbox_header a {
+  color: #6fc992;
+}
 .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.patch div.heading {
-  background-color: #FCE9E3;
-  border: 1px solid #F5D5C3;
+  background-color: #fce9e3;
+  border: 1px solid #f0cecb;
 }
 .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.patch div.heading h3 span.http_method a {
-  background-color: #D38042;
+  background-color: #d38042;
 }
 .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.patch div.heading ul.options li {
-  border-right: 1px solid #dddddd;
-  border-right-color: #f0cecb;
-  color: #D38042;
+  border-right: 1px solid #f0cecb;
+  color: #d38042;
 }
 .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.patch div.heading ul.options li a {
-  color: #D38042;
+  color: #d38042;
 }
 .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.patch div.content {
   background-color: #faf0ef;
   border: 1px solid #f0cecb;
 }
 .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.patch div.content h4 {
-  color: #D38042;
+  color: #d38042;
 }
 .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.patch div.content div.sandbox_header a {
   color: #dcb67f;
-}
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.get div.heading {
-  background-color: #e7f0f7;
-  border: 1px solid #c3d9ec;
-}
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.get div.heading h3 span.http_method a {
-  background-color: #0f6ab4;
-}
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.get div.heading ul.options li {
-  border-right: 1px solid #dddddd;
-  border-right-color: #c3d9ec;
-  color: #0f6ab4;
-}
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.get div.heading ul.options li a {
-  color: #0f6ab4;
-}
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.get div.content {
-  background-color: #ebf3f9;
-  border: 1px solid #c3d9ec;
-}
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.get div.content h4 {
-  color: #0f6ab4;
-}
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.get div.content div.sandbox_header a {
-  color: #6fa5d2;
 }
 .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.get div.content,
 .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.post div.content,
@@ -951,8 +941,8 @@ table {
 .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations ul.options li.first {
   padding-left: 0;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations:first-child,
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations.first {
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations ul.options li:first-child,
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations ul.options li.first {
   padding-left: 0;
 }
 .swagger-ui-wrap p#colophon {

--- a/src/main/html/css/screen.css
+++ b/src/main/html/css/screen.css
@@ -636,7 +636,7 @@ table {
 .swagger-ui-wrap ul#resources li.resource div.heading h2 a:hover {
   color: black;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation {
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations {
   float: none;
   clear: both;
   overflow: hidden;
@@ -644,7 +644,7 @@ table {
   margin: 0 0 10px;
   padding: 0;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.heading {
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations div.heading {
   float: none;
   clear: both;
   overflow: hidden;
@@ -652,7 +652,7 @@ table {
   margin: 0;
   padding: 0;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.heading h3 {
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations div.heading h3 {
   display: block;
   clear: none;
   float: left;
@@ -662,17 +662,17 @@ table {
   line-height: 1.1em;
   color: black;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.heading h3 span.path {
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations div.heading h3 span.path {
   padding-left: 10px;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.heading h3 span.path a {
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations div.heading h3 span.path a {
   color: black;
   text-decoration: none;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.heading h3 span.path a:hover {
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations div.heading h3 span.path a:hover {
   text-decoration: underline;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.heading h3 span.http_method a {
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations div.heading h3 span.http_method a {
   text-transform: uppercase;
   text-decoration: none;
   color: white;
@@ -688,11 +688,11 @@ table {
   -khtml-border-radius: 2px;
   border-radius: 2px;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.heading h3 span {
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations div.heading h3 span {
   margin: 0;
   padding: 0;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.heading ul.options {
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations div.heading ul.options {
   overflow: hidden;
   padding: 0;
   display: block;
@@ -700,17 +700,17 @@ table {
   float: right;
   margin: 6px 10px 0 0;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.heading ul.options li {
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations div.heading ul.options li {
   float: left;
   clear: none;
   margin: 0;
   padding: 2px 10px;
   font-size: 0.9em;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.heading ul.options li a {
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations div.heading ul.options li a {
   text-decoration: none;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.content {
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations div.content {
   border-top: none;
   padding: 10px;
   -moz-border-radius-bottomleft: 6px;
@@ -727,43 +727,67 @@ table {
   border-bottom-right-radius: 6px;
   margin: 0 0 20px;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.content h4 {
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations div.content h4 {
   font-size: 1.1em;
   margin: 0;
   padding: 15px 0 5px;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.content div.sandbox_header {
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations div.content div.sandbox_header {
   float: none;
   clear: both;
   overflow: hidden;
   display: block;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.content div.sandbox_header a {
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations div.content div.sandbox_header a {
   padding: 4px 0 0 10px;
   display: inline-block;
   font-size: 0.9em;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.content div.sandbox_header img {
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations div.content div.sandbox_header img {
   display: block;
   clear: none;
   float: right;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.content div.sandbox_header input.submit {
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations div.content div.sandbox_header input.submit {
   display: block;
   clear: none;
   float: left;
   padding: 6px 8px;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.content form input[type='text'].error {
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations div.content form input[type='text'].error {
   outline: 2px solid black;
   outline-color: #cc0000;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.content div.response div.block pre {
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations div.content div.response div.block pre {
   font-family: "Anonymous Pro", "Menlo", "Consolas", "Bitstream Vera Sans Mono", "Courier New", monospace;
   padding: 10px;
   font-size: 0.9em;
   max-height: 400px;
   overflow-y: auto;
+}
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.get div.heading {
+  background-color: #e7f0f7;
+  border: 1px solid #c3d9ec;
+}
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.get div.heading h3 span.http_method a {
+  background-color: #0f6ab4;
+}
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.get div.heading ul.options li {
+  border-right: 1px solid #c3d9ec;
+  color: #0f6ab4;
+}
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.get div.heading ul.options li a {
+  color: #0f6ab4;
+}
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.get div.content {
+  background-color: #ebf3f9;
+  border: 1px solid #c3d9ec;
+}
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.get div.content h4 {
+  color: #0f6ab4;
+}
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.get div.content div.sandbox_header a {
+  color: #6fa5d2;
 }
 .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.put div.heading {
   background-color: #f9f2e9;
@@ -773,8 +797,7 @@ table {
   background-color: #c5862b;
 }
 .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.put div.heading ul.options li {
-  border-right: 1px solid #dddddd;
-  border-right-color: #f0e0ca;
+  border-right: 1px solid #f0e0ca;
   color: #c5862b;
 }
 .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.put div.heading ul.options li a {
@@ -790,60 +813,6 @@ table {
 .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.put div.content div.sandbox_header a {
   color: #dcb67f;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.head div.heading {
-  background-color: #fcffcd;
-  border: 1px solid black;
-  border-color: #ffd20f;
-}
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.head div.heading h3 span.http_method a {
-  text-transform: uppercase;
-  background-color: #ffd20f;
-}
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.head div.heading ul.options li {
-  border-right: 1px solid #dddddd;
-  border-right-color: #ffd20f;
-  color: #ffd20f;
-}
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.head div.heading ul.options li a {
-  color: #ffd20f;
-}
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.head div.content {
-  background-color: #fcffcd;
-  border: 1px solid black;
-  border-color: #ffd20f;
-}
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.head div.content h4 {
-  color: #ffd20f;
-}
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.head div.content div.sandbox_header a {
-  color: #6fc992;
-}
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.delete div.heading {
-  background-color: #f5e8e8;
-  border: 1px solid #e8c6c7;
-}
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.delete div.heading h3 span.http_method a {
-  text-transform: uppercase;
-  background-color: #a41e22;
-}
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.delete div.heading ul.options li {
-  border-right: 1px solid #dddddd;
-  border-right-color: #e8c6c7;
-  color: #a41e22;
-}
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.delete div.heading ul.options li a {
-  color: #a41e22;
-}
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.delete div.content {
-  background-color: #f7eded;
-  border: 1px solid #e8c6c7;
-}
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.delete div.content h4 {
-  color: #a41e22;
-}
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.delete div.content div.sandbox_header a {
-  color: #c8787a;
-}
 .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.post div.heading {
   background-color: #e7f6ec;
   border: 1px solid #c3e8d1;
@@ -852,8 +821,7 @@ table {
   background-color: #10a54a;
 }
 .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.post div.heading ul.options li {
-  border-right: 1px solid #dddddd;
-  border-right-color: #c3e8d1;
+  border-right: 1px solid #c3e8d1;
   color: #10a54a;
 }
 .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.post div.heading ul.options li a {
@@ -869,55 +837,77 @@ table {
 .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.post div.content div.sandbox_header a {
   color: #6fc992;
 }
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.delete div.heading {
+  background-color: #f5e8e8;
+  border: 1px solid #e8c6c7;
+}
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.delete div.heading h3 span.http_method a {
+  background-color: #a41e22;
+}
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.delete div.heading ul.options li {
+  border-right: 1px solid #e8c6c7;
+  color: #a41e22;
+}
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.delete div.heading ul.options li a {
+  color: #a41e22;
+}
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.delete div.content {
+  background-color: #f7eded;
+  border: 1px solid #e8c6c7;
+}
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.delete div.content h4 {
+  color: #a41e22;
+}
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.delete div.content div.sandbox_header a {
+  color: #c8787a;
+}
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.head div.heading {
+  background-color: #fcffcd;
+  border: 1px solid #ffd20f;
+}
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.head div.heading h3 span.http_method a {
+  background-color: #ffd20f;
+}
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.head div.heading ul.options li {
+  border-right: 1px solid #ffd20f;
+  color: #ffd20f;
+}
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.head div.heading ul.options li a {
+  color: #ffd20f;
+}
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.head div.content {
+  background-color: #fcffcd;
+  border: 1px solid #ffd20f;
+}
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.head div.content h4 {
+  color: #ffd20f;
+}
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.head div.content div.sandbox_header a {
+  color: #6fc992;
+}
 .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.patch div.heading {
-  background-color: #FCE9E3;
-  border: 1px solid #F5D5C3;
+  background-color: #fce9e3;
+  border: 1px solid #f0cecb;
 }
 .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.patch div.heading h3 span.http_method a {
-  background-color: #D38042;
+  background-color: #d38042;
 }
 .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.patch div.heading ul.options li {
-  border-right: 1px solid #dddddd;
-  border-right-color: #f0cecb;
-  color: #D38042;
+  border-right: 1px solid #f0cecb;
+  color: #d38042;
 }
 .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.patch div.heading ul.options li a {
-  color: #D38042;
+  color: #d38042;
 }
 .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.patch div.content {
   background-color: #faf0ef;
   border: 1px solid #f0cecb;
 }
 .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.patch div.content h4 {
-  color: #D38042;
+  color: #d38042;
 }
 .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.patch div.content div.sandbox_header a {
   color: #dcb67f;
-}
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.get div.heading {
-  background-color: #e7f0f7;
-  border: 1px solid #c3d9ec;
-}
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.get div.heading h3 span.http_method a {
-  background-color: #0f6ab4;
-}
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.get div.heading ul.options li {
-  border-right: 1px solid #dddddd;
-  border-right-color: #c3d9ec;
-  color: #0f6ab4;
-}
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.get div.heading ul.options li a {
-  color: #0f6ab4;
-}
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.get div.content {
-  background-color: #ebf3f9;
-  border: 1px solid #c3d9ec;
-}
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.get div.content h4 {
-  color: #0f6ab4;
-}
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.get div.content div.sandbox_header a {
-  color: #6fa5d2;
 }
 .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.get div.content,
 .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation.post div.content,
@@ -951,8 +941,8 @@ table {
 .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations ul.options li.first {
   padding-left: 0;
 }
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations:first-child,
-.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations.first {
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations ul.options li:first-child,
+.swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations ul.options li.first {
   padding-left: 0;
 }
 .swagger-ui-wrap p#colophon {

--- a/src/main/less/fonts.less
+++ b/src/main/less/fonts.less
@@ -1,0 +1,4 @@
+// Global font definitions 
+
+@fontCode: "Anonymous Pro", "Menlo", "Consolas", "Bitstream Vera Sans Mono", "Courier New", monospace;
+@fontParagraph: "Droid Sans", sans-serif;

--- a/src/main/less/operation.less
+++ b/src/main/less/operation.less
@@ -1,0 +1,182 @@
+// an operation style mixin
+.operation() {
+    float: none;
+    clear: both;
+    overflow: hidden;
+    display: block;
+    margin: 0 0 10px;
+    padding: 0;
+    div.heading {
+        float: none;
+        clear: both;
+        overflow: hidden;
+        display: block;
+        margin: 0;
+        padding: 0;
+        h3 {
+            display: block;
+            clear: none;
+            float: left;
+            width: auto;
+            margin: 0;
+            padding: 0;
+            line-height: 1.1em;
+            color: black;
+            span.path {
+                padding-left: 10px;
+                a {
+                    color: black;
+                    text-decoration: none;
+                }
+                a:hover {
+                    text-decoration: underline;
+                }
+            }
+            span.http_method {
+                a {
+                    text-transform: uppercase;
+                    text-decoration: none;
+                    color: white;
+                    display: inline-block;
+                    width: 50px;
+                    font-size: 0.7em;
+                    text-align: center;
+                    padding: 7px 0 4px;
+                    -moz-border-radius: 2px;
+                    -webkit-border-radius: 2px;
+                    -o-border-radius: 2px;
+                    -ms-border-radius: 2px;
+                    -khtml-border-radius: 2px;
+                    border-radius: 2px;
+                }
+            }
+            span {
+                margin: 0;
+                padding: 0;
+            }
+        }
+        ul.options {
+            overflow: hidden;
+            padding: 0;
+            display: block;
+            clear: none;
+            float: right;
+            margin: 6px 10px 0 0;
+            li {
+                float: left;
+                clear: none;
+                margin: 0;
+                padding: 2px 10px;
+                font-size: 0.9em;
+                a {
+                    text-decoration: none;
+                }
+            }
+        }
+    }
+    div.content {
+        border-top: none;
+        padding: 10px;
+        -moz-border-radius-bottomleft: 6px;
+        -webkit-border-bottom-left-radius: 6px;
+        -o-border-bottom-left-radius: 6px;
+        -ms-border-bottom-left-radius: 6px;
+        -khtml-border-bottom-left-radius: 6px;
+        border-bottom-left-radius: 6px;
+        -moz-border-radius-bottomright: 6px;
+        -webkit-border-bottom-right-radius: 6px;
+        -o-border-bottom-right-radius: 6px;
+        -ms-border-bottom-right-radius: 6px;
+        -khtml-border-bottom-right-radius: 6px;
+        border-bottom-right-radius: 6px;
+        margin: 0 0 20px;
+        h4 {
+            font-size: 1.1em;
+            margin: 0;
+            padding: 15px 0 5px;
+        }
+        div.sandbox_header {
+            float: none;
+            clear: both;
+            overflow: hidden;
+            display: block;
+            a {
+                padding: 4px 0 0 10px;
+                display: inline-block;
+                font-size: 0.9em;
+            }
+            img {
+                display: block;
+                clear: none;
+                float: right;
+            }
+            input.submit {
+                display: block;
+                clear: none;
+                float: left;
+                padding: 6px 8px;
+            }
+        }
+        form {
+            input[type='text'].error {
+                outline: 2px solid black;
+                outline-color: #cc0000;
+            }
+        }
+        div.response {
+            div.block {
+                pre {
+                    font-family: @fontCode;
+                    padding: 10px;
+                    font-size: 0.9em;
+                    max-height: 400px;
+                    overflow-y: auto;
+                }
+            }
+        }
+    }
+
+    li.operation.get {
+       .operationType('Get');
+    }
+    li.operation.put {
+       .operationType('Put');
+    }
+    li.operation.post {
+       .operationType('Post');
+    }
+    li.operation.delete {
+        .operationType('Delete');
+    }
+    li.operation.head {
+        .operationType('Head');
+    }
+    li.operation.patch {
+        .operationType('Patch');
+    }
+
+    li.operation {
+        &.get, &.post, &.head, &.put, &.patch, &.delete {
+            div.content {
+                border-top: none;
+            }
+            div.heading ul.options li {
+                &:last-child, &.last {
+                    padding-right: 0;
+                    border-right: none;
+                }
+            }
+        }
+    }
+    ul.options li {
+        a:hover, a:active, a.active {
+            text-decoration: underline;
+        }       
+        &:first-child, &.first {
+            padding-left: 0;
+        }
+        &:first-child, &.first {
+            padding-left: 0;
+        }
+    }
+}

--- a/src/main/less/operationType.less
+++ b/src/main/less/operationType.less
@@ -1,0 +1,40 @@
+// a parametrized mixin for an operation type specific styles (parameter values: Get,Post...)
+.operationType (@operation) {
+    @colorDark: "color@{operation}Dark";
+    @colorMedium: "color@{operation}Medium";
+    @colorLight: "color@{operation}Light";
+    @colorLighter: "color@{operation}Lighter";
+    @colorUltraLight: "color@{operation}UltraLight";
+    div.heading {
+        background-color: @@colorLighter;
+        border: 1px solid @@colorLight;
+        h3 {
+            span.http_method {
+                a {
+                    background-color: @@colorDark;
+                }
+            }
+        }
+        ul.options {
+            li {
+                border-right: 1px solid @@colorLight;
+                color: @@colorDark;
+                a {
+                    color: @@colorDark;
+                }
+            }
+        }
+    }
+    div.content {
+        background-color: @@colorUltraLight;
+        border: 1px solid @@colorLight;
+        h4 {
+            color: @@colorDark;
+        }
+        div.sandbox_header {
+            a {
+                color: @@colorMedium;
+            }
+        }
+    }
+}

--- a/src/main/less/palette.less
+++ b/src/main/less/palette.less
@@ -1,0 +1,43 @@
+// Swagger operations COLOR palette
+
+// GET operation colors 
+@colorGetDark: #0f6ab4;
+@colorGetMedium: #6fa5d2;
+@colorGetLight: #c3d9ec;
+@colorGetLighter: #e7f0f7;
+@colorGetUltraLight: #ebf3f9;
+
+// POST operation colors
+@colorPostDark: #10a54a;
+@colorPostMedium: #6fc992;
+@colorPostLight: #c3e8d1;
+@colorPostLighter: #e7f6ec;
+@colorPostUltraLight: #ebf7f0;
+
+// PUT operation colors 
+@colorPutDark: #c5862b;
+@colorPutMedium: #dcb67f;
+@colorPutLight: #f0e0ca;
+@colorPutLighter: #f9f2e9;
+@colorPutUltraLight: #faf5ee;
+
+// DELETE operation colors 
+@colorDeleteDark: #a41e22;
+@colorDeleteMedium: #c8787a;
+@colorDeleteLight: #e8c6c7;
+@colorDeleteLighter: #f5e8e8;
+@colorDeleteUltraLight: #f7eded;
+
+// HEAD operation colors 
+@colorHeadDark: #ffd20f;
+@colorHeadMedium: #6fc992;
+@colorHeadLight: #ffd20f;
+@colorHeadLighter: #fcffcd;
+@colorHeadUltraLight: #fcffcd;
+
+// PATCH operation colors
+@colorPatchDark: #D38042;
+@colorPatchMedium: #dcb67f;
+@colorPatchLight: #f0cecb;
+@colorPatchLighter: #FCE9E3;
+@colorPatchUltraLight: #faf0ef;

--- a/src/main/less/resource.less
+++ b/src/main/less/resource.less
@@ -1,0 +1,91 @@
+// a resource style mixin
+.resource() {
+    border-bottom: 1px solid #dddddd;
+    &:hover div.heading,
+    &.active div.heading {
+        h2 a {
+            color: black;
+        }
+        ul.options li a {
+            color: #555555;
+        }
+    }
+
+    &:last-child {
+        border-bottom: none;
+    }
+
+    div.heading {
+        border: 1px solid transparent;
+        float: none;
+        clear: both;
+        overflow: hidden;
+        display: block;
+        ul.options {
+            overflow: hidden;
+            padding: 0;
+            display: block;
+            clear: none;
+            float: right;
+            margin: 14px 10px 0 0;
+            li {
+                float: left;
+                clear: none;
+                margin: 0;
+                padding: 2px 10px;
+                border-right: 1px solid #dddddd;
+                color: #666666;
+                font-size: 0.9em;
+                a {
+                    color: #aaaaaa;
+                    text-decoration: none;
+                }
+                a:hover {
+                    text-decoration: underline;
+                    color: black;
+                }
+            }
+
+            li {
+                a:hover, a:active, a.active {
+                    text-decoration: underline;
+                }
+
+                &:first-child,
+                &.first {
+                    padding-left: 0;
+                }
+
+                &:last-child, &.last {
+                    padding-right: 0;
+                    border-right: none;
+                }
+            }
+            &:first-child, &.first {
+                padding-left: 0;
+            }
+        }
+        h2 {
+            color: #999999;
+            padding-left: 0;
+            display: block;
+            clear: none;
+            float: left;
+            font-family: @fontParagraph;
+            font-weight: bold;
+            a {
+                color: #999999;
+            }
+            a:hover {
+                color: black;
+            }
+        }
+    }
+    ul.endpoints {
+        li.endpoint {
+            ul.operations {
+                .operation;
+            }
+        }
+    }
+}

--- a/src/main/less/screen.less
+++ b/src/main/less/screen.less
@@ -1,5 +1,11 @@
+@import 'src/main/less/palette.less';
+@import 'src/main/less/fonts.less';
 @import 'src/main/less/reset.less';
+@import 'src/main/less/operationType.less';
+@import 'src/main/less/operation.less';
+@import 'src/main/less/resource.less';
 @import 'src/main/less/specs.less';
+
 
 #header {
     background-color: #89bf04;

--- a/src/main/less/specs.less
+++ b/src/main/less/specs.less
@@ -1,13 +1,13 @@
 .swagger-ui-wrap {
 
     line-height: 1;
-    font-family: "Droid Sans", sans-serif;
+    font-family: @fontParagraph;
     max-width: 960px;
     margin-left: auto;
     margin-right: auto;
 
     b, strong {
-        font-family: "Droid Sans", sans-serif;
+        font-family: @fontParagraph;
         font-weight: bold;
     }
 
@@ -111,7 +111,7 @@
     }
 
     pre {
-        font-family: "Anonymous Pro", "Menlo", "Consolas", "Bitstream Vera Sans Mono", "Courier New", monospace;
+        font-family: @fontCode;
         background-color: #fcf6db;
         border: 1px solid #e5e0c6;
         padding: 10px;
@@ -208,7 +208,7 @@
     }
 
     .model-signature {
-        font-family: "Droid Sans", sans-serif;
+        font-family: @fontParagraph;
         font-size: 1em;
         line-height: 1.5em;
         .signature-nav {
@@ -295,7 +295,7 @@
     }
 
     .markdown p code, .markdown li code {
-        font-family: "Anonymous Pro", "Menlo", "Consolas", "Bitstream Vera Sans Mono", "Courier New", monospace;
+        font-family: @fontCode;
         background-color: #f0f0f0;
         color: black;
         padding: 1px 3px;
@@ -315,7 +315,7 @@
         font-size: 1.5em;
         line-height: 1.3em;
         padding: 10px 0 10px 0;
-        font-family: "Droid Sans", sans-serif;
+        font-family: @fontParagraph;
         font-weight: bold;
     }
 
@@ -368,7 +368,7 @@
     }
 
     .code {
-        font-family: "Anonymous Pro", "Menlo", "Consolas", "Bitstream Vera Sans Mono", "Courier New", monospace;
+        font-family: @fontCode;
     }
 
     form.formtastic {
@@ -376,7 +376,7 @@
             ol {
                 li.text {
                     textarea {
-                        font-family: "Droid Sans", sans-serif;
+                        font-family: @fontParagraph;
                         height: 250px;
                         padding: 4px;
                         display: block;
@@ -453,7 +453,7 @@
             color: #666666;
         }
         pre {
-            font-family: "Anonymous Pro", "Menlo", "Consolas", "Bitstream Vera Sans Mono", "Courier New", monospace;
+            font-family: @fontCode;
             background-color: #fcf6db;
             border: 1px solid #e5e0c6;
             padding: 10px;
@@ -469,481 +469,10 @@
     }
 
     ul#resources {
-        font-family: "Droid Sans", sans-serif;
+        font-family: @fontParagraph;
         font-size: 0.9em;
-
         li.resource {
-            border-bottom: 1px solid #dddddd;
-
-            &:hover div.heading,
-            &.active div.heading {
-                h2 a {
-                    color: black;
-                }
-                ul.options li a {
-                    color: #555555;
-                }
-            }
-
-            &:last-child {
-                border-bottom: none;
-            }
-
-            div.heading {
-                border: 1px solid transparent;
-                float: none;
-                clear: both;
-                overflow: hidden;
-                display: block;
-                ul.options {
-                    overflow: hidden;
-                    padding: 0;
-                    display: block;
-                    clear: none;
-                    float: right;
-                    margin: 14px 10px 0 0;
-                    li {
-                        float: left;
-                        clear: none;
-                        margin: 0;
-                        padding: 2px 10px;
-                        border-right: 1px solid #dddddd;
-                        color: #666666;
-                        font-size: 0.9em;
-                        a {
-                            color: #aaaaaa;
-                            text-decoration: none;
-                        }
-                        a:hover {
-                            text-decoration: underline;
-                            color: black;
-                        }
-                    }
-
-                    li {
-                        a:hover, a:active, a.active {
-                            text-decoration: underline;
-                        }
-
-                        &:first-child,
-                        &.first {
-                            padding-left: 0;
-                        }
-
-                        &:last-child, &.last {
-                            padding-right: 0;
-                            border-right: none;
-                        }
-                    }
-                    &:first-child, &.first {
-                        padding-left: 0;
-                    }
-                }
-                h2 {
-                    color: #999999;
-                    padding-left: 0;
-                    display: block;
-                    clear: none;
-                    float: left;
-                    font-family: "Droid Sans", sans-serif;
-                    font-weight: bold;
-                    a {
-                        color: #999999;
-                    }
-                    a:hover {
-                        color: black;
-                    }
-                }
-            }
-            ul.endpoints {
-                li.endpoint {
-                    ul.operations {
-                        li.operation {
-                            float: none;
-                            clear: both;
-                            overflow: hidden;
-                            display: block;
-                            margin: 0 0 10px;
-                            padding: 0;
-                            div.heading {
-                                float: none;
-                                clear: both;
-                                overflow: hidden;
-                                display: block;
-                                margin: 0;
-                                padding: 0;
-                                h3 {
-                                    display: block;
-                                    clear: none;
-                                    float: left;
-                                    width: auto;
-                                    margin: 0;
-                                    padding: 0;
-                                    line-height: 1.1em;
-                                    color: black;
-                                    span.path {
-                                        padding-left: 10px;
-                                        a {
-                                            color: black;
-                                            text-decoration: none;
-                                        }
-                                        a:hover {
-                                            text-decoration: underline;
-                                        }
-                                    }
-                                    span.http_method {
-                                        a {
-                                            text-transform: uppercase;
-                                            text-decoration: none;
-                                            color: white;
-                                            display: inline-block;
-                                            width: 50px;
-                                            font-size: 0.7em;
-                                            text-align: center;
-                                            padding: 7px 0 4px;
-                                            -moz-border-radius: 2px;
-                                            -webkit-border-radius: 2px;
-                                            -o-border-radius: 2px;
-                                            -ms-border-radius: 2px;
-                                            -khtml-border-radius: 2px;
-                                            border-radius: 2px;
-                                        }
-                                    }
-                                    span {
-                                        margin: 0;
-                                        padding: 0;
-                                    }
-                                }
-                                ul.options {
-                                    overflow: hidden;
-                                    padding: 0;
-                                    display: block;
-                                    clear: none;
-                                    float: right;
-                                    margin: 6px 10px 0 0;
-                                    li {
-                                        float: left;
-                                        clear: none;
-                                        margin: 0;
-                                        padding: 2px 10px;
-                                        font-size: 0.9em;
-                                        a {
-                                            text-decoration: none;
-                                        }
-                                    }
-                                }
-                            }
-                            div.content {
-                                border-top: none;
-                                padding: 10px;
-                                -moz-border-radius-bottomleft: 6px;
-                                -webkit-border-bottom-left-radius: 6px;
-                                -o-border-bottom-left-radius: 6px;
-                                -ms-border-bottom-left-radius: 6px;
-                                -khtml-border-bottom-left-radius: 6px;
-                                border-bottom-left-radius: 6px;
-                                -moz-border-radius-bottomright: 6px;
-                                -webkit-border-bottom-right-radius: 6px;
-                                -o-border-bottom-right-radius: 6px;
-                                -ms-border-bottom-right-radius: 6px;
-                                -khtml-border-bottom-right-radius: 6px;
-                                border-bottom-right-radius: 6px;
-                                margin: 0 0 20px;
-                                h4 {
-                                    font-size: 1.1em;
-                                    margin: 0;
-                                    padding: 15px 0 5px;
-                                }
-                                div.sandbox_header {
-                                    float: none;
-                                    clear: both;
-                                    overflow: hidden;
-                                    display: block;
-                                    a {
-                                        padding: 4px 0 0 10px;
-                                        display: inline-block;
-                                        font-size: 0.9em;
-                                    }
-                                    img {
-                                        display: block;
-                                        clear: none;
-                                        float: right;
-                                    }
-                                    input.submit {
-                                        display: block;
-                                        clear: none;
-                                        float: left;
-                                        padding: 6px 8px;
-                                    }
-                                }
-                                form {
-                                    input[type='text'].error {
-                                        outline: 2px solid black;
-                                        outline-color: #cc0000;
-                                    }
-                                }
-                                div.response {
-                                    div.block {
-                                        pre {
-                                            font-family: "Anonymous Pro", "Menlo", "Consolas", "Bitstream Vera Sans Mono", "Courier New", monospace;
-                                            padding: 10px;
-                                            font-size: 0.9em;
-                                            max-height: 400px;
-                                            overflow-y: auto;
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        li.operation.put {
-                            div.heading {
-                                background-color: #f9f2e9;
-                                border: 1px solid #f0e0ca;
-                                h3 {
-                                    span.http_method {
-                                        a {
-                                            background-color: #c5862b;
-                                        }
-                                    }
-                                }
-                                ul.options {
-                                    li {
-                                        border-right: 1px solid #dddddd;
-                                        border-right-color: #f0e0ca;
-                                        color: #c5862b;
-                                        a {
-                                            color: #c5862b;
-                                        }
-                                    }
-                                }
-                            }
-                            div.content {
-                                background-color: #faf5ee;
-                                border: 1px solid #f0e0ca;
-                                h4 {
-                                    color: #c5862b;
-                                }
-                                div.sandbox_header {
-                                    a {
-                                        color: #dcb67f;
-
-                                    }
-                                }
-                            }
-                        }
-                        li.operation.head {
-                            div.heading {
-                                background-color: #fcffcd;
-                                border: 1px solid black;
-                                border-color: #ffd20f;
-                                h3 {
-                                    span.http_method {
-                                        a {
-                                            text-transform: uppercase;
-                                            background-color: #ffd20f;
-                                        }
-                                    }
-                                }
-                                ul.options {
-                                    li {
-                                        border-right: 1px solid #dddddd;
-                                        border-right-color: #ffd20f;
-                                        color: #ffd20f;
-                                        a {
-                                            color: #ffd20f;
-                                        }
-                                    }
-                                }
-                            }
-                            div.content {
-                                background-color: #fcffcd;
-                                border: 1px solid black;
-                                border-color: #ffd20f;
-                                h4 {
-                                    color: #ffd20f;
-                                }
-                                div.sandbox_header {
-                                    a {
-                                        color: #6fc992;
-                                    }
-                                }
-                            }
-                        }
-                        li.operation.delete {
-                            div.heading {
-                                background-color: #f5e8e8;
-                                border: 1px solid #e8c6c7;
-                                h3 {
-                                    span.http_method {
-                                        a {
-                                            text-transform: uppercase;
-                                            background-color: #a41e22;
-
-                                        }
-                                    }
-                                }
-                                ul.options {
-                                    li {
-                                        border-right: 1px solid #dddddd;
-                                        border-right-color: #e8c6c7;
-                                        color: #a41e22;
-                                        a {
-                                            color: #a41e22;
-                                        }
-                                    }
-                                }
-                            }
-                            div.content {
-                                background-color: #f7eded;
-                                border: 1px solid #e8c6c7;
-                                h4 {
-                                    color: #a41e22;
-                                }
-                                div.sandbox_header {
-                                    a {
-                                        color: #c8787a;
-                                    }
-                                }
-                            }
-                        }
-                        li.operation.post {
-                            div.heading {
-                                background-color: #e7f6ec;
-                                border: 1px solid #c3e8d1;
-                                h3 {
-                                    span.http_method {
-                                        a {
-                                            background-color: #10a54a;
-                                        }
-                                    }
-                                }
-                                ul.options {
-                                    li {
-                                        border-right: 1px solid #dddddd;
-                                        border-right-color: #c3e8d1;
-                                        color: #10a54a;
-                                        a {
-                                            color: #10a54a;
-                                        }
-                                    }
-                                }
-                            }
-                            div.content {
-                                background-color: #ebf7f0;
-                                border: 1px solid #c3e8d1;
-                                h4 {
-                                    color: #10a54a;
-                                }
-                                div.sandbox_header {
-                                    a {
-                                        color: #6fc992;
-                                    }
-                                }
-                            }
-                        }
-                        li.operation.patch {
-                            div.heading {
-                                background-color: #FCE9E3;
-                                border: 1px solid #F5D5C3;
-                                h3 {
-                                    span.http_method {
-                                        a {
-                                            background-color: #D38042;
-
-                                        }
-                                    }
-                                }
-                                ul.options {
-                                    li {
-                                        border-right: 1px solid #dddddd;
-                                        border-right-color: #f0cecb;
-                                        color: #D38042;
-                                        a {
-                                            color: #D38042;
-                                        }
-                                    }
-                                }
-                            }
-                            div.content {
-                                background-color: #faf0ef;
-                                border: 1px solid #f0cecb;
-
-                                h4 {
-                                    color: #D38042;
-
-                                }
-                                div.sandbox_header {
-                                    a {
-                                        color: #dcb67f;
-                                    }
-                                }
-                            }
-                        }
-                        li.operation.get {
-                            div.heading {
-                                background-color: #e7f0f7;
-                                border: 1px solid #c3d9ec;
-                                h3 {
-                                    span.http_method {
-                                        a {
-                                            background-color: #0f6ab4;
-                                        }
-                                    }
-                                }
-                                ul.options {
-                                    li {
-                                        border-right: 1px solid #dddddd;
-                                        border-right-color: #c3d9ec;
-                                        color: #0f6ab4;
-                                        a {
-                                            color: #0f6ab4;
-                                        }
-                                    }
-                                }
-                            }
-                            div.content {
-                                background-color: #ebf3f9;
-                                border: 1px solid #c3d9ec;
-                                h4 {
-                                    color: #0f6ab4;
-                                }
-                                div.sandbox_header {
-                                    a {
-                                        color: #6fa5d2;
-                                    }
-                                }
-                            }
-                        }
-                        li.operation {
-                            &.get, &.post, &.head, &.put, &.patch, &.delete {
-                                div.content {
-                                    border-top: none;
-                                }
-                                div.heading ul.options li {
-                                    &:last-child, &.last {
-                                        padding-right: 0;
-                                        border-right: none;
-                                    }
-                                }
-                            }
-                        }
-                        ul.options li {
-                            a:hover, a:active, a.active {
-                                text-decoration: underline;
-                            }
-
-                            &:first-child,
-                            &.first {
-                                padding-left: 0;
-                            }
-
-                        }
-                        &:first-child, &.first {
-                            padding-left: 0;
-                        }
-                    }
-                }
-            }
+            .resource;
         }
     }
 
@@ -952,7 +481,7 @@
         padding: 10px 0;
         font-size: 0.8em;
         border-top: 1px solid #dddddd;
-        font-family: "Droid Sans", sans-serif;
+        font-family: @fontParagraph;
         color: #999999;
         font-style: italic;
         a {
@@ -968,7 +497,7 @@
     }
 
     .markdown ol, .markdown ul {
-        font-family: "Droid Sans", sans-serif;
+        font-family: @fontParagraph;
         margin: 5px 0 10px;
         padding: 0 0 0 18px;
         list-style-type: disc;


### PR DESCRIPTION
Hi,
this change simplifies some UI look customization work:

 1 Colors - operation type color scheme (GET,POST...) can be easily changed by replacing the variable values in the palette.less file, thanks to LESS color functions one can optionally declare colors like:
@colorGetDark: #0f6ab4;
@colorGetMedium: lighten(@colorGetDark, 10%);
@colorGetLight: desaturate(lighten(@colorGetDark, 45%), 50%);

2. Fonts - as swagger-ui currently uses 2 font-family values, there are 2 global variables in fonts.less

3. Simple mixins - resource.less and operation.less, extracting that to separeted files seems to be natural, like splitting Coffee scripts to different files (views).

4. Parametrized mixin operationView.less (GET, POST...) shrinked some copy/paste code in this area. 