### PR TITLE
Don't dereference param.type if undefined

### DIFF
--- a/src/main/javascript/view/ParameterView.js
+++ b/src/main/javascript/view/ParameterView.js
@@ -3,7 +3,7 @@
 SwaggerUi.Views.ParameterView = Backbone.View.extend({
   initialize: function(){
     Handlebars.registerHelper('isArray', function(param, opts) {
-      if (param.type.toLowerCase() === 'array' || param.allowMultiple) {
+      if ((param.type && param.type.toLowerCase() === 'array') || param.allowMultiple) {
         return opts.fn(this);
       } else {
         return opts.inverse(this);


### PR DESCRIPTION
Within swagger-spec 2.0 a Parameter Object is missing the type field if
in == 'body'. This fixes crashes when such a case is reached.