### PR TITLE
Forcing old images to not be CRLF conformed due to new gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,5 @@ dist/**/*.woff binary
 dist/**/*.woff2 binary
 dist/**/*.png binary
 dist/*.html text
+
+src/main/html/images/*.png binary


### PR DESCRIPTION
This was breaking an automated build process in drupal via drush: No longer able to automatically change branches because the LF was inserted in place of CRLF in binary files? Screenshot is from my fork, but it was without modification (until this PR). Our project is temporarily building from my fork until we find a better resolution.

mac osx git version 2.3.2 (Apple Git-55) (same issue on centos box however)

![screen shot 2015-04-17 at 2 12 48 pm](https://cloud.githubusercontent.com/assets/1635293/7212150/d850b386-e517-11e4-8966-aa204cdff47e.png)
