### PR TITLE
Add index.js file that returns the dist location when require()d

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,7 @@
+var pack = require('./package');
+var path = require('path');
+
+module.exports = {
+    version: pack.version,
+    dist: path.resolve(__dirname, 'dist')
+};


### PR DESCRIPTION
Add index.js file that returns the dist location and version when required:

```
var swaggerui = require('swagger-ui');
console.log(swaggerui);
```

```
{
  version: '2.0.12',
  dist: '/Users/winklerp/Documents/Projects/swagger-ui/dist'
}
```

This can then be used in a server route, e.g.:

```
server.route({
    method: 'GET',
    path: '/api-docs/{param*}',
    handler: {
        directory: {
            path: swaggerui.dist
        }
    }
});
```
