### PR TITLE
Update swagger-ui.js

### DIFF
--- a/dist/swagger-ui.js
+++ b/dist/swagger-ui.js
@@ -1735,13 +1735,13 @@ helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
       if (content === void 0) {
         code = $('<code />').text("no content");
         pre = $('<pre class="json" />').append(code);
-      } else if (contentType.indexOf("application/json") === 0 || contentType.indexOf("application/hal+json") === 0) {
+      } else if (contentType && (contentType.indexOf("application/json") === 0 || contentType.indexOf("application/hal+json") === 0)) {
         code = $('<code />').text(JSON.stringify(JSON.parse(content), null, 2));
         pre = $('<pre class="json" />').append(code);
-      } else if (contentType.indexOf("application/xml") === 0) {
+      } else if (contentType &&contentType.indexOf("application/xml") === 0) {
         code = $('<code />').text(this.formatXml(content));
         pre = $('<pre class="xml" />').append(code);
-      } else if (contentType.indexOf("text/html") === 0) {
+      } else if (!contentType || contentType.indexOf("text/html") === 0) {
         code = $('<code />').html(content);
         pre = $('<pre class="xml" />').append(code);
       } else {


### PR DESCRIPTION
Treat content as html if no contentType header is set. Fixes issues related to 401 status codes from node passportjs.