### PR TITLE
removed unused ',' so that IE won't puke.

### DIFF
--- a/lib/shred.bundle.js
+++ b/lib/shred.bundle.js
@@ -2207,7 +2207,7 @@ module.exports = {
     constructor.prototype.getHeaders = function() { return getHeaders(this,arguments); };
     constructor.prototype.setHeader = function(key,value) { return setHeader(this,key,value); };
     constructor.prototype.setHeaders = function(hash) { return setHeaders(this,hash); };
-  },
+  }
 };
 
 });


### PR DESCRIPTION
This extra comma makes IE fail to render UI.