### PR TITLE
Oauth2 scope fixes

### DIFF
--- a/src/main/javascript/utils/utils.js
+++ b/src/main/javascript/utils/utils.js
@@ -20,6 +20,7 @@ window.SwaggerUi.utils = {
                     auths[key] = auths[key] || {};
                     if (auths[key].type === 'oauth2') {
                         singleOauth2Security[key] = Object.assign({}, auths[key]);
+                        singleOauth2Security[key].scopes = Object.assign({}, auths[key].scopes);
                         for (var i in singleOauth2Security[key].scopes) {
                             if (item[key].indexOf(i) < 0) {
                                 delete singleOauth2Security[key].scopes[i];

--- a/src/main/javascript/view/Oauth2Model.js
+++ b/src/main/javascript/view/Oauth2Model.js
@@ -21,9 +21,7 @@ SwaggerUi.Models.Oauth2Model = Backbone.Model.extend({
     },
 
     validate: function () {
-        var valid =  _.findIndex(this.get('scopes'), function (o) {
-           return o.checked === true;
-        }) > -1;
+        var valid = true;
 
         this.set('valid', valid);
 


### PR DESCRIPTION
This pull request includes two Oauth2 scope related fixes.

The first commit fixes so the global scopes object is not mutated when a path does not require all valid scopes. Without this fix the Oauth2 security method is basically broken if you are using more than one path with different scopes.

The second commit changes the valid behavior for the Oauth2 security method so it is valid even if no scopes is specified. There might be valid api calls that does not require a scope. Eg. a `debug_token` endpoint.