### PR TITLE
Use the correct new sorting parameter name

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -52,7 +52,7 @@
           log("Unable to Load SwaggerUI");
         },
         docExpansion: "none",
-        sorter : "alpha"
+        apisSorter: "alpha"
       });
 
       function addApiKeyAuthorization(){

--- a/src/main/html/index.html
+++ b/src/main/html/index.html
@@ -52,7 +52,7 @@
           log("Unable to Load SwaggerUI");
         },
         docExpansion: "none",
-        sorter : "alpha"
+        apisSorter: "alpha"
       });
 
       function addApiKeyAuthorization(){


### PR DESCRIPTION
I'd been wondering why my APIs were showing up in a seemingly random order every time; then I noticed that the parameter name had been changed, but `index.html` hadn't been updated. :)