### PR TITLE
Go back to released http-server versions dependency now that they released CORS support in 0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "gulp-uglify": "^1.1.0",
     "gulp-watch": "^4.1.1",
     "gulp-wrap": "^0.11.0",
-    "http-server": "git+https://github.com/nodeapps/http-server.git",
+    "http-server": "^0.8.0",
     "jshint-stylish": "^1.0.1",
     "less": "^2.4.0",
     "mocha": "^2.1.0",


### PR DESCRIPTION
http-server dependency was changed to git master version by commit bdb181cb08749b230adc2ea78d2eac3fbf4ffa06 because it required https://github.com/indexzero/http-server/commit/30f4d1e008b3d707a764eb06ad4c1ac2becd9e96, which is now included in http-server v0.8.0.

This avoids a dependency on github, which was unavailable yesterday (see [Github Status](https://status.github.com/messages/2015-08-25)).