### PR TITLE
Adding deprecated indicator to operations

### DIFF
--- a/src/main/html/css/screen.css
+++ b/src/main/html/css/screen.css
@@ -669,6 +669,10 @@
 .swagger-section .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.heading h3 span.path a:hover {
   text-decoration: underline;
 }
+.swagger-section .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.heading h3 span.path a.deprecated {
+    color: #666666;
+    text-decoration: line-through;
+}
 .swagger-section .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.heading h3 span.http_method a {
   text-transform: uppercase;
   text-decoration: none;

--- a/src/main/template/operation.handlebars
+++ b/src/main/template/operation.handlebars
@@ -7,7 +7,7 @@
           <a href='#!/{{parentId}}/{{nickname}}' class="toggleOperation">{{method}}</a>
           </span>
           <span class='path'>
-          <a href='#!/{{parentId}}/{{nickname}}' class="toggleOperation">{{path}}</a>
+          <a href='#!/{{parentId}}/{{nickname}}' class="toggleOperation {{#if deprecated}}deprecated{{/if}}">{{path}}</a>
           </span>
         </h3>
         <ul class='options'>
@@ -17,6 +17,9 @@
         </ul>
       </div>
       <div class='content' id='{{parentId}}_{{nickname}}_content' style='display:none'>
+        {{#if deprecated}}
+            <h4>Warning: Deprecated</h4>
+        {{/if}}
         {{#if description}}
         <h4>Implementation Notes</h4>
         <p>{{{description}}}</p>


### PR DESCRIPTION
This won't work until we get the latest (post-2.0.41) swagger.js.  It relies on swagger.js to provide 'deprecated' in the model.  It does no harm to include it now, though, and others can update swagger.js locally and get the deprecated indicator on operations.
