### PR TITLE
added a stream end to gulp-less to prevent less errors stopping watch

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -91,7 +91,7 @@ function _less() {
       './src/main/less/style.less'
     ])
     .pipe(less())
-    .on('error', log)
+    .on('error', function(err){ log(err); this.emit('end');})
     .pipe(gulp.dest('./src/main/html/css/'))
     .pipe(connect.reload());
 }


### PR DESCRIPTION
Less errors were crashing Gulp-watch, this will allow you to fix your error and continue without having to reset gulp