### PR TITLE
Fix TypeError with param type

### DIFF
--- a/src/main/coffeescript/view/OperationView.coffee
+++ b/src/main/coffeescript/view/OperationView.coffee
@@ -75,7 +75,7 @@ class OperationView extends Backbone.View
     contentTypeModel.produces = @model.produces
 
     for param in @model.parameters
-      type = param.type || param.dataType
+      type = param.type || param.dataType || ''
       if type.toLowerCase() == 'file'
         if !contentTypeModel.consumes
           log "set content type "


### PR DESCRIPTION
using || operation with "" || undefined returns undefined. Should add an additional || to end the expression with a "" to protect against the value becoming undefined and breaking the .toLowerCase() call on line 79