### PR TITLE
encodeURIComponent on api_key

### DIFF
--- a/src/main/html/index.html
+++ b/src/main/html/index.html
@@ -56,7 +56,7 @@
       });
 
       function addApiKeyAuthorization() {
-        var key = $('#input_apiKey')[0].value;
+        var key = encodeURIComponent($('#input_apiKey')[0].value);
         log("key: " + key);
         if(key && key.trim() != "") {
             log("added key " + key);


### PR DESCRIPTION
The token value is not encoded when added to the get parameter. Special characters like "+" must be encoded when passed in the URL.