### PR TITLE
Correct developer contact link

### DIFF
--- a/src/main/template/main.handlebars
+++ b/src/main/template/main.handlebars
@@ -3,7 +3,7 @@
   <div class="info_title">{{info.title}}</div>
   <div class="info_description">{{{info.description}}}</div>
   {{#if info.termsOfServiceUrl}}<div class="info_tos"><a href="{{info.termsOfServiceUrl}}">Terms of service</a></div>{{/if}}
-  {{#if info.contact}}<div class='info_contact'><a href="mailto:{{info.contact.name}}">Contact the developer</a></div>{{/if}}
+  {{#if info.contact}}<div class='info_contact'><a href="mailto:{{info.contact.name}} <{{info.contact.email}}>?subject={{info.title}}">Contact the developer</a></div>{{/if}}
   {{#if info.license}}<div class='info_license'><a href='{{info.license.url}}'>{{info.license.name}}</a></div>{{/if}}
   {{/if}}
 </div>


### PR DESCRIPTION
Add contact email rather than only contact name.

I don't think spaces should be URL-encoded. If they should, I don't know which helper should be used.