### PR TITLE
Fix generated XML when property definitions reference primitive types

### DIFF
--- a/dist/swagger-ui.js
+++ b/dist/swagger-ui.js
@@ -21989,7 +21989,7 @@ SwaggerUi.partials.signature = (function () {
   function getDescriptorByRef($ref, name, models, config) {
     var modelType = simpleRef($ref);
     var model = models[modelType] || {};
-    var type = model.type || 'object';
+    var type = model.definition && model.definition.type ? model.definition.type : 'object';
     name = name || model.name;
 
     if (config.modelsToIgnore.indexOf($ref) > -1) {

--- a/src/main/javascript/view/partials/signature.js
+++ b/src/main/javascript/view/partials/signature.js
@@ -899,7 +899,7 @@ SwaggerUi.partials.signature = (function () {
   function getDescriptorByRef($ref, name, models, config) {
     var modelType = simpleRef($ref);
     var model = models[modelType] || {};
-    var type = model.type || 'object';
+    var type = model.definition && model.definition.type ? model.definition.type : 'object';
     name = name || model.name;
 
     if (config.modelsToIgnore.indexOf($ref) > -1) {


### PR DESCRIPTION
When sample XML results are generated, the code looking up a `$ref` attempts to read the property `type` from `model`, which does not exist. As a result, the type defaults to `object` and only `$refs` to `object` definitions work properly.

Minimal example:
`{  
  "swagger":"2.0",
  "schemes":[  
    "http"
  ],
  "paths":{
    "/pet":{  
      "get":{
        "summary":"Get pet",
        "description":"Returns a single pet",
        "operationId":"getPet",
        "produces":[  
          "application/xml"
        ],
        "responses":{  
          "200":{  
            "description":"successful operation",
            "schema":{  
              "$ref":"#/definitions/Pet"
            }
          }
        },
        "security":[  
          {  
            "api_key":[]
          }
        ]
      }
    }
  },
  "definitions":{  
    "Primitive": {
      "type": "integer"
    },
    "Pet":{  
      "type":"object",
      "properties":{  
        "id":{ 
          "$ref":"#/definitions/Primitive"
        }
      }
    }
  }
}`

Before: 
`
<?xml version="1.0"?>
<Pet>
  <!-- invalid XML -->
</Pet>
`

After:
`
<?xml version="1.0"?>
<Pet>
  <id>1</id>
</Pet>
`