### PR TITLE
Remove extra comma in module.exports object

### DIFF
--- a/dist/lib/shred.bundle.js
+++ b/dist/lib/shred.bundle.js
@@ -2207,7 +2207,7 @@ module.exports = {
     constructor.prototype.getHeaders = function() { return getHeaders(this,arguments); };
     constructor.prototype.setHeader = function(key,value) { return setHeader(this,key,value); };
     constructor.prototype.setHeaders = function(hash) { return setHeaders(this,hash); };
-  },
+  }
 };
 
 });

--- a/lib/shred.bundle.js
+++ b/lib/shred.bundle.js
@@ -2207,7 +2207,7 @@ module.exports = {
     constructor.prototype.getHeaders = function() { return getHeaders(this,arguments); };
     constructor.prototype.setHeader = function(key,value) { return setHeader(this,key,value); };
     constructor.prototype.setHeaders = function(hash) { return setHeaders(this,hash); };
-  },
+  }
 };
 
 });


### PR DESCRIPTION
This extra comma breaks swagger in IE