### PR TITLE
add --client command line arg to gulpfile

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,6 +15,7 @@ var connect = require('gulp-connect');
 var header = require('gulp-header');
 var pkg = require('./package.json');
 var order = require('gulp-order');
+var argv = require('yargs').argv;
 var banner = ['/**',
   ' * <%= pkg.name %> - <%= pkg.description %>',
   ' * @version v<%= pkg.version %>',
@@ -53,11 +54,12 @@ function templates() {
  */
 gulp.task('dist', ['clean'], function() {
 
+  // Get local client or one specified on the command line
+  var swaggerClient = argv.client ? argv.client : './node_modules/swagger-client/browser/swagger-client.js';
+  log('swagger-client: ' + swaggerClient);
   return es.merge(
-      gulp.src([
-        './src/main/javascript/**/*.js',
-        './node_modules/swagger-client/browser/swagger-client.js'
-      ]),
+      gulp.src('./src/main/javascript/**/*.js'),
+      gulp.src(swaggerClient),
       templates()
     )
     .pipe(order(['scripts.js', 'templates.js']))

--- a/package.json
+++ b/package.json
@@ -1,10 +1,12 @@
 {
   "name": "swagger-ui",
   "author": "Tony Tam <fehguy@gmail.com>",
-  "contributors": [{
-    "name": "Mohsen Azimi",
-    "email": "me@azimi.me"
-  }],
+  "contributors": [
+    {
+      "name": "Mohsen Azimi",
+      "email": "me@azimi.me"
+    }
+  ],
   "description": "Swagger UI is a dependency-free collection of HTML, JavaScript, and CSS assets that dynamically generate beautiful documentation from a Swagger-compliant API",
   "version": "2.1.2-M2",
   "homepage": "http://swagger.io",
@@ -45,6 +47,7 @@
     "less": "^2.4.0",
     "mocha": "^2.1.0",
     "selenium-webdriver": "^2.45.0",
-    "swagger-client": "2.1.2-M2"
+    "swagger-client": "2.1.2-M2",
+    "yargs": "^3.8.0"
   }
 }


### PR DESCRIPTION
Small change to gulpfile to allow for --client command line argument.
``` bash
# Usage:
gulp --client='../some/swagger-client.js'
# default still works as expected...
gulp
```
> defaults to the node_module's swagger-client