### PR TITLE
Support additional query parameters during OAuth2 authorization process

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -51,7 +51,8 @@
               clientSecret: "your-client-secret",
               realm: "your-realms",
               appName: "your-app-name", 
-              scopeSeparator: ","
+              scopeSeparator: ",",
+              additionalQueryStringParams: {}
             });
           }
 

--- a/dist/lib/swagger-oauth.js
+++ b/dist/lib/swagger-oauth.js
@@ -7,6 +7,7 @@ var oauth2KeyName;
 var redirect_uri;
 var clientSecret;
 var scopeSeparator;
+var additionalQueryStringParams;
 
 function handleLogin() {
   var scopes = [];
@@ -156,6 +157,9 @@ function handleLogin() {
     url += '&client_id=' + encodeURIComponent(clientId);
     url += '&scope=' + encodeURIComponent(scopes.join(scopeSeparator));
     url += '&state=' + encodeURIComponent(state);
+    for (var key in additionalQueryStringParams) {
+        url += '&' + key + '=' + encodeURIComponent(additionalQueryStringParams[key]);
+    }
 
     window.open(url);
   });
@@ -190,6 +194,7 @@ function initOAuth(opts) {
   clientSecret = (o.clientSecret||errors.push('missing client secret'));
   realm = (o.realm||errors.push('missing realm'));
   scopeSeparator = (o.scopeSeparator||' ');
+  additionalQueryStringParams = (o.additionalQueryStringParams||{});
 
   if(errors.length > 0){
     log('auth unable initialize oauth: ' + errors);

--- a/lib/swagger-oauth.js
+++ b/lib/swagger-oauth.js
@@ -7,6 +7,7 @@ var oauth2KeyName;
 var redirect_uri;
 var clientSecret;
 var scopeSeparator;
+var additionalQueryStringParams;
 
 function handleLogin() {
   var scopes = [];
@@ -156,6 +157,9 @@ function handleLogin() {
     url += '&client_id=' + encodeURIComponent(clientId);
     url += '&scope=' + encodeURIComponent(scopes.join(scopeSeparator));
     url += '&state=' + encodeURIComponent(state);
+    for (var key in additionalQueryStringParams) {
+        url += '&' + key + '=' + encodeURIComponent(additionalQueryStringParams[key]);
+    }
 
     window.open(url);
   });
@@ -190,6 +194,7 @@ function initOAuth(opts) {
   clientSecret = (o.clientSecret||errors.push('missing client secret'));
   realm = (o.realm||errors.push('missing realm'));
   scopeSeparator = (o.scopeSeparator||' ');
+  additionalQueryStringParams = (o.additionalQueryStringParams||{});
 
   if(errors.length > 0){
     log('auth unable initialize oauth: ' + errors);

--- a/src/main/html/index.html
+++ b/src/main/html/index.html
@@ -51,7 +51,8 @@
               clientSecret: "your-client-secret",
               realm: "your-realms",
               appName: "your-app-name", 
-              scopeSeparator: ","
+              scopeSeparator: ",",
+              additionalQueryStringParams: {}
             });
           }
 


### PR DESCRIPTION
Hi, while trying to integrate an Azure Active Directory (AAD) protected API with Swagger-UI I encountered the issue where it is required to specify the "Resource" parameter but there was no way of easily providing it. This problem is covered in the open issue https://github.com/swagger-api/swagger-ui/issues/1302.

I made a generic mechanism for passing custom parameters (instead of adding a specific "Resource" parameter) since I also really needed a custom parameter "domain_hint" as explained here - http://www.cloudidentity.com/blog/2014/11/17/skipping-the-home-realm-discovery-page-in-azure-ad/.

I'd appreciate it if this addition can be merged into Swagger-UI. Thanks!