### PR TITLE
Don't discard false as a json schema example value for a boolean propert...

### DIFF
--- a/lib/swagger-client.js
+++ b/lib/swagger-client.js
@@ -1288,7 +1288,7 @@ var Property = function(name, obj, required) {
   this.optional = true;
   this.optional = !required;
   this.default = obj.default || null;
-  this.example = obj.example || null;
+  this.example = obj.example !== undefined ? obj.example : null;
   this.collectionFormat = obj.collectionFormat || null;
   this.maximum = obj.maximum || null;
   this.exclusiveMaximum = obj.exclusiveMaximum || null;
@@ -1333,7 +1333,7 @@ Property.prototype.sampleValue = function(isArray, ignoredModels) {
       output = refModelName;
     }
   }
-  else if(this.example)
+  else if(this.example !== undefined)
     output = this.example;
   else if(this.default)
     output = this.default;


### PR DESCRIPTION
Don't discard false as a json schema example value for a boolean property.