### PR TITLE
Added Window Specific Guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Swagger UI works in all evergreen desktop browsers (Chrome, Safari, Firefox). In
 ### Build
 You can rebuild swagger-ui on your own to tweak it or just so you can say you did.  To do so, follow these steps:
 
+### Windows Users: Please install [Python](https://www.python.org/downloads/windows/) before follow below guidelines for node-gyp rebuild to run.
+
 1. `npm install`
 2. `gulp`
 3. You should see the distribution under the dist folder. Open [`./dist/index.html`](./dist/index.html) to launch Swagger UI in a browser


### PR DESCRIPTION
Guidelines  will be useful for people who install Swagger ui in windows. error is below.

![python-error-in-windows-7](https://cloud.githubusercontent.com/assets/1652629/12335045/2a616e40-bb23-11e5-83c4-2163c4c087cf.png)
