### PR TITLE
check 'defaultValue' before calling 'replace'

### DIFF
--- a/src/main/javascript/helpers/handlebars.js
+++ b/src/main/javascript/helpers/handlebars.js
@@ -32,7 +32,9 @@ Handlebars.registerHelper('renderTextParam', function(param) {
         idAtt = ' id=\'' + param.valueId + '\'';
     }
 
-    defaultValue = defaultValue.replace(/'/g,'&apos;');
+    if (typeof defaultValue === 'string' || defaultValue instanceof String) {
+        defaultValue = defaultValue.replace(/'/g,'&apos;');
+    }
 
     if(isArray) {
         result = '<textarea class=\'body-textarea' + (param.required ? ' required' : '') + '\' name=\'' + param.name + '\'' + idAtt + dataVendorExtensions;


### PR DESCRIPTION
fix error "defaultValue.replace is not a function" when defaultValue is Integer