### PR TITLE
Sync `develop_2.0` branch back to `master`

### DIFF
--- a/dist/lib/swagger-client.js
+++ b/dist/lib/swagger-client.js
@@ -288,7 +288,7 @@ SwaggerClient.prototype.buildFromSpec = function(response) {
     for(httpMethod in response.paths[path]) {
       var operation = response.paths[path][httpMethod];
       var tags = operation.tags;
-      if(typeof tags === undefined)
+      if(typeof tags === 'undefined')
         tags = [];
       var operationId = this.idFromOp(path, httpMethod, operation);
       var operation = new Operation (

--- a/lib/swagger-client.js
+++ b/lib/swagger-client.js
@@ -288,7 +288,7 @@ SwaggerClient.prototype.buildFromSpec = function(response) {
     for(httpMethod in response.paths[path]) {
       var operation = response.paths[path][httpMethod];
       var tags = operation.tags;
-      if(typeof tags === undefined)
+      if(typeof tags === 'undefined')
         tags = [];
       var operationId = this.idFromOp(path, httpMethod, operation);
       var operation = new Operation (


### PR DESCRIPTION
Looks like you moved from `develop_2.0` branch back to `master` for swagger 2.0 spec support.  Can you merge this fix back to master?

Thanks!
