### PR TITLE
Use console.log() instead of log()

### DIFF
--- a/dist/lib/swagger-oauth.js
+++ b/dist/lib/swagger-oauth.js
@@ -187,7 +187,7 @@ function initOAuth(opts) {
   realm = (o.realm||errors.push('missing realm'));
 
   if(errors.length > 0){
-    log('auth unable initialize oauth: ' + errors);
+    console.log('auth unable initialize oauth: ' + errors);
     return;
   }
 

--- a/lib/swagger-oauth.js
+++ b/lib/swagger-oauth.js
@@ -187,7 +187,7 @@ function initOAuth(opts) {
   realm = (o.realm||errors.push('missing realm'));
 
   if(errors.length > 0){
-    log('auth unable initialize oauth: ' + errors);
+    console.log('auth unable initialize oauth: ' + errors);
     return;
   }
 


### PR DESCRIPTION
log() fails in latest Chrome.