### PR TITLE
Fix timing issues in unit-tests

### DIFF
--- a/test/e2e/servers.js
+++ b/test/e2e/servers.js
@@ -29,7 +29,7 @@ module.exports.start = function (specsLocation, done) {
   setTimeout(function(){
     driver.get(url);
     done();
-  }, process.env.TRAVIS ? 20000 : 3000);
+  }, process.env.TRAVIS ? 20000 : 5000);
 };
 
 module.exports.close = function() {

--- a/test/e2e/v1.js
+++ b/test/e2e/v1.js
@@ -4,6 +4,7 @@ var expect = require('chai').expect;
 var driver = require('./driver');
 var servers = require('./servers');
 var webdriver = require('selenium-webdriver');
+var until = webdriver.until;
 
 var elements = [
   'swagger-ui-container',
@@ -39,12 +40,8 @@ describe('swagger 1.x spec tests', function () {
     });
   });
 
-  it('should have "Swagger UI" in title', function (done) {
-    driver.sleep(200);
-    driver.getTitle().then(function(title) {
-      expect(title).to.contain('Swagger UI');
-      done();
-    });
+  it('should have "Swagger UI" in title', function () {
+    return driver.wait(until.titleIs('Swagger UI'), 1000);
   });
 
   elements.forEach(function (id) {

--- a/test/e2e/v2.js
+++ b/test/e2e/v2.js
@@ -4,7 +4,7 @@ var expect = require('chai').expect;
 var webdriver = require('selenium-webdriver');
 var driver = require('./driver');
 var servers = require('./servers');
-
+var until = webdriver.until;
 
 var elements = [
   'swagger-ui-container',
@@ -40,12 +40,8 @@ describe('swagger 2.0 spec tests', function () {
     });
   });
 
-  it('should have "Swagger UI" in title', function (done) {
-    driver.sleep(200);
-    driver.getTitle().then(function(title) {
-      expect(title).to.contain('Swagger UI');
-      done();
-    });
+  it('should have "Swagger UI" in title', function () {
+    return driver.wait(until.titleIs('Swagger UI'), 1000);
   });
 
   elements.forEach(function (id) {


### PR DESCRIPTION
Using a hard-coded delay 200ms when waiting for the page to load is a recipe for intermittent test failures. A better solution is to use `webdriver.until` and actively wait until the page is loaded (the title is set).

Also the delay 3000ms is not always enough for the selenium webdriver to initialise the browser, I am proposing to increase this delay a bit.