### PR TITLE
fix how default url is loaded from window.location

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -29,12 +29,13 @@
 
   <script type="text/javascript">
     $(function () {
-      var url = window.location.search.match(/url=([^&]+)/);
+      var url = window.location.origin
       if (url && url.length > 1) {
-        url = decodeURIComponent(url[1]);
+        url = decodeURIComponent(url)+"/api-docs";
       } else {
-        url = "http://petstore.swagger.io/v2/swagger.json";
+        url = "http://localhost:9000/api-docs";
       }
+
 
       // Pre load translate...
       if(window.SwaggerTranslator) {

--- a/src/main/html/index.html
+++ b/src/main/html/index.html
@@ -29,11 +29,11 @@
 
   <script type="text/javascript">
     $(function () {
-      var url = window.location.search.match(/url=([^&]+)/);
+      var url = window.location.origin
       if (url && url.length > 1) {
-        url = decodeURIComponent(url[1]);
+        url = decodeURIComponent(url)+"/api-docs";
       } else {
-        url = "http://petstore.swagger.io/v2/swagger.json";
+        url = "http://localhost:9000/api-docs";
       }
 
       // Pre load translate...


### PR DESCRIPTION
window.location.search.match(/url=([^&]+)/) yields null on some browsers. replace with window.location.origin to get proper url from web browser for querying application api-docs and for loading base url in swagger-ui/index.html