### PR TITLE
Use a SPDX-compatible identifier for the 'license' value

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Create your own fork of [swagger-api/swagger-ui](https://github.com/swagger-api/
 To share your changes, [submit a pull request](https://github.com/swagger-api/swagger-ui/pull/new/develop_2.0).
 
 ## Change Log
-Plsee see [releases](https://github.com/swagger-api/swagger-ui/releases) for change log.
+Please see [releases](https://github.com/swagger-api/swagger-ui/releases) for change log.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "description": "Swagger UI is a dependency-free collection of HTML, JavaScript, and CSS assets that dynamically generate beautiful documentation from a Swagger-compliant API",
   "version": "2.1.0",
   "homepage": "http://swagger.io",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "main": "dist/swagger-ui.js",
   "scripts": {
     "build": "gulp",


### PR DESCRIPTION
This fixes the warning issued at `npm install` time.