### PR TITLE
Work with Generics improved

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -15,6 +15,17 @@ log = function(){
   }
 };
 
+isArray = function(type) {
+  var t = type.toLowerCase();
+  var collections = ["list", "set", "array", "collection"];
+  for(c in collections) {
+    if(t.indexOf(collections[c]) != -1) {
+      return true;
+    }
+  }
+  return false;
+};
+
 var SwaggerApi = function(url, options) {
   this.url = null;
   this.debug = false;
@@ -448,6 +459,28 @@ var SwaggerModel = function(modelName, obj) {
   }
 }
 
+SwaggerModel.prototype.clone = function() {
+  var copy = new this.constructor(this.name, {id: this.name});
+  for (var attr in this) {
+    if (this.hasOwnProperty(attr)) {
+      copy[attr] = this[attr];
+    }
+  }
+  return copy;
+};
+
+SwaggerModel.prototype.injectGeneric = function(model) {
+  for (var i = 0; i < this.properties.length; i++) {
+    var property = this.properties[i];
+    if(property.dataType.match("<[a-zA-Z]+>") && isArray(property.dataType)) {
+      property.dataType = "Array";
+      property.dataTypeWithRef = "Array[" + model.name +"]";
+      property.refModel = model;
+    }
+  }
+  return this;
+};
+
 SwaggerModel.prototype.setReferencedModels = function(allModels) {
   var results = [];
   for (var i = 0; i < this.properties.length; i++) {
@@ -470,20 +503,27 @@ SwaggerModel.prototype.getMockSignature = function(modelsToIgnore) {
     propertiesStr.push(prop.toString());
   }
 
+  var modelsToIgnore = (modelsToIgnore||[]);
+  modelsToIgnore.push(this.name);
+  return this._formatSignature(propertiesStr) + this._formatInnerSignatures(modelsToIgnore);
+};
+
+SwaggerModel.prototype._formatSignature = function(propertiesStr) {
   var strong = '<span class="strong">';
   var stronger = '<span class="stronger">';
   var strongClose = '</span>';
   var classOpen = strong + this.name + ' {' + strongClose;
   var classClose = strong + '}' + strongClose;
-  var returnVal = classOpen + '<div>' + propertiesStr.join(',</div><div>') + '</div>' + classClose;
-  if (!modelsToIgnore)
-    modelsToIgnore = [];
-  modelsToIgnore.push(this.name);
+  return classOpen + '<div>' + propertiesStr.join(',</div><div>') + '</div>' + classClose;
+};
+
+SwaggerModel.prototype._formatInnerSignatures = function(modelsToIgnore) {
+  var returnVal = "";
 
   for (var i = 0; i < this.properties.length; i++) {
     prop = this.properties[i];
     if ((prop.refModel != null) && modelsToIgnore.indexOf(prop.refModel.name) === -1) {
-      returnVal = returnVal + ('<br>' + prop.refModel.getMockSignature(modelsToIgnore));
+      returnVal += ('<br>' + prop.refModel.getMockSignature(modelsToIgnore));
     }
   }
   return returnVal;
@@ -491,7 +531,7 @@ SwaggerModel.prototype.getMockSignature = function(modelsToIgnore) {
 
 SwaggerModel.prototype.createJSONSample = function(modelsToIgnore) {
   var result = {};
-  var modelsToIgnore = (modelsToIgnore||[])
+  var modelsToIgnore = (modelsToIgnore||[]);
   modelsToIgnore.push(this.name);
   for (var i = 0; i < this.properties.length; i++) {
     prop = this.properties[i];
@@ -504,7 +544,7 @@ SwaggerModel.prototype.createJSONSample = function(modelsToIgnore) {
 var SwaggerModelProperty = function(name, obj) {
   this.name = name;
   this.dataType = obj.type || obj.dataType || obj["$ref"];
-  this.isCollection = this.dataType && (this.dataType.toLowerCase() === 'array' || this.dataType.toLowerCase() === 'list' || this.dataType.toLowerCase() === 'set');
+  this.isCollection = this.dataType && isArray(this.dataType);
   this.descr = obj.description;
   this.required = obj.required;
   if (obj.items != null) {
@@ -698,15 +738,28 @@ SwaggerOperation.prototype.isListType = function(type) {
   }
 };
 
+SwaggerOperation.prototype.containerType = function(type) {
+  if (type.indexOf('[') >= 0) {
+    return type.substring(0, type.indexOf('['));
+  } else {
+    return void 0;
+  }
+};
+
 SwaggerOperation.prototype.getSignature = function(type, models) {
-  var isPrimitive, listType;
+  var isPrimitive, listType, containerType;
   listType = this.isListType(type);
+  containerType = this.containerType(type);
   isPrimitive = ((listType != null) && models[listType]) || (models[type] != null) ? false : true;
   if (isPrimitive) {
     return type;
   } else {
     if (listType != null) {
-      return models[listType].getMockSignature();
+      if(!isArray(containerType)) {
+        return models[containerType].clone().injectGeneric(models[listType]).getMockSignature();
+      } else {
+        return models[listType].getMockSignature();
+      }
     } else {
       return models[type].getMockSignature();
     }
@@ -716,8 +769,13 @@ SwaggerOperation.prototype.getSignature = function(type, models) {
 SwaggerOperation.prototype.getSampleJSON = function(type, models) {
   var isPrimitive, listType, val;
   listType = this.isListType(type);
+  containerType = this.containerType(type);
   isPrimitive = ((listType != null) && models[listType]) || (models[type] != null) ? false : true;
-  val = isPrimitive ? void 0 : (listType != null ? models[listType].createJSONSample() : models[type].createJSONSample());
+  val = isPrimitive ? void 0 : (listType != null
+    ? (!isArray(containerType)
+    ? models[containerType].clone().injectGeneric(models[listType]).createJSONSample()
+    : models[listType].createJSONSample())
+    : models[type].createJSONSample());
   if (val) {
     val = listType ? [val] : val;
     return JSON.stringify(val, null, 2);


### PR DESCRIPTION
To SwaggerModel added function injectGeneric which inserts reference to model.
For instance, we have ContainerClass[InnerClass].
ContainerClass {
  value (java.util.Collection<T>, optional)
}
It will become
ContainerClass {
  value (Array[InnerClass], optional)
}

Minor improvements:
- collection added to array types
- getMockSignature() splitted on smaller methods
