### PR TITLE
expandOperationsForResource misspelled

### DIFF
--- a/src/main/coffeescript/view/ResourceView.coffee
+++ b/src/main/coffeescript/view/ResourceView.coffee
@@ -25,7 +25,7 @@ class ResourceView extends Backbone.View
 
     $('.toggleEndpointList', @el).click(this.callDocs.bind(this, 'toggleEndpointListForResource'))
     $('.collapseResource', @el).click(this.callDocs.bind(this, 'collapseOperationsForResource'))
-    $('.expandResource', @el).click(this.callDocs.bind(this, 'expandOperationsForResoruce'))
+    $('.expandResource', @el).click(this.callDocs.bind(this, 'expandOperationsForResource'))
     
     return @
 


### PR DESCRIPTION
The bind call to selector '.expandResource' was misspelled as "expandOperationsForResoruce"
