### PR TITLE
Fix API declarations loading for files with swaggerVersion 1.2

### DIFF
--- a/dist/swagger-ui.js
+++ b/dist/swagger-ui.js
@@ -3555,7 +3555,7 @@ SwaggerSpecConverter.prototype.resourceListing = function(obj, swagger, callback
 };
 
 SwaggerSpecConverter.prototype.getAbsolutePath = function(version, docLocation, path)  {
-  if(version === '1.0') {
+  if(version === '1.0' || version === '1.1' || version === '1.2') {
     if(docLocation.endsWith('.json')) {
       // get root path
       var pos = docLocation.lastIndexOf('/');


### PR DESCRIPTION
The version can be 1.0, 1.1 or 1.2 according to the spec.  These require
to cut the file name from the resource listing URL when the absolute path
to the respective API declaration is computed.