### PR TITLE
Issue #1423: $ref schema objects in Responses Definitions Object don't seem to be displayed correctly

### DIFF
--- a/src/main/javascript/view/OperationView.js
+++ b/src/main/javascript/view/OperationView.js
@@ -139,8 +139,8 @@ SwaggerUi.Views.OperationView = Backbone.View.extend({
         schemaObj = this.model.responses[code].schema;
         if (schemaObj && schemaObj.$ref) {
           schema = schemaObj.$ref;
-          if (schema.indexOf('#/definitions/') === 0) {
-            schema = schema.substring('#/definitions/'.length);
+          if (schema.indexOf('#/definitions/') !== -1) {
+            schema = schema.replace(/^.*#\/definitions\//, '');
           }
         }
         this.model.responseMessages.push({


### PR DESCRIPTION
Responses containing references to definitions were not being fully resolved when the spec was pulled in over AJAX but was working locally. OperationView.render()'s parsing of the responses was just checking if the ref _started_ with '#/definitions/', not whether it contained it, and when pulled in over AJAX the refs have the URL prepended to them