### PR TITLE
Fix file displayed as undefined

### DIFF
--- a/dist/swagger-ui.js
+++ b/dist/swagger-ui.js
@@ -4167,6 +4167,8 @@ Operation.prototype.getType = function (param) {
     if (param.items) {
       str = this.getType(param.items);
     }
+  } else if (type === 'file') {
+	str = 'file';
   }
 
   if (param.$ref) {


### PR DESCRIPTION
File was not showing properly in the DataType for formData. There was a ticket about it as well #1478