### PR TITLE
Pass swagger options to swagger-js Operation#execute method

### DIFF
--- a/src/main/javascript/view/OperationView.js
+++ b/src/main/javascript/view/OperationView.js
@@ -313,7 +313,7 @@ SwaggerUi.Views.OperationView = Backbone.View.extend({
       if (isFileUpload) {
         return this.handleFileUpload(map, form);
       } else {
-        return this.model['do'](map, opts, this.showCompleteStatus, this.showErrorStatus, this);
+        return this.model.execute(map, this.options.swaggerOptions, this.showCompleteStatus, this.showErrorStatus);
       }
     }
   },

--- a/src/main/javascript/view/OperationView.js
+++ b/src/main/javascript/view/OperationView.js
@@ -313,7 +313,7 @@ SwaggerUi.Views.OperationView = Backbone.View.extend({
       if (isFileUpload) {
         return this.handleFileUpload(map, form);
       } else {
-        return this.model.execute(map, this.options.swaggerOptions, this.showCompleteStatus, this.showErrorStatus);
+        return this.model.execute(map, this.options.swaggerOptions || {}, this.showCompleteStatus, this.showErrorStatus, this);
       }
     }
   },


### PR DESCRIPTION
As in subject, ```Operation#execute``` from swagger-js expects ```swaggerOptions``` by the look of this code: https://github.com/swagger-api/swagger-js/blob/develop_2.0/lib/types/operation.js#L542-L544 and swagger-js tests.