### PR TITLE
Duplicate 'name' when a parameter is 'enum' type and required.

### DIFF
--- a/src/main/template/param_list.handlebars
+++ b/src/main/template/param_list.handlebars
@@ -1,7 +1,8 @@
 {{#if required}}
 <td class='code required'>{{name}}</td>
-{{/if}}
+{{else}}
 <td class='code'>{{name}}</td>
+{{/if}}
 <td>
   <select {{#isArray this}} multiple='multiple'{{/isArray}} class='parameter' name='{{name}}'>
     {{#if required}}


### PR DESCRIPTION
Duplicate 'name' when a parameter is 'enum' type and required.
![untitled](https://cloud.githubusercontent.com/assets/9012/7232591/7568e322-e7b7-11e4-95c8-bbd7c7cebda0.png)
