### PR TITLE
Add support for oauth client secret when calling the token URL. Fixes #1384. Fixes #1324.

### DIFF
--- a/lib/swagger-oauth.js
+++ b/lib/swagger-oauth.js
@@ -5,6 +5,7 @@ var clientId;
 var realm;
 var oauth2KeyName;
 var redirect_uri;
+var clientSecret;
 
 function handleLogin() {
   var scopes = [];
@@ -184,6 +185,7 @@ function initOAuth(opts) {
   popupMask = (o.popupMask||$('#api-common-mask'));
   popupDialog = (o.popupDialog||$('.api-popup-dialog'));
   clientId = (o.clientId||errors.push('missing client id'));
+  clientSecret = (o.clientSecret||errors.push('missing client secret'));
   realm = (o.realm||errors.push('missing realm'));
 
   if(errors.length > 0){
@@ -206,6 +208,7 @@ function initOAuth(opts) {
 window.processOAuthCode = function processOAuthCode(data) {
   var params = {
     'client_id': clientId,
+    'client_secret': clientSecret,
     'code': data.code,
     'grant_type': 'authorization_code',
     'redirect_uri': redirect_uri

--- a/src/main/html/index.html
+++ b/src/main/html/index.html
@@ -37,6 +37,7 @@
           if(typeof initOAuth == "function") {
             initOAuth({
               clientId: "your-client-id",
+              clientSecret: "your-client-secret",
               realm: "your-realms",
               appName: "your-app-name"
             });


### PR DESCRIPTION
This adds the 'client_secret' parameter to token requests.