### PR TITLE
Added error log to SwaggerOperation

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -686,8 +686,10 @@ var SwaggerOperation = function(nickname, path, method, parameters, summary, not
   this.authorizations = authorizations;
   this["do"] = __bind(this["do"], this);
 
-  if (errors.length > 0)
+  if (errors.length > 0) {
+    console.error('SwaggerOperation errors', errors, arguments);
     this.resource.api.fail(errors);
+  }
 
   this.path = this.path.replace('{format}', 'json');
   this.method = this.method.toLowerCase();


### PR DESCRIPTION
If failing to find a method or path, the error "SwaggerOperation query is missing method." gives no context on what resource this occurred on to find and solve the problem. This logs all errors and arguments in the console at the very least.
