### PR TITLE
Use text are for paramType 'form' parameters

### DIFF
--- a/src/main/coffeescript/view/ParameterView.coffee
+++ b/src/main/coffeescript/view/ParameterView.coffee
@@ -6,7 +6,7 @@ class ParameterView extends Backbone.View
           opts.fn(@)
         else
           opts.inverse(@)
-          
+
   render: ->
     type = @model.type || @model.dataType
 
@@ -21,7 +21,7 @@ class ParameterView extends Backbone.View
 
     @model.type = type
     @model.paramType = @model.in || @model.paramType
-    @model.isBody = true if @model.paramType == 'body' or @model.in == 'body'
+    @model.isBody = true if @model.paramType == 'body' or @model.in == 'body' or @model.paramType == 'form' or @model.in == 'formData'
     @model.isFile = true if type and type.toLowerCase() == 'file'
     @model.default = (@model.default || @model.defaultValue)
 


### PR DESCRIPTION
When using multipart/form-data (ie paramType 'form'), generally one of the parameters will be file, but other parameters have potential to be similar to a body parameter. In my case, I have 2 parameters, one is a file upload, the other is a json structure. When this is the case, currently I get a `<input type="text" />` which is not friendly for a json parameter (and the click to populate with schema doesn't work on an `<input>` field).

I had also thought about only making it a <textarea> if the type is not 'string' or 'integer'. So for those cases, it will still render a text input field. Thoughts on that?