### PR TITLE
add a new type for the swagger model

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -637,6 +637,8 @@ SwaggerModelProperty.prototype.toSampleValue = function(value) {
     result = 0.0;
   } else if (value === "string") {
     result = "";
+  } else if (value === "dict" || value === "json") {
+    result = {};
   } else {
     result = value;
   }


### PR DESCRIPTION
add type of **{}** in SwaggerModelProperty.prototype.toSampleValue @ **lib/swgger.js** file

i think it may need to post some sub-obejct in the model
eg.
<pre>
{
  "name": "elvis",
  "children": {
    "abc1": {},
    "abc2": {},
   }
}
<pre>