### PR TITLE
Encode slashes in path parameters

### DIFF
--- a/dist/lib/swagger-client.js
+++ b/dist/lib/swagger-client.js
@@ -1464,18 +1464,7 @@ Operation.prototype.encodeQueryParam = function(arg) {
  * TODO revisit, might not want to leave '/'
  **/
 Operation.prototype.encodePathParam = function(pathParam) {
-  var encParts, part, parts, i, len;
-  pathParam = pathParam.toString();
-  if (pathParam.indexOf('/') === -1) {
-    return encodeURIComponent(pathParam);
-  } else {
-    parts = pathParam.split('/');
-    encParts = [];
-    for (i = 0, len = parts.length; i < len; i++) {
-      encParts.push(encodeURIComponent(parts[i]));
-    }
-    return encParts.join('/');
-  }
+  return encodeURIComponent(pathParam.toString());
 };
 
 var Model = function(name, definition) {

--- a/lib/swagger-client.js
+++ b/lib/swagger-client.js
@@ -1464,18 +1464,7 @@ Operation.prototype.encodeQueryParam = function(arg) {
  * TODO revisit, might not want to leave '/'
  **/
 Operation.prototype.encodePathParam = function(pathParam) {
-  var encParts, part, parts, i, len;
-  pathParam = pathParam.toString();
-  if (pathParam.indexOf('/') === -1) {
-    return encodeURIComponent(pathParam);
-  } else {
-    parts = pathParam.split('/');
-    encParts = [];
-    for (i = 0, len = parts.length; i < len; i++) {
-      encParts.push(encodeURIComponent(parts[i]));
-    }
-    return encParts.join('/');
-  }
+  return encodeURIComponent(pathParam.toString());
 };
 
 var Model = function(name, definition) {


### PR DESCRIPTION
Slashes in path parameters should be encoded in order to produce valid URLs.

Fixes: #1013