### PR TITLE
Prevent the OperationView to display an error in case the response contains a whitespace only body with content type application/json

### DIFF
--- a/src/main/javascript/view/OperationView.js
+++ b/src/main/javascript/view/OperationView.js
@@ -549,6 +549,7 @@ SwaggerUi.Views.OperationView = Backbone.View.extend({
       url = response.request.url;
     }
     var headers = response.headers;
+    content = content.trim();
 
     // if server is nice, and sends content-type back, we can use it
     var contentType = null;

--- a/src/main/javascript/view/OperationView.js
+++ b/src/main/javascript/view/OperationView.js
@@ -549,7 +549,7 @@ SwaggerUi.Views.OperationView = Backbone.View.extend({
       url = response.request.url;
     }
     var headers = response.headers;
-    content = content.trim();
+    content = jQuery.trim(content);
 
     // if server is nice, and sends content-type back, we can use it
     var contentType = null;


### PR DESCRIPTION
Hi there,

we're currently investigating using swagger as the primary means to document our APIs at XING. We really like swagger so far and see a lot of potential in it for us. You guys do an awesome job.

During our tests with swagger we bumped into little things here and there. I just wanted to contribute a little bit back :-)

Our APIs are mostly Rails based and Rails seems to return responses body containing whitespace on 201s, which results in a parser error. I've already send a pull request for swagger-js to make it more robust against that (https://github.com/swagger-api/swagger-js/pull/370)

This little change prevents another UI glitch caused by trying to parse whitespace as json.

Like I said in the other PR, sorry for not including tests. I'm not a javascript crack and failed to write some. I hope that's alright ^^