### PR TITLE
Operation params are exposed via url for easier sharing

### DIFF
--- a/src/main/coffeescript/view/OperationView.coffee
+++ b/src/main/coffeescript/view/OperationView.coffee
@@ -173,6 +173,8 @@ class OperationView extends Backbone.View
       isFileUpload = false
 
       for o in form.find("input")
+        if o.type is "button"
+          continue
         if(o.value? && jQuery.trim(o.value).length > 0)
           map[o.name] = o.value
         if o.type is "file"
@@ -194,7 +196,15 @@ class OperationView extends Backbone.View
       if isFileUpload
         @handleFileUpload map, form
       else
+        @updateLocationHash(map)
         @model.do(map, opts, @showCompleteStatus, @showErrorStatus, @)
+
+  updateLocationHash: (map) ->
+    queryString = ""
+    if _.size(map) > 0
+      queryString = "?" + $.param(map)
+
+    location.hash = "#!/#{@model.parentId}/#{@model.nickname}#{queryString}"
 
   success: (response, parent) ->
     parent.showCompleteStatus response


### PR DESCRIPTION
Our API has quite a few parameters, so when pointing developers to our docs, I wanted to help them fill out some of the more interesting fields. While default values can accomplish the same goal to some extent, it's convenient to be able to share many different parameters for the same operation.

So for the pet store example, I might want to point a developer to a particularly interesting pet, or help them create a default pet in their account to start them off (though this feature only really makes sense on a more complex API).

Example: this will open the `pet/getPetById` operation and pre-fill the `petId` field with the value `4`
`http://localhost:3000/#!/pet/getPetById?petId=4`

Example: this will open the `pet/addPet` operation and pre-fill the `body` field with the value `{"id":4, "name":"Spike"}` so the developer only has to click the "Try it out!" button to create their first pet.
`http://localhost:3000/#!/pet/addPet?body=%7B%22id%22%3A4%2C+%22name%22%3A%22Spike%22%7D&parameterContentType=application%2Fjson`

Clicking "Try it out!" updates location.hash with the current params, which you can then copy & paste.

Caveat: it's just a concept, not tested exhaustively, and I'm by no means a Swagger expert.