### PR TITLE
Moved reference to throbber.gif to CSS file.

### DIFF
--- a/dist/css/screen.css
+++ b/dist/css/screen.css
@@ -743,16 +743,19 @@
   display: inline-block;
   font-size: 0.9em;
 }
-.swagger-section .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.content div.sandbox_header img {
-  display: block;
-  clear: none;
-  float: right;
-}
 .swagger-section .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.content div.sandbox_header input.submit {
   display: block;
   clear: none;
   float: left;
   padding: 6px 8px;
+}
+.swagger-section .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.content div.sandbox_header span.response_throbber {
+  background-image: url('../images/throbber.gif');
+  width: 128px;
+  height: 16px;
+  display: block;
+  clear: none;
+  float: right;
 }
 .swagger-section .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.content form input[type='text'].error {
   outline: 2px solid black;

--- a/src/main/html/css/screen.css
+++ b/src/main/html/css/screen.css
@@ -743,16 +743,19 @@
   display: inline-block;
   font-size: 0.9em;
 }
-.swagger-section .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.content div.sandbox_header img {
-  display: block;
-  clear: none;
-  float: right;
-}
 .swagger-section .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.content div.sandbox_header input.submit {
   display: block;
   clear: none;
   float: left;
   padding: 6px 8px;
+}
+.swagger-section .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.content div.sandbox_header span.response_throbber {
+  background-image: url('../images/throbber.gif');
+  width: 128px;
+  height: 16px;
+  display: block;
+  clear: none;
+  float: right;
 }
 .swagger-section .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.content form input[type='text'].error {
   outline: 2px solid black;

--- a/src/main/less/specs.less
+++ b/src/main/less/specs.less
@@ -671,16 +671,19 @@
                                         display: inline-block;
                                         font-size: 0.9em;
                                     }
-                                    img {
-                                        display: block;
-                                        clear: none;
-                                        float: right;
-                                    }
                                     input.submit {
                                         display: block;
                                         clear: none;
                                         float: left;
                                         padding: 6px 8px;
+                                    }
+                                    span.response_throbber {
+                                      background-image: url('../images/throbber.gif');
+                                      width: 128px;
+                                      height: 16px;
+                                      display: block;
+                                      clear: none;
+                                      float: right;
                                     }
                                 }
                                 form {

--- a/src/main/template/operation.handlebars
+++ b/src/main/template/operation.handlebars
@@ -83,7 +83,7 @@
           <div class='sandbox_header'>
             <input class='submit' name='commit' type='button' value='Try it out!' />
             <a href='#' class='response_hider' style='display:none'>Hide Response</a>
-            <img alt='Throbber' class='response_throbber' src='images/throbber.gif' style='display:none' />
+            <span class='response_throbber' style='display:none'></span>
           </div>
           {{/if}}
         </form>


### PR DESCRIPTION
In a more complex set-up, a `swagger-ui` page may be served deeper into the site wherein `img.response_throbber` cannot locate `../images/throbber.gif`, because it simply isn't there.

This patch moves the reference to the gif from the `img` tag and into the CSS file. Therefore the image only needs to be located relative to the CSS file, not on the page itself.

(This is somewhat related to https://github.com/wordnik/swagger-ui/issues/470)
