### PR TITLE
Multiple values for array type parameters as separated lines in the textarea

### DIFF
--- a/src/main/javascript/helpers/handlebars.js
+++ b/src/main/javascript/helpers/handlebars.js
@@ -5,3 +5,24 @@ Handlebars.registerHelper('sanitize', function(html) {
     html = html.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '');
     return new Handlebars.SafeString(html);
 });
+
+Handlebars.registerHelper('renderTextParam', function(param) {
+    var result;
+    var isArray = param.type.toLowerCase() === 'array' || param.allowMultiple;
+    var defaultValue = isArray && Array.isArray(param.default) ? param.default.join('\n') : param.default;
+
+    if (typeof defaultValue === 'undefined') {
+        defaultValue = '';
+    }
+
+    if(isArray) {
+        result = "<textarea class='body-textarea" + (param.required ? " required" : "") + "' name='" + param.name + "'"
+            + " placeholder='Provide multiple values in new lines" + (param.required ? " (at least one required)." : ".") + "'>"
+            + defaultValue + "</textarea>";
+    } else {
+        result = "<input class='parameter'" + (param.required ? " class='required'" : "") + " minlength='" + (param.required ? 1 : 0)
+            + "' name='" + param.name +"' placeholder='" + (param.required ? "(required)" : "") + "'"
+            + " type='text' value='" + defaultValue + "'/>";
+    }
+    return new Handlebars.SafeString(result);
+});

--- a/src/main/javascript/helpers/handlebars.js
+++ b/src/main/javascript/helpers/handlebars.js
@@ -16,13 +16,13 @@ Handlebars.registerHelper('renderTextParam', function(param) {
     }
 
     if(isArray) {
-        result = "<textarea class='body-textarea" + (param.required ? " required" : "") + "' name='" + param.name + "'"
-            + " placeholder='Provide multiple values in new lines" + (param.required ? " (at least one required)." : ".") + "'>"
-            + defaultValue + "</textarea>";
+        result = '<textarea class=\'body-textarea' + (param.required ? ' required' : '') + '\' name=\'' + param.name + '\'';
+        result += ' placeholder=\'Provide multiple values in new lines' + (param.required ? ' (at least one required).' : '.') + '\'>';
+        result += defaultValue + '</textarea>';
     } else {
-        result = "<input class='parameter'" + (param.required ? " class='required'" : "") + " minlength='" + (param.required ? 1 : 0)
-            + "' name='" + param.name +"' placeholder='" + (param.required ? "(required)" : "") + "'"
-            + " type='text' value='" + defaultValue + "'/>";
+        result = '<input class=\'parameter\'' + (param.required ? ' class=\'required\'' : '') + ' minlength=\'' + (param.required ? 1 : 0) + '\'';
+        result += ' name=\'' + param.name +'\' placeholder=\'' + (param.required ? '(required)' : '') + '\'';
+        result += ' type=\'text\' value=\'' + defaultValue + '\'/>';
     }
     return new Handlebars.SafeString(result);
 });

--- a/src/main/javascript/view/OperationView.js
+++ b/src/main/javascript/view/OperationView.js
@@ -275,6 +275,20 @@ SwaggerUi.Views.OperationView = Backbone.View.extend({
         error_free = false;
       }
     });
