### PR TITLE
Add support for content-types which contain a quote symbol.

### DIFF
--- a/src/main/template/content_type.handlebars
+++ b/src/main/template/content_type.handlebars
@@ -2,7 +2,7 @@
 <select name="contentType" id="{{contentTypeId}}">
 {{#if produces}}
   {{#each produces}}
-	<option value="{{{this}}}">{{{this}}}</option>
+	<option value="{{this}}">{{{this}}}</option>
 	{{/each}}
 {{else}}
   <option value="application/json">application/json</option>

--- a/src/main/template/parameter_content_type.handlebars
+++ b/src/main/template/parameter_content_type.handlebars
@@ -2,7 +2,7 @@
 <select name="parameterContentType" id="{{parameterContentTypeId}}">
 {{#if consumes}}
   {{#each consumes}}
-  <option value="{{{this}}}">{{{this}}}</option>
+  <option value="{{this}}">{{{this}}}</option>
   {{/each}}
 {{else}}
   <option value="application/json">application/json</option>

--- a/src/main/template/response_content_type.handlebars
+++ b/src/main/template/response_content_type.handlebars
@@ -2,7 +2,7 @@
 <select name="responseContentType" id="{{responseContentTypeId}}">
 {{#if produces}}
   {{#each produces}}
-  <option value="{{{this}}}">{{{this}}}</option>
+  <option value="{{this}}">{{{this}}}</option>
   {{/each}}
 {{else}}
   <option value="application/json">application/json</option>


### PR DESCRIPTION
We are using a content-type which contains a URL, that needs to be quoted.  This causes some sad HTML rendering since the urls aren't endocded when being rendered.

Our content-type is application/hal+json; charset=utf-8; version=1.0; profile="http://donate-api.justgiving.com/profiles"