### PR TITLE
path regex matcher allows quantifiers in pattern

### DIFF
--- a/lib/swagger-client.js
+++ b/lib/swagger-client.js
@@ -2341,7 +2341,7 @@ SwaggerOperation.prototype.urlify = function (args) {
     if (param.paramType === 'path') {
       if (typeof args[param.name] !== 'undefined') {
         // apply path params and remove from args
-        var reg = new RegExp('\\{\\s*?' + param.name + '.*?\\}(?=\\s*?(\\/?|$))', 'gi');
+        var reg = new RegExp('\\{\\s*?' + param.name + '[^\\{\\}\\/]*(?:[^\\{\\}\\/]*\\{.*?\\})*.*?\\}(?=(\\/?|$))', 'gi');
         url = url.replace(reg, this.encodePathParam(args[param.name]));
         delete args[param.name];
       }


### PR DESCRIPTION
This fixes an issue that we've had for a while: #562.

Flexible support for multiple quantifiers in various positions.
e.g. `@Path( "/{first : (?i)[\\w\\d]{2}[\\w\\d]{2}}5/{second : (?i)[\\w\\d]{4}}" )`