### PR TITLE
Use a SPDX-compatible identifier for the 'license' value

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "description": "Swagger UI is a dependency-free collection of HTML, JavaScript, and CSS assets that dynamically generate beautiful documentation from a Swagger-compliant API",
   "version": "2.1.0",
   "homepage": "http://swagger.io",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "main": "dist/swagger-ui.js",
   "scripts": {
     "build": "gulp",


### PR DESCRIPTION
This fixes the warning issued at `npm install` time.