### PR TITLE
Fixing case where there is no parameter type

### DIFF
--- a/src/main/javascript/view/ParameterView.js
+++ b/src/main/javascript/view/ParameterView.js
@@ -7,7 +7,7 @@ SwaggerUi.Views.ParameterView = Backbone.View.extend({
 
   initialize: function(){
     Handlebars.registerHelper('isArray', function(param, opts) {
-      if (param.type.toLowerCase() === 'array' || param.allowMultiple) {
+      if (param.type && param.type.toLowerCase() === 'array' || param.allowMultiple) {
         return opts.fn(this);
       } else {
         return opts.inverse(this);


### PR DESCRIPTION
Fixing case where there is no parameter type.  This happens when a body parameter is defined by a schema.