### PR TITLE
Do not create operations for non-HTTP methods/verbs

### DIFF
--- a/lib/swagger-client.js
+++ b/lib/swagger-client.js
@@ -95,7 +95,7 @@ SwaggerAuthorizations.prototype.apply = function(obj, authorizations) {
           if (result === true)
             status = true;
         }
-      }      
+      }
     }
   }
 
@@ -415,6 +415,9 @@ SwaggerClient.prototype.buildFromSpec = function(response) {
     if(typeof response.paths[path] === 'object') {
       var httpMethod;
       for(httpMethod in response.paths[path]) {
+        if(['delete', 'get', 'head', 'options', 'patch', 'post', 'put'].indexOf(httpMethod) === -1) {
+          continue;
+        }
         var operation = response.paths[path][httpMethod];
         var tags = operation.tags;
         if(typeof tags === 'undefined') {
@@ -991,7 +994,7 @@ Operation.prototype.encodeCollection = function(type, name, value) {
 }
 
 /**
- * TODO this encoding needs to be changed 
+ * TODO this encoding needs to be changed
  **/
 Operation.prototype.encodeQueryParam = function(arg) {
   return escape(arg);
@@ -1031,7 +1034,7 @@ var Model = function(name, definition) {
       if(requiredFields.indexOf(key) >= 0)
         required = true;
       this.properties.push(new Property(key, property, required));
-    }    
+    }
   }
 }
 
@@ -1210,7 +1213,7 @@ Property.prototype.toString = function() {
       str += ', <span class="propOptKey">optional</span>';
     str += ')';
   }
-  else 
+  else
     str = this.name + ' (' + JSON.stringify(this.obj) + ')';
 
   if(typeof this.description !== 'undefined')


### PR DESCRIPTION
For path properties that are not HTTP methods/verbs, do not process them as Swagger operations.

Fixes #678
