### PR TITLE
Make oauth2 scopes optional

### DIFF
--- a/src/main/javascript/view/Oauth2Model.js
+++ b/src/main/javascript/view/Oauth2Model.js
@@ -21,12 +21,22 @@ SwaggerUi.Models.Oauth2Model = Backbone.Model.extend({
     },
 
     validate: function () {
-        var valid =  _.findIndex(this.get('scopes'), function (o) {
-           return o.checked === true;
-        }) > -1;
+      var valid = false;
+      var scp = this.get('scopes');
+      var idx =  _.findIndex(scp, function (o) {
+         return o.checked === true;
+      });
 
-        this.set('valid', valid);
+      if(scp.length > 0 && idx >= 0) {
+          valid = true;
+      }
 
-        return valid;
+      if(scp.length == 0) {
+          valid = true;
+      }
+
+      this.set('valid', valid);
+
+      return valid;
     }
 });

--- a/src/main/javascript/view/Oauth2Model.js
+++ b/src/main/javascript/view/Oauth2Model.js
@@ -31,7 +31,7 @@ SwaggerUi.Models.Oauth2Model = Backbone.Model.extend({
           valid = true;
       }
 
-      if(scp.length == 0) {
+      if(scp.length === 0) {
           valid = true;
       }
 


### PR DESCRIPTION
This implements the fix in https://github.com/swagger-api/swagger-ui/issues/2150.

I have tested it and can authorize without any scopes defined in path and securityDefinition.