### PR TITLE
Fixed contact and terms of service references in main.handlebars

### DIFF
--- a/src/main/template/main.handlebars
+++ b/src/main/template/main.handlebars
@@ -2,8 +2,8 @@
   {{#if info}}
   <div class="info_title">{{info.title}}</div>
   <div class="info_description">{{{info.description}}}</div>
-  {{#if info.termsOfServiceUrl}}<div class="info_tos"><a href="{{info.termsOfServiceUrl}}">Terms of service</a></div>{{/if}}
-  {{#if info.contact}}<div class='info_contact'><a href="mailto:{{info.contact.name}}">Contact the developer</a></div>{{/if}}
+  {{#if info.termsOfService}}<div class="info_tos"><a href="{{info.termsOfService}}">Terms of service</a></div>{{/if}}
+  {{#if info.contact}}<div class='info_contact'><a href="mailto:{{info.contact.email}}">Contact the developer</a></div>{{/if}}
   {{#if info.license}}<div class='info_license'><a href='{{info.license.url}}'>{{info.license.name}}</a></div>{{/if}}
   {{/if}}
 </div>


### PR DESCRIPTION
My model is passing a contact object and terms of service object conforming to the [2.0 spec](https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#infoObject) and looks similar to:

```json
info: {
  termsOfService: "http://mydomain.com/terms.html",
  contact: {
    name: "Product Development Team",
    url: "http://www.mydomain.com",
    email: "info@mydomain.com"
  }
},
```

However, in the swagger-ui, the 'Contact the Developer' link is "mailto:Product Development Team" and the terms of service link is not displayed. I found that the reference in main.handlebars was referencing the incorrect field names.

I based the pull request branch off of develop. If you would rather it be based off of master, please let me know. Also, I did not rebuild dist as part of this pull request. Again, please let me know if you want me to include that as well.