### PR TITLE
Attempt to append the popupDialog to a swagger-section

### DIFF
--- a/lib/swagger-oauth.js
+++ b/lib/swagger-oauth.js
@@ -37,7 +37,7 @@ function handleLogin() {
         '</div>',
         '</div>'].join(''));
 
-    if(('.swagger-section').length == 1)
+    if($('.swagger-section').length == 1)
       $('.swagger-section').append(popupDialog);
     else
       $(document.body).append(popupDialog);


### PR DESCRIPTION
This is needed to pickup swagger CSS styles when you don't have `swagger-section` class defined on `body`.
