### PR TITLE
Add Support For Windows

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -3,6 +3,7 @@ path        = require 'path'
 {exec}      = require 'child_process'
 less        = require 'less'
 handlebars  = require 'handlebars'
+shelljs     = require 'shelljs'
 
 sourceFiles  = [
   'SwaggerUi'

--- a/Cakefile
+++ b/Cakefile
@@ -19,10 +19,12 @@ sourceFiles  = [
   'view/ParameterContentTypeView'
 ]
 
+NODE_MODULES = path.join __dirname, 'node_modules/'
+NODE_BIN_DIR = "#{NODE_MODULES}.bin/"
 
 task 'clean', 'Removes distribution', ->
   console.log 'Clearing dist...'
-  exec 'rm -rf dist'
+  shelljs.rm('-rf', 'dist')
 
 task 'dist', 'Build a distribution', ->
   console.log "Build distribution in ./dist"
@@ -62,23 +64,25 @@ task 'dist', 'Build a distribution', ->
     fs.writeFile 'dist/_swagger-ui.coffee', appContents.join('\n\n'), 'utf8', (err) ->
       throw err if err
       console.log '   : Compiling...'
-      exec 'coffee --compile dist/_swagger-ui.coffee', (err, stdout, stderr) ->
+      exec "#{NODE_BIN_DIR}coffee --compile dist/_swagger-ui.coffee", (err, stdout, stderr) ->
         throw err if err
         fs.unlink 'dist/_swagger-ui.coffee'
         console.log '   : Combining with javascript...'
 
         fs.readFile 'package.json', 'utf8', (err, fileContents) ->
           obj = JSON.parse(fileContents)
-          exec 'echo "// swagger-ui.js" > dist/swagger-ui.js'
-          exec 'echo "// version ' + obj.version + '" >> dist/swagger-ui.js'
-          exec 'cat src/main/javascript/doc.js dist/_swagger-ui-templates.js dist/_swagger-ui.js >> dist/swagger-ui.js', (err, stdout, stderr) ->
+          shelljs.echo('"// swagger-ui.js" > dist/swagger-ui.js')
+          shelljs.echo('"// version ' + obj.version + '" >> dist/swagger-ui.js')
+          shelljs.cat('src/main/javascript/doc.js').toEnd('dist/swagger-ui.js');
+          shelljs.cat('dist/_swagger-ui-templates.js').toEnd('dist/swagger-ui.js');
+          shelljs.cat('dist/_swagger-ui.js').toEnd('dist/swagger-ui.js');
+
+          fs.unlink 'dist/_swagger-ui.js'
+          fs.unlink 'dist/_swagger-ui-templates.js'
+          console.log '   : Minifying all...'
+          exec 'java -jar "./bin/yuicompressor-2.4.7.jar" --type js -o ' + 'dist/swagger-ui.min.js ' + 'dist/swagger-ui.js', (err, stdout, stderr) ->
             throw err if err
-            fs.unlink 'dist/_swagger-ui.js'
-            fs.unlink 'dist/_swagger-ui-templates.js'
-            console.log '   : Minifying all...'
-            exec 'java -jar "./bin/yuicompressor-2.4.7.jar" --type js -o ' + 'dist/swagger-ui.min.js ' + 'dist/swagger-ui.js', (err, stdout, stderr) ->
-              throw err if err
-              lessc()
+            lessc()
 
   lessc = ->
     # Someone who knows CoffeeScript should make this more Coffee-licious
@@ -92,11 +96,11 @@ task 'dist', 'Build a distribution', ->
 
   pack = ->
     console.log '   : Packaging...'
-    exec 'cp -r lib dist'
+    shelljs.cp('-r', 'lib', 'dist');
     console.log '   : Copied swagger-ui libs'
-    exec 'cp -r node_modules/swagger-client/lib/swagger.js dist/lib'
+    shelljs.cp('-r', 'node_modules/swagger-client/lib/swagger.js', 'dist/lib')
     console.log '   : Copied swagger dependencies'
-    exec 'cp -r src/main/html/* dist'
+    shelljs.cp('-r', 'src/main/html/*', 'dist')
     console.log '   : Copied html dependencies'
     console.log '   !'
 

--- a/Cakefile
+++ b/Cakefile
@@ -96,11 +96,11 @@ task 'dist', 'Build a distribution', ->
 
   pack = ->
     console.log '   : Packaging...'
-    shelljs.cp('-r', 'lib', 'dist');
+    shelljs.cp('-fr', 'lib', 'dist');
     console.log '   : Copied swagger-ui libs'
-    shelljs.cp('-r', 'node_modules/swagger-client/lib/swagger.js', 'dist/lib')
+    shelljs.cp('-fr', 'node_modules/swagger-client/lib/swagger.js', 'dist/lib')
     console.log '   : Copied swagger dependencies'
-    shelljs.cp('-r', 'src/main/html/*', 'dist')
+    shelljs.cp('-fr', 'src/main/html/*', 'dist')
     console.log '   : Copied html dependencies'
     console.log '   !'
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can rebuild swagger-ui on your own to tweak it or just so you can say you di
 1. install [handlebars](http://handlebarsjs.com/)
 2. install java
 3. npm install
-4. npm run-script build
+4. npm run-script build (or npm run-script build-win for Windows user)
 5. You should see the distribution under the dist folder. Open ./dist/index.html to launch Swagger UI in a browser
 
 ### Use

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "coffee-script": "~1.6.3",
     "swagger-client": "2.0.41",
     "handlebars": "~1.0.10",
-    "less": "~1.4.2"
+    "less": "~1.4.2",
+    "shelljs": "~0.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Swagger UI is a dependency-free collection of HTML, Javascript, and CSS assets that dynamically generate beautiful documentation from a Swagger-compliant API",
   "scripts": {
     "build": "PATH=$PATH:./node_modules/.bin cake dist",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build-win": ".\\node_modules\\.bin\\cake.cmd dist"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
As mentioned in #76. `dist` is not a Windows friendly as unix related operations such as `cat` will fail. In order to allow it to work, I use [shelljs](https://github.com/arturadib/shelljs).

Changes includes:
  - Add dependencies to shelljs
  - Replace unix operations with shelljs' methods
  - Add build option for Windows (`npm run-script build-win`)
  - Update README.md with instruction to build for Windows.