### PR TITLE
[#2167] fix xml generator break condition

### DIFF
--- a/src/main/javascript/view/partials/signature.js
+++ b/src/main/javascript/view/partials/signature.js
@@ -870,7 +870,7 @@ SwaggerUi.partials.signature = (function () {
         output = createPrimitiveXML(descriptor);
     }
 
-    if ($ref) {
+    if ($ref && descriptor.type !== 'loop') {
       index = config.modelsToIgnore.indexOf($ref);
       if (index > -1) {
         config.modelsToIgnore.splice(index, 1);


### PR DESCRIPTION
The xml generator goes into an infinity loop if models are double nested because model references get remove from modelsToIgnore directly after they caused a loop.