### PR TITLE
set ttf files as binary in gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,4 +11,5 @@ dist/**/*.woff2 binary
 dist/**/*.png binary
 dist/*.html text
 
+src/main/html/fonts/*.ttf binary
 src/main/html/images/*.png binary


### PR DESCRIPTION
Because of it ttf files are marked as modified after we git clone master with git 1.7.9.5.