### PR TITLE
Take out `checkConsoleErrors` from inside title check

### DIFF
--- a/src/test/e2e/index.js
+++ b/src/test/e2e/index.js
@@ -61,13 +61,14 @@ describe('basics', function (done) {
 
         if (hasTitle) {
           expect(title).to.contain('Swagger UI');
-          checkConsoleErrors();
           done();
         }
         return hasTitle;
       });
     }, 1000);
   });
+
+  checkConsoleErrors();
 });
 
 describe('cleanup', function  () {

--- a/src/test/e2e/index.js
+++ b/src/test/e2e/index.js
@@ -40,6 +40,7 @@ function checkConsoleErrors () {
           errors.push(log);
         }
       });
+
       expect(errors).to.be.empty;
 
       done();
@@ -55,17 +56,11 @@ describe('basics', function (done) {
   });
 
   it('should have "Swagger UI" in title', function (done) {
-    driver.wait(function() {
-      return driver.getTitle().then(function(title) {
-        var hasTitle = title.indexOf('Swagger UI') > -1;
-
-        if (hasTitle) {
-          expect(title).to.contain('Swagger UI');
-          done();
-        }
-        return hasTitle;
-      });
-    }, 1000);
+    driver.sleep(200);
+    driver.getTitle().then(function(title) {
+      expect(title).to.contain('Swagger UI');
+      done();
+    });
   });
 
   checkConsoleErrors();


### PR DESCRIPTION
`it` inside another `it` will not get executed.