### PR TITLE
No request url or response body data on file upload

### DIFF
--- a/src/main/coffeescript/view/OperationView.coffee
+++ b/src/main/coffeescript/view/OperationView.coffee
@@ -278,7 +278,12 @@ class OperationView extends Backbone.View
 
   # puts the response data in UI
   showStatus: (response) ->
-    content = response.data
+    if response.content is undefined
+            content = response.data
+            url = response.url
+    else
+        content = response.content.data
+        url = response.request.url
     headers = response.headers
 
     # if server is nice, and sends content-type back, we can use it
@@ -297,14 +302,14 @@ class OperationView extends Backbone.View
       code = $('<code />').html(content)
       pre = $('<pre class="xml" />').append(code)
     else if /^image\//.test(contentType)
-      pre = $('<img>').attr('src',response.url)
+      pre = $('<img>').attr('src',url)
     else
       # don't know what to render!
       code = $('<code />').text(content)
       pre = $('<pre class="json" />').append(code)
 
     response_body = pre
-    $(".request_url", $(@el)).html "<pre>" + response.url + "</pre>"
+    $(".request_url", $(@el)).html "<pre>" + url + "</pre>"
     $(".response_code", $(@el)).html "<pre>" + response.status + "</pre>"
     $(".response_body", $(@el)).html response_body
     $(".response_headers", $(@el)).html "<pre>" + JSON.stringify(response.headers, null, "  ").replace(/\n/g, "<br>") + "</pre>"


### PR DESCRIPTION
When the operations contains a file input the response data is wrapped as a shred response. The showStatus method does not take care of this and will not show the data in the UI. This is a simple hack to fix this. 
