### PR TITLE
fix some XSS with improved handlebar template escaping

### DIFF
--- a/src/main/template/content_type.handlebars
+++ b/src/main/template/content_type.handlebars
@@ -2,7 +2,7 @@
 <select name="contentType" id="{{contentTypeId}}">
 {{#if produces}}
   {{#each produces}}
-	<option value="{{{this}}}">{{{this}}}</option>
+	<option value="{{this}}">{{this}}</option>
 	{{/each}}
 {{else}}
   <option value="application/json">application/json</option>

--- a/src/main/template/main.handlebars
+++ b/src/main/template/main.handlebars
@@ -1,7 +1,7 @@
 <div class='info' id='api_info'>
   {{#if info}}
   <div class="info_title">{{info.title}}</div>
-  <div class="info_description markdown">{{{info.description}}}</div>
+  <div class="info_description markdown">{{info.description}}</div>
   {{#if externalDocs}}
   <p>{{externalDocs.description}}</p>
   <a href="{{externalDocs.url}}" target="_blank">{{externalDocs.url}}</a>

--- a/src/main/template/operation.handlebars
+++ b/src/main/template/operation.handlebars
@@ -12,7 +12,7 @@
         </h3>
         <ul class='options'>
           <li>
-          <a href='#!/{{encodedParentId}}/{{nickname}}' class="toggleOperation">{{{summary}}}</a>
+          <a href='#!/{{encodedParentId}}/{{nickname}}' class="toggleOperation">{{summary}}</a>
           </li>
         </ul>
       </div>
@@ -22,7 +22,7 @@
         {{/if}}
         {{#if description}}
         <h4>Implementation Notes</h4>
-        <div class="markdown">{{{description}}}</div>
+        <div class="markdown">{{description}}</div>
         {{/if}}
         {{#oauth}}
         <div class="auth">
@@ -30,7 +30,7 @@
         {{#each oauth}}
           <div class="api_information_panel">
           {{#each this}}
-            <div title='{{{this.description}}}'>{{this.scope}}</div>
+            <div title='{{this.description}}'>{{this.scope}}</div>
           {{/each}}
           </div>
         {{/each}}

--- a/src/main/template/param.handlebars
+++ b/src/main/template/param.handlebars
@@ -27,8 +27,8 @@
 	{{/if}}
 
 </td>
-<td class="markdown">{{{description}}}</td>
-<td>{{{paramType}}}</td>
+<td class="markdown">{{description}}</td>
+<td>{{paramType}}</td>
 <td>
 	<span class="model-signature"></span>
 </td>

--- a/src/main/template/param_list.handlebars
+++ b/src/main/template/param_list.handlebars
@@ -14,6 +14,6 @@
 
   </select>
 </td>
-<td class="markdown">{{#if required}}<strong>{{/if}}{{{description}}}{{#if required}}</strong>{{/if}}</td>
-<td>{{{paramType}}}</td>
+<td class="markdown">{{#if required}}<strong>{{/if}}{{description}}{{#if required}}</strong>{{/if}}</td>
+<td>{{paramType}}</td>
 <td><span class="model-signature"></span></td>

--- a/src/main/template/param_readonly.handlebars
+++ b/src/main/template/param_readonly.handlebars
@@ -10,6 +10,6 @@
         {{/if}}
     {{/if}}
 </td>
-<td class="markdown">{{{description}}}</td>
-<td>{{{paramType}}}</td>
+<td class="markdown">{{description}}</td>
+<td>{{paramType}}</td>
 <td><span class="model-signature"></span></td>

--- a/src/main/template/param_readonly_required.handlebars
+++ b/src/main/template/param_readonly_required.handlebars
@@ -10,6 +10,6 @@
         {{/if}}
     {{/if}}
 </td>
-<td class="markdown">{{{description}}}</td>
-<td>{{{paramType}}}</td>
+<td class="markdown">{{description}}</td>
+<td>{{paramType}}</td>
 <td><span class="model-signature"></span></td>

--- a/src/main/template/param_required.handlebars
+++ b/src/main/template/param_required.handlebars
@@ -24,7 +24,7 @@
 	{{/if}}
 </td>
 <td>
-	<strong><span class="markdown">{{{description}}}</span></strong>
+	<strong><span class="markdown">{{description}}</span></strong>
 </td>
-<td>{{{paramType}}}</td>
+<td>{{paramType}}</td>
 <td><span class="model-signature"></span></td>

--- a/src/main/template/parameter_content_type.handlebars
+++ b/src/main/template/parameter_content_type.handlebars
@@ -2,7 +2,7 @@
 <select name="parameterContentType" id="{{parameterContentTypeId}}">
 {{#if consumes}}
   {{#each consumes}}
-  <option value="{{{this}}}">{{{this}}}</option>
+  <option value="{{this}}">{{this}}</option>
   {{/each}}
 {{else}}
   <option value="application/json">application/json</option>

--- a/src/main/template/resource.handlebars
+++ b/src/main/template/resource.handlebars
@@ -1,6 +1,6 @@
 <div class='heading'>
   <h2>
-    <a href='#!/{{id}}' class="toggleEndpointList" data-id="{{id}}">{{name}}</a> {{#summary}} : {{/summary}}{{{summary}}}
+    <a href='#!/{{id}}' class="toggleEndpointList" data-id="{{id}}">{{name}}</a> {{#summary}} : {{/summary}}{{summary}}
   </h2>
   <ul class='options'>
     <li>

--- a/src/main/template/response_content_type.handlebars
+++ b/src/main/template/response_content_type.handlebars
@@ -2,7 +2,7 @@
 <select name="responseContentType" id="{{responseContentTypeId}}">
 {{#if produces}}
   {{#each produces}}
-  <option value="{{{this}}}">{{{this}}}</option>
+  <option value="{{this}}">{{this}}</option>
   {{/each}}
 {{else}}
   <option value="application/json">application/json</option>

--- a/src/main/template/status_code.handlebars
+++ b/src/main/template/status_code.handlebars
@@ -1,5 +1,5 @@
 <td width='15%' class='code'>{{code}}</td>
-<td class="markdown">{{{message}}}</td>
+<td class="markdown">{{message}}</td>
 <td width='50%'><span class="model-signature" /></td>
 <td class="headers">
   <table>


### PR DESCRIPTION
I think this will address many cases of cross-site scripting via swagger api-data. I would love feedback from someone more familiar with the project. 

The root of many of our XSS issues appears due to Handlebar templates. 

We have a few fields where we are likely incorrectly disabling Handlebar's HTML escaping by using "triple-stash" ```{{{ }}}``` (http://handlebarsjs.com/#html-escaping)

Please note: this PR doesn't fix [signature.handlebars](https://github.com/swagger-api/swagger-ui/blob/master/src/main/template/signature.handlebars). The signature feature still needs more attention to fix a related XSS vulnerability while keeping functionality. 

Related:
https://github.com/swagger-api/swagger-ui/issues/830