### PR TITLE
Fixing tags check for undefined.

### DIFF
--- a/lib/swagger-client.js
+++ b/lib/swagger-client.js
@@ -288,7 +288,7 @@ SwaggerClient.prototype.buildFromSpec = function(response) {
     for(httpMethod in response.paths[path]) {
       var operation = response.paths[path][httpMethod];
       var tags = operation.tags;
-      if(typeof tags === undefined)
+      if(typeof tags === 'undefined')
         tags = [];
       var operationId = this.idFromOp(path, httpMethod, operation);
       var operation = new Operation (


### PR DESCRIPTION
The check for `tags` element is not checking for undefined correctly.  This causes a `tags.length` error when tags is not defined in the spec.
