### PR TITLE
Logout view didn't show username for basic authentication

### DIFF
--- a/src/main/javascript/view/AuthsCollection.js
+++ b/src/main/javascript/view/AuthsCollection.js
@@ -69,7 +69,7 @@ SwaggerUi.Collections.AuthsCollection = Backbone.Collection.extend({
         var authz = Object.assign({}, window.swaggerUi.api.clientAuthorizations.authz);
 
         return _.map(data, function (auth, name) {
-            var isBasic = authz.basic && auth.type === 'basic';
+            var isBasic = authz.basicAuth && auth.type === 'basic';
 
             _.extend(auth, {
                 title: name
@@ -79,8 +79,8 @@ SwaggerUi.Collections.AuthsCollection = Backbone.Collection.extend({
                 _.extend(auth, {
                     isLogout: true,
                     value: isBasic ? undefined : authz[name].value,
-                    username: isBasic ? authz.basic.username : undefined,
-                    password: isBasic ? authz.basic.password : undefined,
+                    username: isBasic ? authz.basicAuth.username : undefined,
+                    password: isBasic ? authz.basicAuth.password : undefined,
                     valid: true
                 });
             }


### PR DESCRIPTION
Username was not displayed when logged in with basic authentication because _window.swaggerUi.api.clientAuthorizations.authz.basic_ is undefined. Using _window.swaggerUi.api.clientAuthorizations.authz.basicAuth_ instead.

![logout](https://cloud.githubusercontent.com/assets/1659631/15993640/f2e77686-30ec-11e6-871a-1e82eb3aa98e.png)
