### PR TITLE
Make reference to api-docs relative.

### DIFF
--- a/src/main/coffeescript/view/HeaderView.coffee
+++ b/src/main/coffeescript/view/HeaderView.coffee
@@ -12,7 +12,7 @@ class HeaderView extends Backbone.View
   showPetStore: (e) ->
     @trigger(
       'update-swagger-ui'
-      {url:"http://petstore.swagger.wordnik.com/api/api-docs"}
+      {url:"api-docs"}
     )
 
   showWordnikDev: (e) ->


### PR DESCRIPTION
This should work both with the Pet Store example and any implementation that uses the same pattern of putting the swagger files in a subdirectory called 'api-docs'.