### PR TITLE
Call to swaggerUi.load before possible use.

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -63,6 +63,8 @@
         }
       }
 
+      window.swaggerUi.load();
+      
       $('#input_apiKey').change(addApiKeyAuthorization);
 
       // if you have an apiKey you would like to pre-populate on the page for demonstration purposes...
@@ -71,8 +73,6 @@
         $('#input_apiKey').val(apiKey);
         addApiKeyAuthorization();
       */
-
-      window.swaggerUi.load();
 
       function log() {
         if ('console' in window) {


### PR DESCRIPTION
Using addApiKeyAuthorization function, needs to be done after swaggerUi is loaded, otherwise calling ``window.swaggerUi.api.clientAuthorizations.add`` will fail, and the authorization headers will not be aded.