### PR TITLE
Update default validator with correct protocol

### DIFF
--- a/src/main/javascript/view/MainView.js
+++ b/src/main/javascript/view/MainView.js
@@ -68,7 +68,7 @@ SwaggerUi.Views.MainView = Backbone.View.extend({
       } else {
 
         // Default validator
-        this.model.validatorUrl = 'http://online.swagger.io/validator';
+        this.model.validatorUrl = window.location.protocol + '//online.swagger.io/validator';
       }
     }
   },


### PR DESCRIPTION
Current code defaults to http protocol, but when package is installed in a https environment, the default validator should be securely available.