### PR TITLE
Provide option highlightSizeThreshold 

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ To use swagger-ui you should take a look at the [source of swagger-ui html page]
 * *sorter* apply a sort to the API list. It can be 'alpha' (sort paths alphanumerically) or 'method' (sort operations by HTTP method). Default is the order returned by the server unchanged.
 * *onComplete* is a callback function parameter which can be passed to be notified of when SwaggerUI has completed rendering successfully.
 * *onFailure* is a callback function parameter which can be passed to be notified of when SwaggerUI encountered a failure was unable to render.
+* *highlightSizeThreshold* any size response below this threshold will be highlighted syntactically, attempting to highlight large responses can lead to browser hangs, not including a threshold will default to highlight all returned responses
 * All other parameters are explained in greater detail below
 
 

--- a/src/main/coffeescript/view/MainView.coffee
+++ b/src/main/coffeescript/view/MainView.coffee
@@ -33,7 +33,7 @@ class MainView extends Backbone.View
 
   addResource: (resource) ->
     # Render a resource and add it to resources li
-    resourceView = new ResourceView({model: resource, tagName: 'li', id: 'resource_' + resource.id, className: 'resource'})
+    resourceView = new ResourceView({model: resource, tagName: 'li', id: 'resource_' + resource.id, className: 'resource', swaggerOptions: @options.swaggerOptions})
     $('#resources').append resourceView.render().el
 
   clear: ->

--- a/src/main/coffeescript/view/OperationView.coffee
+++ b/src/main/coffeescript/view/OperationView.coffee
@@ -365,7 +365,10 @@ class OperationView extends Backbone.View
     $(".response", $(@el)).slideDown()
     $(".response_hider", $(@el)).show()
     $(".response_throbber", $(@el)).hide()
-    hljs.highlightBlock($('.response_body', $(@el))[0])
+    response_body_el = $('.response_body', $(@el))[0]
+    # only highlight the response if response is less than threshold, default state is highlight response
+    opts = @options.swaggerOptions
+    if opts.highlightSizeThreshold && response.data.length > opts.highlightSizeThreshold then response_body_el else hljs.highlightBlock(response_body_el)
 
   toggleOperationContent: ->
     elem = $('#' + Docs.escapeResourceName(@model.parentId) + "_" + @model.nickname + "_content")

--- a/src/main/coffeescript/view/ResourceView.coffee
+++ b/src/main/coffeescript/view/ResourceView.coffee
@@ -27,7 +27,7 @@ class ResourceView extends Backbone.View
     operation.number = @number
 
     # Render an operation and add it to operations li
-    operationView = new OperationView({model: operation, tagName: 'li', className: 'endpoint'})
+    operationView = new OperationView({model: operation, tagName: 'li', className: 'endpoint', swaggerOptions: @options.swaggerOptions})
     $('.endpoints', $(@el)).append operationView.render().el
 
     @number++


### PR DESCRIPTION
to allow conditional syntax highlighting based on response size.  If option isn't included it defaults to highlight all responses.

In response to https://github.com/wordnik/swagger-ui/issues/449
