### PR TITLE
allow default to be false, tweak "required" in param_list

### DIFF
--- a/src/main/javascript/view/ParameterView.js
+++ b/src/main/javascript/view/ParameterView.js
@@ -30,7 +30,13 @@ SwaggerUi.Views.ParameterView = Backbone.View.extend({
     this.model.paramType = this.model.in || this.model.paramType;
     this.model.isBody = this.model.paramType === 'body' || this.model.in === 'body';
     this.model.isFile = type && type.toLowerCase() === 'file';
-    this.model.default = (this.model.default || this.model.defaultValue);
+
+    // Allow for default === false
+    if(typeof this.model.default === 'undefined') {
+      this.model.default = this.model.defaultValue;
+    }
+
+    this.model.hasDefault = (typeof this.model.default !== 'undefined');
     this.model.valueId = 'm' + this.model.name + Math.random();
 
     if (this.model.allowableValues) {

--- a/src/main/template/param_list.handlebars
+++ b/src/main/template/param_list.handlebars
@@ -1,23 +1,17 @@
 <td class='code{{#if required}} required{{/if}}'><label for='{{valueId}}'>{{name}}</labe></td>
 <td>
-  <select {{#isArray this}} multiple='multiple'{{/isArray}} class={{#if required}}'parameter required'{{else}}'parameter'{{/if}} name='{{name}}' id='{{valueId}}'>
-    {{#if required}}
-    {{else}}
-      {{#if default}}
-      {{else}}
-        {{#isArray this}}
-        {{else}}
-          <option selected="" value=''></option>
-        {{/isArray}}
-      {{/if}}
-    {{/if}}
+  <select {{#isArray this}} multiple="multiple"{{/isArray}} class="parameter {{#if required}} required {{/if}}" name="{{name}}" id="{{valueId}}">
+
+    {{#unless required}}
+      <option {{#unless hasDefault}}  selected="" {{/unless}} value=''></option>
+    {{/unless}}
+
     {{#each allowableValues.descriptiveValues}}
-      {{#if isDefault}}
-        <option selected="" value='{{value}}'>{{value}} (default)</option>
-      {{else}}
-        <option value='{{value}}'>{{value}}</option>
-      {{/if}}
+
+      <option {{#if isDefault}} selected=""  {{/if}}  value='{{value}}'> {{value}} {{#if isDefault}} (default) {{/if}} </option>
+
     {{/each}}
+
   </select>
 </td>
 <td class="markdown">{{#if required}}<strong>{{/if}}{{{description}}}{{#if required}}</strong>{{/if}}</td>


### PR DESCRIPTION
Linked to https://github.com/swagger-api/swagger-ui/issues/1191#issuecomment-97450141
And code from https://github.com/swagger-api/swagger-js/pull/397

Allow for this.model.default (param.default) to be false
If not param.required, then add empty <option/> to list in para_list. Redo the logic there.