### PR TITLE
Sync specs.less with {print,screen}.css (#1710)

### DIFF
--- a/src/main/less/specs.less
+++ b/src/main/less/specs.less
@@ -530,6 +530,7 @@
             margin: 0 0 10px 0;
             code {
                 line-height: 1.6em;
+                overflow: auto;
             }
         }
     }


### PR DESCRIPTION
In ceb6655663278f548637da2b1150f11e50aad2e9 (#2130), CSS code has been changed in `src/main/html/csss/{print,screen}.css` instead of LESS source.
This commit resynchronize the source with the generated code.
This fixes #1710.