+    form.find('select.required').each(function() {
+      $(this).removeClass('error');
+      if (this.selectedIndex === -1) {
+        $(this).addClass('error');
+        $(this).wiggle({
+          callback: (function(_this) {
+            return function() {
+              $(_this).focus();
+            };
+          })(this)
+        });
+        error_free = false;
+      }
+    });
     if (error_free) {
       map = {};
       opts = {
@@ -295,8 +309,9 @@ SwaggerUi.Views.OperationView = Backbone.View.extend({
       ref2 = form.find('textarea');
       for (m = 0, len1 = ref2.length; m < len1; m++) {
         o = ref2[m];
-        if ((o.value !== null) && jQuery.trim(o.value).length > 0) {
-          map[o.name] = o.value;
+        val = this.getTextAreaValue(o);
+        if ((val !== null) && jQuery.trim(val).length > 0) {
+          map[o.name] = val;
         }
       }
       ref3 = form.find('select');
@@ -661,5 +676,38 @@ SwaggerUi.Views.OperationView = Backbone.View.extend({
     } else {
       Docs.expandOperation(elem);
     }
+  },
+
+  getTextAreaValue: function(textArea) {
+    var param, parsed, result, i;
+    if (textArea.value === null || jQuery.trim(textArea.value).length === 0) {
+      return null;
+    }
+    param = this.getParamByName(textArea.name);
+    if (param && param.type && param.type.toLowerCase() === 'array') {
+      parsed = textArea.value.split('\n');
+      result = [];
+      for (i = 0; i < parsed.length; i++) {
+        if (parsed[i] !== null && jQuery.trim(parsed[i]).length > 0) {
+          result.push(parsed[i]);
+        }
+      }
+      return result.length > 0 ? result : null;
+    } else {
+      return textArea.value;
+    }
+  },
+
+  getParamByName: function(name) {
+    var i;
+    if (this.model.parameters) {
+      for(i = 0; i < this.model.parameters.length; i++) {
+        if (this.model.parameters[i].name === name) {
+          return this.model.parameters[i];
+        }
+      }
+    }
+    return null;
   }
+
 });

--- a/src/main/javascript/view/ParameterView.js
+++ b/src/main/javascript/view/ParameterView.js
@@ -4,9 +4,9 @@ SwaggerUi.Views.ParameterView = Backbone.View.extend({
   initialize: function(){
     Handlebars.registerHelper('isArray', function(param, opts) {
       if (param.type.toLowerCase() === 'array' || param.allowMultiple) {
-        opts.fn(this);
+        return opts.fn(this);
       } else {
-        opts.inverse(this);
+        return opts.inverse(this);
       }
     });
   },

--- a/src/main/template/param.handlebars
+++ b/src/main/template/param.handlebars
@@ -21,11 +21,8 @@
 			<input type="file" name='{{name}}'/>
 			<div class="parameter-content-type" />
 		{{else}}
-			{{#if default}}
-				<input class='parameter' minlength='0' name='{{name}}' placeholder='' type='text' value='{{default}}'/>
-			{{else}}
-				<input class='parameter' minlength='0' name='{{name}}' placeholder='' type='text' value=''/>
-			{{/if}}
+			{{#renderTextParam this}}
+			{{/renderTextParam}}
 		{{/if}}
 	{{/if}}
 

--- a/src/main/template/param_list.handlebars
+++ b/src/main/template/param_list.handlebars
@@ -1,9 +1,10 @@
 {{#if required}}
 <td class='code required'>{{name}}</td>
-{{/if}}
+{{else}}
 <td class='code'>{{name}}</td>
+{{/if}}
 <td>
-  <select {{#isArray this}} multiple='multiple'{{/isArray}} class='parameter' name='{{name}}'>
+  <select {{#isArray this}} multiple='multiple'{{/isArray}} class={{#if required}}'parameter required'{{else}}'parameter'{{/if}} name='{{name}}'>
     {{#if required}}
     {{else}}
       {{#if default}}

--- a/src/main/template/param_required.handlebars
+++ b/src/main/template/param_required.handlebars
@@ -18,11 +18,8 @@
 		{{#if isFile}}
 			<input class='parameter' class='required' type='file' name='{{name}}'/>
 		{{else}}
-			{{#if default}}
-				<input class='parameter required' minlength='1' name='{{name}}' placeholder='(required)' type='text' value='{{default}}'/>
-			{{else}}
-				<input class='parameter required' minlength='1' name='{{name}}' placeholder='(required)' type='text' value=''/>
-			{{/if}}
+			{{#renderTextParam this}}
+			{{/renderTextParam}}
 		{{/if}}
 	{{/if}}
 </td>


### PR DESCRIPTION
Hi,

This addresses eg. the #982 and #987 and likely some others around the subject.
Except of the multi-line text area for the array type params, I've also got a rid of the 'required' and 'default' attributes of the array type parameters.

Please check the use cases here: https://swagger-test-valdemon.c9.io
The above sample UC additionally cover aspects of required parameters and/or default values in a context of the array type.

The validation error (shown in Swagger UI bottom right) is related to declaring the default value as array for the array type parameter, which doesn't sound like wrong I'd say, according to: http://json-schema.org/latest/json-schema-validation.html#anchor101.
Checking the sample 'swagger.json' against any JSON schema validator succeeds btw.

@webron: this is the #1121 duplicate, now created against the develop_2.0 branch.
The #1121 branch was created from develop_2.0 branch, I've only missed, that the master branch is proposed as default when creating any PR. Sorry for the inconvenience.

Best,
Waldek