### PR TITLE
Fixed issue displaying array types #829

### DIFF
--- a/dist/lib/swagger-client.js
+++ b/dist/lib/swagger-client.js
@@ -2763,8 +2763,6 @@ var Property = function(name, obj, required) {
   else if (obj.type === 'array') {
     if(obj.items['$ref'])
       this['$ref'] = simpleRef(obj.items['$ref']);
-    else
-      obj = obj.items;
   }
   this.name = name;
   this.description = obj.description;
@@ -2790,6 +2788,10 @@ Property.prototype.sampleValue = function(isArray, ignoredModels) {
   isArray = (isArray || this.isArray());
   ignoredModels = (ignoredModels || {});
   var type = getStringSignature(this.obj);
+
+  if (isArray)
+    type = type.replace('Array[', '').replace(']', '');
+
   var output;
 
   if(this['$ref']) {
@@ -2830,8 +2832,9 @@ Property.prototype.sampleValue = function(isArray, ignoredModels) {
 };
 
 getStringSignature = function(obj) {
+  var isArray = obj.type === 'array';
   var str = '';
-  if(obj.type === 'array') {
+  if(isArray) {
     obj = (obj.items || obj['$ref'] || {});
     str += 'Array[';
   }
@@ -2857,7 +2860,7 @@ getStringSignature = function(obj) {
     str += simpleRef(obj['$ref']);
   else
     str += obj.type;
-  if(obj.type === 'array')
+  if(isArray)
     str += ']';
   return str;
 };

--- a/lib/swagger-client.js
+++ b/lib/swagger-client.js
@@ -2763,8 +2763,6 @@ var Property = function(name, obj, required) {
   else if (obj.type === 'array') {
     if(obj.items['$ref'])
       this['$ref'] = simpleRef(obj.items['$ref']);
-    else
-      obj = obj.items;
   }
   this.name = name;
   this.description = obj.description;
@@ -2790,6 +2788,10 @@ Property.prototype.sampleValue = function(isArray, ignoredModels) {
   isArray = (isArray || this.isArray());
   ignoredModels = (ignoredModels || {});
   var type = getStringSignature(this.obj);
+
+  if (isArray)
+    type = type.replace('Array[', '').replace(']', '');
+
   var output;
 
   if(this['$ref']) {
@@ -2830,8 +2832,9 @@ Property.prototype.sampleValue = function(isArray, ignoredModels) {
 };
 
 getStringSignature = function(obj) {
+  var isArray = obj.type === 'array';
   var str = '';
-  if(obj.type === 'array') {
+  if(isArray) {
     obj = (obj.items || obj['$ref'] || {});
     str += 'Array[';
   }
@@ -2857,7 +2860,7 @@ getStringSignature = function(obj) {
     str += simpleRef(obj['$ref']);
   else
     str += obj.type;
-  if(obj.type === 'array')
+  if(isArray)
     str += ']';
   return str;
 };


### PR DESCRIPTION
Repost: The data type displayed in the Model block currently only indicates an array when a $ref is used. These changes will fix the Model section to include the array wrapper around primitive data types (references were already working). This also fixes a bug where the data type is not displayed in the Model Schema block.