### PR TITLE
pull out onChange handler for #input_apiKey so it can be called manually

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -65,9 +65,11 @@
     });
 
     // if you have an apiKey you would like to pre-populate on the page for demonstration purposes...
-    // var apiKey = "myApiKeyXXXX123456789";
-    // $('#input_apiKey').val(apiKey);
-    // addApiKeyAuthorization();
+    /*
+       var apiKey = "myApiKeyXXXX123456789";
+       $('#input_apiKey').val(apiKey);
+       addApiKeyAuthorization();
+    */
 
     window.swaggerUi.load();
   });


### PR DESCRIPTION
Hi there.  One feature clients have really loved is the ability to exercise the API endpoints with a prepopulated ApiKey if the API is protected with one.  This comes in really handy for marketing purposes - people can play around in a sandbox environment before going through the process of getting a real ApiKey. 

Before the introduction of the ApiKeyAuthorization class, setting the 'apiKey' property when creating SwaggerUi would pre-populate the 'api_key' input and then I just had to use that for generated API calls.

ApiKeyAuthorization is sweet but I'm wondering if we can just pull out the handler for change() on the 'api_key' input so that we can call it after code that sets the 'api_key' value manually?  This is needed since the change() event doesn't fire unless focus is lost on an input - which it doesn't have in this case.  I left in sample commented-out code that shows this.

What do you think?
