### PR TITLE
add jshint to gulp..lint and dist

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,6 +15,7 @@ var connect = require('gulp-connect');
 var header = require('gulp-header');
 var pkg = require('./package.json');
 var order = require('gulp-order');
+var jshint = require('gulp-jshint');
 var banner = ['/**',
   ' * <%= pkg.name %> - <%= pkg.description %>',
   ' * @version v<%= pkg.version %>',
@@ -49,9 +50,18 @@ function templates() {
 }
 
 /**
+ * JShint all *.js files
+ */
+gulp.task('lint', function () {
+  return gulp.src('./src/main/javascript/**/*.js')
+    .pipe(jshint())
+    .pipe(jshint.reporter('jshint-stylish'));
+});
+
+/**
  * Build a distribution
  */
-gulp.task('dist', ['clean'], function() {
+gulp.task('dist', ['clean','lint'], function() {
 
   return es.merge(
       gulp.src([

--- a/package.json
+++ b/package.json
@@ -1,10 +1,12 @@
 {
   "name": "swagger-ui",
   "author": "Tony Tam <fehguy@gmail.com>",
-  "contributors": [{
-    "name": "Mohsen Azimi",
-    "email": "me@azimi.me"
-  }],
+  "contributors": [
+    {
+      "name": "Mohsen Azimi",
+      "email": "me@azimi.me"
+    }
+  ],
   "description": "Swagger UI is a dependency-free collection of HTML, JavaScript, and CSS assets that dynamically generate beautiful documentation from a Swagger-compliant API",
   "version": "2.1.2-M2",
   "homepage": "http://swagger.io",
@@ -35,6 +37,7 @@
     "gulp-declare": "^0.3.0",
     "gulp-handlebars": "^3.0.1",
     "gulp-header": "^1.2.2",
+    "gulp-jshint": "^1.10.0",
     "gulp-less": "^3.0.1",
     "gulp-order": "^1.1.1",
     "gulp-rename": "^1.2.0",
@@ -42,6 +45,7 @@
     "gulp-watch": "^4.1.1",
     "gulp-wrap": "^0.11.0",
     "http-server": "git+https://github.com/nodeapps/http-server.git",
+    "jshint-stylish": "^1.0.1",
     "less": "^2.4.0",
     "mocha": "^2.1.0",
     "selenium-webdriver": "^2.45.0",


### PR DESCRIPTION
fixes #1221 
Not much too it, there is already a .jshintignore file. I thought of adding a .jshinrc but the weight of those pedantic details got to me.

At least no more missing semi-colons breaking the travis build :D

PS: using same styler as swagger-js