### PR TITLE
Escape returned HTML

### DIFF
--- a/src/main/coffeescript/view/OperationView.coffee
+++ b/src/main/coffeescript/view/OperationView.coffee
@@ -356,7 +356,7 @@ class OperationView extends Backbone.View
       code = $('<code />').text(@formatXml(content))
       pre = $('<pre class="xml" />').append(code)
     else if contentType is "text/html"
-      code = $('<code />').html(content)
+      code = $('<code />').html(_.escape(content))
       pre = $('<pre class="xml" />').append(code)
     else if /^image\//.test(contentType)
       pre = $('<img>').attr('src',url)


### PR DESCRIPTION
When HTML is returned by the service, it will now be escaped for viewing the source on the Response Body pane.

Thanks for creating and maintaining such an awesome tool!

The issue I was having is that one of the calls returns a full HTML page, complete with a head and referenced JavaScript files. The Swagger UI page was getting stuck trying to pull in these resources.

Is there a need for the HTML to be rendered on the page? As a developer, I find the HTML source to be more useful.
