### PR TITLE
Remove unnecessary class from main.handlebars template

### DIFF
--- a/src/main/template/main.handlebars
+++ b/src/main/template/main.handlebars
@@ -13,7 +13,7 @@
   {{#if info.license}}<div class='info_license'><a target="_blank" href='{{info.license.url}}'>{{info.license.name}}</a></div>{{/if}}
   {{/if}}
 </div>
-<div class='container' id='resources_container'>
+<div id='resources_container'>
   <div class='authorize-wrapper'></div>
 
   <ul id='resources'></ul>


### PR DESCRIPTION
The main template contains a `<div class='container' id='resources_container'>`. The `container` class does not seem to be styled or used anywhere. On the other hand, it has an unfortunate name clash with bootstrap, which is resolved by simply removing the unnecessary class.
