### PR TITLE
Fixed terms of service link

### DIFF
--- a/src/main/template/main.handlebars
+++ b/src/main/template/main.handlebars
@@ -2,7 +2,7 @@
   {{#if info}}
   <div class="info_title">{{info.title}}</div>
   <div class="info_description">{{{info.description}}}</div>
-  {{#if info.termsOfServiceUrl}}<div class="info_tos"><a href="{{info.termsOfServiceUrl}}">Terms of service</a></div>{{/if}}
+  {{#if info.termsOfService}}<div class="info_tos"><a href="{{info.termsOfService}}">Terms of service</a></div>{{/if}}
   {{#if info.contact}}<div class='info_contact'><a href="mailto:{{info.contact.name}}">Contact the developer</a></div>{{/if}}
   {{#if info.license}}<div class='info_license'><a href='{{info.license.url}}'>{{info.license.name}}</a></div>{{/if}}
   {{/if}}


### PR DESCRIPTION
This corrects the terms of service link to match the [2.0 spec](https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#infoObject)