### PR TITLE
Fixes overflow issue for markdown code examples

### DIFF
--- a/dist/css/print.css
+++ b/dist/css/print.css
@@ -667,6 +667,7 @@
 }
 .swagger-section .swagger-ui-wrap .markdown pre code {
   line-height: 1.6em;
+  overflow: auto;
 }
 .swagger-section .swagger-ui-wrap div.gist {
   margin: 20px 0 25px 0 !important;

--- a/dist/css/screen.css
+++ b/dist/css/screen.css
@@ -667,6 +667,7 @@
 }
 .swagger-section .swagger-ui-wrap .markdown pre code {
   line-height: 1.6em;
+  overflow: auto;
 }
 .swagger-section .swagger-ui-wrap div.gist {
   margin: 20px 0 25px 0 !important;

--- a/src/main/html/css/print.css
+++ b/src/main/html/css/print.css
@@ -667,6 +667,7 @@
 }
 .swagger-section .swagger-ui-wrap .markdown pre code {
   line-height: 1.6em;
+  overflow: auto;
 }
 .swagger-section .swagger-ui-wrap div.gist {
   margin: 20px 0 25px 0 !important;

--- a/src/main/html/css/screen.css
+++ b/src/main/html/css/screen.css
@@ -667,6 +667,7 @@
 }
 .swagger-section .swagger-ui-wrap .markdown pre code {
   line-height: 1.6em;
+  overflow: auto;
 }
 .swagger-section .swagger-ui-wrap div.gist {
   margin: 20px 0 25px 0 !important;


### PR DESCRIPTION
Hello there. This tiny PR fixes CSS for the markdown box when given a code example that's larger than the width.

Before:
![screen shot 2016-04-29 at 2 29 59 pm](https://cloud.githubusercontent.com/assets/585697/14930196/e7bb7922-0e16-11e6-88f8-99d2fee78a22.png)

After:
![css_overflow](https://cloud.githubusercontent.com/assets/585697/14930201/eeb0a4e6-0e16-11e6-9b46-d2a2695cf2cc.gif)


Thanks for considering!