### PR TITLE
path param pattern is too weak,

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -955,7 +955,31 @@ SwaggerOperation.prototype.urlify = function(args) {
       if(args[param.name]) {
         // apply path params and remove from args
         var reg = new RegExp('\{' + param.name + '[^\}]*\}', 'gi');
-        url = url.replace(reg, this.encodePathParam(args[param.name]));
+        var paramStart = url.search(reg);
+        function findParamEnd(start,url){
+              var end = -1;
+              if(start>=0){
+                  var counter = 1;
+                  end = start+1;
+                  while(end<url.length){
+                      switch(url.charAt(end)){
+                          case '{':
+                              counter++;
+                              break;
+                          case '}':
+                              counter--;
+                              break;
+                      }
+                      end++;
+                      if(counter==0) break;
+                  }
+              }
+              return end;
+        }
+        var paramEnd = findParamEnd(paramStart,url);
+        if(paramStart>=0){
+          url = url.substring(0,paramStart)+this.encodePathParam(args[param.name]) + url.substring(paramEnd);
+        }
         delete args[param.name];
       }
       else
@@ -1567,7 +1591,7 @@ SwaggerAuthorizations.prototype.apply = function(obj, authorizations) {
           if (result === true)
             status = true;
         }
-      }      
+      }
     }
   }
 


### PR DESCRIPTION
 it can't handle properly /entities/{id:[a-z0-9-]{36}}

So let's count brackets to search for param definition end.