### PR TITLE
Oauth 2.0: use space as delimiter for scopes.

### DIFF
--- a/lib/swagger-oauth.js
+++ b/lib/swagger-oauth.js
@@ -147,7 +147,7 @@ function handleLogin() {
     url += '&redirect_uri=' + encodeURIComponent(redirectUrl);
     url += '&realm=' + encodeURIComponent(realm);
     url += '&client_id=' + encodeURIComponent(clientId);
-    url += '&scope=' + encodeURIComponent(scopes);
+    url += '&scope=' + encodeURIComponent(scopes.join(' '));
 
     window.open(url);
   });


### PR DESCRIPTION
From [RFC6749 section-3.3](http://tools.ietf.org/html/rfc6749#section-3.3):
The value of the scope parameter is expressed as a list of **space-delimited**, case-sensitive strings.
Current code use comma as delimiter:
> encodeURIComponent(["foo", "bar"])
'foo%2Cbar'
> decodeURIComponent(encodeURIComponent(["foo", "bar"]))
'foo,bar'