### PR TITLE
Fix - Swagger/Swashbuckle OAuth2 Authorizations not set #1134

### DIFF
--- a/lib/swagger-oauth.js
+++ b/lib/swagger-oauth.js
@@ -277,7 +277,7 @@ window.onOAuthComplete = function onOAuthComplete(token) {
             }
           }
         });
-        window.authorizations.add(oauth2KeyName, new ApiKeyAuthorization('Authorization', 'Bearer ' + b, 'header'));
+        window.swaggerUi.api.clientAuthorizations.add(oauth2KeyName, new SwaggerClient.ApiKeyAuthorization('Authorization', 'Bearer ' + b, 'header'));
       }
     }
   }


### PR DESCRIPTION
Correcting: https://github.com/swagger-api/swagger-ui/issues/1134 