### PR TITLE
Fix issue with missing type parameter

### DIFF
--- a/dist/lib/swagger.js
+++ b/dist/lib/swagger.js
@@ -738,7 +738,7 @@
       }
       param.type = type;
 
-      if (type.toLowerCase() === 'boolean') {
+      if (type && type.toLowerCase() === 'boolean') {
         param.allowableValues = {};
         param.allowableValues.values = ["true", "false"];
       }


### PR DESCRIPTION
If the swagger definition is missing the type parameter it kills the UI.
