### PR TITLE
Send POST body with content-type: application/x-www-form-urlencoded

### DIFF
--- a/dist/swagger-ui.js
+++ b/dist/swagger-ui.js
@@ -4244,7 +4244,7 @@ Operation.prototype.getBody = function (headers, args, opts) {
   }
 
   // handle form params
-  if (headers['Content-Type'] === 'application/x-www-form-urlencoded') {
+  if (headers['Content-Type'] === 'application/x-www-form-urlencoded' && param.in === 'formData') {
     var encoded = '';
 
     for (key in formParams) {


### PR DESCRIPTION
In current code when 
1) content-type:application/x-www-urlencoded and 
2) In swagger spec we have in: body

The generated curl statement doesn't have -d as part of the request and sends empty body to API backend.

Sample gist: https://gist.githubusercontent.com/VinayBhalerao/fe84395595777db0ffb1/raw/511fa8c3df4cf5fb1116dc413311bd2394a9d602/petstore-example

Use sample json to send in body : https://gist.github.com/VinayBhalerao/ad23a69299146551a0d3

As part of solution, we ask to use in:formData in spec and in code we urlencoded the whole body and then send to API backend. The generated curl statement has the body in -d parameters in urlencoded format, but this doesn't work since some backend only accept json array as part of body.

Fix:
1) Generate -d as part of curl request and send body when content-type:application/x-www-url-form-encoded.... if in swagger spec in:body
2) If in swagger spec in:formData, send the body in url-encoded format to backend

