### PR TITLE
Changes to support swagger 1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,5 +22,6 @@
     "swagger-client": "2.0.36",
     "handlebars": "~1.0.10",
     "less": "~1.4.2"
-  }
+  },
+  "main": "dist/swagger-ui.js"
 }

--- a/src/main/coffeescript/view/MainView.coffee
+++ b/src/main/coffeescript/view/MainView.coffee
@@ -5,14 +5,15 @@ class MainView extends Backbone.View
   }
 
   initialize: (opts={}) ->
+    @options = opts
     if opts.swaggerOptions.sorter
       sorterName = opts.swaggerOptions.sorter
       sorter = sorters[sorterName]
       for route in @model.apisArray
         route.operationsArray.sort sorter
-      if (sorterName == "alpha") # sort top level paths if alpha 
+      if (sorterName == "alpha") # sort top level paths if alpha
         @model.apisArray.sort sorter
- 
+
   render: ->
     # Render the outer container for resources
     $(@el).html(Handlebars.templates.main(@model))

--- a/src/main/coffeescript/view/OperationView.coffee
+++ b/src/main/coffeescript/view/OperationView.coffee
@@ -10,7 +10,8 @@ class OperationView extends Backbone.View
     'mouseout .api-ic'        : 'mouseExit'
   }
 
-  initialize: ->
+  initialize: (opts={}) ->
+    @options = opts
 
   mouseEnter: (e) ->
     elem = $(e.currentTarget.parentNode).find('#api_information_panel')
@@ -62,7 +63,7 @@ class OperationView extends Backbone.View
         sampleJSON: @model.responseSampleJSON
         isParam: false
         signature: @model.responseClassSignature
-        
+
       responseSignatureView = new SignatureView({model: signatureModel, tagName: 'div'})
       $('.model-signature', $(@el)).append responseSignatureView.render().el
     else
@@ -102,7 +103,7 @@ class OperationView extends Backbone.View
     # Render status codes
     statusCodeView = new StatusCodeView({model: statusCode, tagName: 'tr'})
     $('.operation-status', $(@el)).append statusCodeView.render().el
-  
+
   submitOperation: (e) ->
     e?.preventDefault()
     # Check for errors
@@ -133,7 +134,7 @@ class OperationView extends Backbone.View
         if(o.value? && jQuery.trim(o.value).length > 0)
           map["body"] = o.value
 
-      for o in form.find("select") 
+      for o in form.find("select")
         val = this.getSelectedValue o
         if(val? && jQuery.trim(val).length > 0)
           map[o.name] = val
@@ -179,17 +180,17 @@ class OperationView extends Backbone.View
         bodyParam.append($(el).attr('name'), el.files[0])
         params += 1
 
-    @invocationUrl = 
+    @invocationUrl =
       if @model.supportHeaderParams()
         headerParams = @model.getHeaderParams(map)
         @model.urlify(map, false)
       else
         @model.urlify(map, true)
 
-    $(".request_url", $(@el)).html("<pre></pre>") 
+    $(".request_url", $(@el)).html("<pre></pre>")
     $(".request_url pre", $(@el)).text(@invocationUrl);
-    
-    obj = 
+
+    obj =
       type: @model.method
       url: @invocationUrl
       headers: headerParams
@@ -235,12 +236,12 @@ class OperationView extends Backbone.View
     o
 
   getSelectedValue: (select) ->
-    if !select.multiple 
+    if !select.multiple
       select.value
     else
       options = []
       options.push opt.value for opt in select.options when opt.selected
-      if options.length > 0 
+      if options.length > 0
         options.join ","
       else
         null
@@ -276,7 +277,7 @@ class OperationView extends Backbone.View
     lines = xml.split('\n')
     indent = 0
     lastType = 'other'
-    # 4 types of tags - single, closing, opening, other (text, doctype, comment) - 4*4 = 16 transitions 
+    # 4 types of tags - single, closing, opening, other (text, doctype, comment) - 4*4 = 16 transitions
     transitions =
       'single->single': 0
       'single->closing': -1
@@ -320,9 +321,9 @@ class OperationView extends Backbone.View
           formatted = formatted.substr(0, formatted.length - 1) + ln + '\n'
         else
           formatted += padding + ln + '\n'
-      
+
     formatted
-    
+
 
   # puts the response data in UI
   showStatus: (response) ->
@@ -357,7 +358,7 @@ class OperationView extends Backbone.View
       pre = $('<pre class="json" />').append(code)
 
     response_body = pre
-    $(".request_url", $(@el)).html("<pre></pre>") 
+    $(".request_url", $(@el)).html("<pre></pre>")
     $(".request_url pre", $(@el)).text(url);
     $(".response_code", $(@el)).html "<pre>" + response.status + "</pre>"
     $(".response_body", $(@el)).html response_body

--- a/src/main/coffeescript/view/OperationView.coffee
+++ b/src/main/coffeescript/view/OperationView.coffee
@@ -42,7 +42,7 @@ class OperationView extends Backbone.View
     $(e.currentTarget.parentNode).find('#api_information_panel').hide()
 
   render: ->
-    isMethodSubmissionSupported = true #jQuery.inArray(@model.method, @model.supportedSubmitMethods) >= 0
+    isMethodSubmissionSupported = jQuery.inArray(@model.method, @options.swaggerOptions.supportedSubmitMethods) >= 0
     @model.isReadOnly = true unless isMethodSubmissionSupported
 
     @model.oauth = null

--- a/src/main/coffeescript/view/ParameterView.coffee
+++ b/src/main/coffeescript/view/ParameterView.coffee
@@ -1,12 +1,13 @@
 class ParameterView extends Backbone.View
-  initialize: ->
+  initialize: (opts={}) ->
+    @options = opts
     Handlebars.registerHelper 'isArray',
       (param, opts) ->
         if param.type.toLowerCase() == 'array' || param.allowMultiple
           opts.fn(@)
         else
           opts.inverse(@)
-          
+
   render: ->
     type = @model.type || @model.dataType
     @model.isBody = true if @model.paramType == 'body'

--- a/src/main/coffeescript/view/ResourceView.coffee
+++ b/src/main/coffeescript/view/ResourceView.coffee
@@ -1,5 +1,6 @@
 class ResourceView extends Backbone.View
-  initialize: ->
+  initialize: (opts={}) ->
+    @options = opts
 
   render: ->
     $(@el).html(Handlebars.templates.resource(@model))
@@ -19,12 +20,12 @@ class ResourceView extends Backbone.View
 
       operation.nickname = id
       operation.parentId = @model.id
-      @addOperation operation 
+      @addOperation operation
 
     $('.toggleEndpointList', @el).click(this.callDocs.bind(this, 'toggleEndpointListForResource'))
     $('.collapseResource', @el).click(this.callDocs.bind(this, 'collapseOperationsForResource'))
     $('.expandResource', @el).click(this.callDocs.bind(this, 'expandOperationsForResoruce'))
-    
+
     return @
 
   addOperation: (operation) ->


### PR DESCRIPTION
I've started maintaining a project for which the upgrade from Swagger 1.2 to 2 is unlikely to happen in the near future, it's going to involve quite a lot of work and due to swagger-api/swagger-spec#182 it's unlikely we'll even be able to upgrade.

I've been maintaining [achingbrain/swagger-ui-browserify](https://github.com/achingbrain/swagger-ui-browserify) to address swagger-api/swagger-ui#1596 - this PR contains the changes necessary to support the older swagger-ui and as such the older Swagger spec.

You probably won't be able to merge this PR directly but perhaps you could create a branch from the 2.0.24 tag, merge these changes in and release it as 2.0.25?