### PR TITLE
Don't send undefined parameters

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -831,7 +831,9 @@ SwaggerOperation.prototype.urlify = function(args) {
     if(param.paramType === 'query') {
       if(queryParams !== '')
         queryParams += "&";
-      queryParams += encodeURIComponent(param.name) + '=' + encodeURIComponent(args[param.name]);
+		if(args[param.name] !== undefined) {
+          queryParams += encodeURIComponent(param.name) + '=' + encodeURIComponent(args[param.name]);
+        }
     }
   }
   if ((queryParams != null) && queryParams.length > 0)


### PR DESCRIPTION
This

https://github.com/wordnik/swagger-ui/issues/180

is still happening. This change fixes it.