### PR TITLE
protect against type == undefined

### DIFF
--- a/dist/lib/swagger.js
+++ b/dist/lib/swagger.js
@@ -641,7 +641,7 @@
         parameter = _ref1[_i];
         parameter.name = parameter.name || parameter.type || parameter.dataType;
         type = parameter.type || parameter.dataType;
-        if (type.toLowerCase() === 'boolean') {
+        if (type != undefined && type.toLowerCase() === 'boolean') {
           parameter.allowableValues = {};
           parameter.allowableValues.values = ["true", "false"];
         }
@@ -970,7 +970,7 @@
             _results = [];
             for (_i = 0, _len = _ref.length; _i < _len; _i++) {
               param = _ref[_i];
-              if (type.toLowerCase() === "file") {
+              if (type != undefined && type.toLowerCase() === "file") {
                 _results.push(param);
               }
             }

--- a/dist/swagger-ui.js
+++ b/dist/swagger-ui.js
@@ -1511,7 +1511,7 @@ helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
       for (_i = 0, _len = _ref5.length; _i < _len; _i++) {
         param = _ref5[_i];
         type = param.type || param.dataType;
-        if (type.toLowerCase() === 'file') {
+        if (type != undefined && type.toLowerCase() === 'file') {
           if (!contentTypeModel.consumes) {
             console.log("set content type ");
             contentTypeModel.consumes = 'multipart/form-data';
@@ -1902,7 +1902,7 @@ helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
       if (this.model.paramType === 'body') {
         this.model.isBody = true;
       }
-      if (type.toLowerCase() === 'file') {
+      if (type != undefined && type.toLowerCase() === 'file') {
         this.model.isFile = true;
       }
       template = this.template();

--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -641,7 +641,7 @@
         parameter = _ref1[_i];
         parameter.name = parameter.name || parameter.type || parameter.dataType;
         type = parameter.type || parameter.dataType;
-        if (type.toLowerCase() === 'boolean') {
+        if (type != undefined && type.toLowerCase() === 'boolean') {
           parameter.allowableValues = {};
           parameter.allowableValues.values = ["true", "false"];
         }
@@ -970,7 +970,7 @@
             _results = [];
             for (_i = 0, _len = _ref.length; _i < _len; _i++) {
               param = _ref[_i];
-              if (type.toLowerCase() === "file") {
+              if (type != undefined && type.toLowerCase() === "file") {
                 _results.push(param);
               }
             }


### PR DESCRIPTION
We had a case where type was undefined in some of the json generated by swagger in response to our annotations. Swagger-ui would essentially become non-responsive in those cases - clicking various API entry points would do nothing. Adding the checks in this merge got the UI to be functional again. We haven't figured out why our annotations were causing type == undefined yet - if we do, we'll either change our annotations, or generate a pull request for that, too.

Side note: Swagger is awesome - you have relieved us of manually keeping a separate wiki in synch, and for that, we thank you!
