### PR TITLE
Call to swaggerUi.load before possible use.

### DIFF
--- a/src/main/html/index.html
+++ b/src/main/html/index.html
@@ -64,6 +64,8 @@
       }
 
       $('#input_apiKey').change(addApiKeyAuthorization);
+      
+      window.swaggerUi.load();
 
       // if you have an apiKey you would like to pre-populate on the page for demonstration purposes...
       /*
@@ -71,8 +73,6 @@
         $('#input_apiKey').val(apiKey);
         addApiKeyAuthorization();
       */
-
-      window.swaggerUi.load();
 
       function log() {
         if ('console' in window) {


### PR DESCRIPTION
Using addApiKeyAuthorization function, needs to be done after swaggerUi is loaded, otherwise calling ``window.swaggerUi.api.clientAuthorizations.add`` will fail,  and the authorization headers will not be aded.