### PR TITLE
btoa was not working before it was dereferenced

### DIFF
--- a/dist/lib/swagger.js
+++ b/dist/lib/swagger.js
@@ -1380,7 +1380,8 @@ var PasswordAuthorization = function(name, username, password) {
 };
 
 PasswordAuthorization.prototype.apply = function(obj, authorizations) {
-  obj.headers["Authorization"] = "Basic " + this._btoa(this.username + ":" + this.password);
+  var base64encoder = this._btoa;
+  obj.headers["Authorization"] = "Basic " + base64encoder(this.username + ":" + this.password);
   return true;
 };
 


### PR DESCRIPTION
In Chrome, initial setup showed an Uncaught TypeError: Illegal Invocation Error at this point.

Not sure why it wasn't working, but after dereferencing, it now encodes just fine.

Related to:
https://github.com/wordnik/swagger-js/issues/63
https://github.com/wordnik/swagger-js/issues/64
