### PR TITLE
Fix OAuth2 login when no scope is defined

### DIFF
--- a/lib/swagger-oauth.js
+++ b/lib/swagger-oauth.js
@@ -15,8 +15,8 @@ function handleLogin() {
     var defs = auths;
     for(key in defs) {
       var auth = defs[key];
+      oauth2KeyName = key;
       if(auth.type === 'oauth2' && auth.scopes) {
-        oauth2KeyName = key;
         var scope;
         if(Array.isArray(auth.scopes)) {
           // 1.2 support


### PR DESCRIPTION
When no scope is defined OAuth2 key name is not registered. This patch fixes the problem moving the assignment before scopes handling.