### PR TITLE
Allow `ctrl + enter` pressed to make multiline

### DIFF
--- a/src/main/html/index.html
+++ b/src/main/html/index.html
@@ -82,6 +82,7 @@
       });
 
       function multilinable(q, cls) {
+        $('<label>Press "ctrl + enter" to make multiline</label>').insertAfter($(q));
         $(q).keypress(function (e) {
           if (e.ctrlKey && e.keyCode == 13) {
             var $el = $(e.target);
@@ -99,7 +100,6 @@
             return false;
           }
         });
-        // $(q).attr('placeholder', 'Press <ctrl + enter> to make multiline');
       }
 
       function addApiKeyAuthorization(){

--- a/src/main/html/index.html
+++ b/src/main/html/index.html
@@ -68,6 +68,8 @@
           }
 
           addApiKeyAuthorization();
+
+          toTextareas('input.parameter', 'body-textarea');
         },
         onFailure: function(data) {
           log("Unable to Load SwaggerUI");
@@ -78,6 +80,30 @@
         defaultModelRendering: 'schema',
         showRequestHeaders: false
       });
+
+        function toTextareas(q, cls) {
+          $(q).keypress(function (e) {
+            if (e.which == 13) {
+              toTextarea(e.target, cls);
+              return false;
+            }
+          });
+        }
+
+        function toTextarea(el, cls) {
+          var $el = $(el);
+          var $ta = $(document.createElement('textarea'));
+          var attributes = $el.prop("attributes");
+          $.each(attributes, function() {
+            $ta.attr(this.name, this.value);
+          });
+          var v = $el.val();
+          if (v) v = v + '\n';
+          $ta.val(v);
+          $ta.addClass(cls);
+          $el.replaceWith($ta);
+          $ta.focus();
+        }
 
       function addApiKeyAuthorization(){
         var key = encodeURIComponent($('#input_apiKey')[0].value);

--- a/src/main/html/index.html
+++ b/src/main/html/index.html
@@ -69,7 +69,7 @@
 
           addApiKeyAuthorization();
 
-          toTextareas('input.parameter', 'body-textarea');
+          multilinable('input.parameter', 'body-textarea');
         },
         onFailure: function(data) {
           log("Unable to Load SwaggerUI");
@@ -81,29 +81,26 @@
         showRequestHeaders: false
       });
 
-        function toTextareas(q, cls) {
-          $(q).keypress(function (e) {
-            if (e.which == 13) {
-              toTextarea(e.target, cls);
-              return false;
-            }
-          });
-        }
-
-        function toTextarea(el, cls) {
-          var $el = $(el);
-          var $ta = $(document.createElement('textarea'));
-          var attributes = $el.prop("attributes");
-          $.each(attributes, function() {
-            $ta.attr(this.name, this.value);
-          });
-          var v = $el.val();
-          if (v) v = v + '\n';
-          $ta.val(v);
-          $ta.addClass(cls);
-          $el.replaceWith($ta);
-          $ta.focus();
-        }
+      function multilinable(q, cls) {
+        $(q).keypress(function (e) {
+          if (e.ctrlKey && e.keyCode == 13) {
+            var $el = $(e.target);
+            var $ta = $(document.createElement('textarea'));
+            var attributes = $el.prop("attributes");
+            $.each(attributes, function() {
+              $ta.attr(this.name, this.value);
+            });
+            var v = $el.val();
+            if (v) v = v + '\n';
+            $ta.val(v);
+            $ta.addClass(cls);
+            $el.replaceWith($ta);
+            $ta.focus();
+            return false;
+          }
+        });
+        // $(q).attr('placeholder', 'Press <ctrl + enter> to make multiline');
+      }
 
       function addApiKeyAuthorization(){
         var key = encodeURIComponent($('#input_apiKey')[0].value);


### PR DESCRIPTION
Using ctrl + enter to switch text editor to multiline, and added `Press "ctrl + enter" to make multiline` note after the text editor.
