### PR TITLE
Fix validator's https detection

### DIFF
--- a/src/main/javascript/view/MainView.js
+++ b/src/main/javascript/view/MainView.js
@@ -62,7 +62,7 @@ SwaggerUi.Views.MainView = Backbone.View.extend({
       this.model.validatorUrl = null;
     } else {
       // Default validator
-      if(window.location.protocol === 'https') {
+      if(window.location.protocol === 'https:') {
         this.model.validatorUrl = 'https://online.swagger.io/validator';
       }
       else {


### PR DESCRIPTION
This will make the URL's protocol correct, but it does not fix the issue that ```https://online.swagger.io/validator``` redirects to ```http://online.swagger.io/validator``` which returns an insecure image, breaking the nice green ```https``` logo in chrome.