### PR TITLE
OperationView.js: fix rendering of Markdown (GFM) in description fields.

### DIFF
--- a/src/main/javascript/view/OperationView.js
+++ b/src/main/javascript/view/OperationView.js
@@ -69,9 +69,6 @@ SwaggerUi.Views.OperationView = Backbone.View.extend({
       this.model.isReadOnly = true;
     }
     this.model.description = this.model.description || this.model.notes;
-    if (this.model.description) {
-      this.model.description = this.model.description.replace(/(?:\r\n|\r|\n)/g, '<br />');
-    }
     this.model.oauth = null;
     modelAuths = this.model.authorizations || this.model.security;
     if (modelAuths) {

--- a/src/main/template/operation.handlebars
+++ b/src/main/template/operation.handlebars
@@ -22,7 +22,7 @@
         {{/if}}
         {{#if description}}
         <h4>Implementation Notes</h4>
-        <p class="markdown">{{{description}}}</p>
+        <div class="markdown">{{{description}}}</div>
         {{/if}}
         {{#oauth}}
         <div class="auth">


### PR DESCRIPTION
This removes substitution of \r\n, \r, \n to `<br>`, since the subsequent set of
renderGFM() gets confused by them. Furthermore, the marked module already does a
decent job of substituting \n with proper HTML (`<p>`, if I'm not mistaken).

Fixes issue #1049.