### PR TITLE
Add support for JWT token based authentication

### DIFF
--- a/lib/swagger-jwt-auth.js
+++ b/lib/swagger-jwt-auth.js
@@ -1,0 +1,104 @@
+;(function (namespace, $) {
+    'use strict';
+
+    if (!namespace) {
+        throw new Error('Swagger-JWT-Auth: Please include this extension after including the SwaggerUI library!');
+    }
+
+    var JwtAuthorization = function JwtAuthorization(options) {
+        options = options || {};
+
+        this.name = 'Authorization';
+        this.headerType = options.headerType || 'Bearer';
+        this.tokenString = '';
+        this.token = null;
+        this.tokenPropertyName = options.tokenPropertyName || 'access_token';
+        this.username = options.username || undefined;
+        this.password = options.password || undefined;
+    };
+
+    JwtAuthorization.prototype.apply = function (obj) {
+        if (typeof obj.headers[this.name] === 'undefined') {
+            obj.headers[this.name] = this.headerType + ' ' + this.tokenString;
+        }
+
+        return true;
+    };
+
+    JwtAuthorization.prototype.createPayload = function (username, password) {
+        return {
+            username: username,
+            password: password
+        };
+    };
+
+    JwtAuthorization.prototype.getToken = function (url, cb) {
+        var payload = this.createPayload(this.username, this.password);
+
+        $.ajax({
+            url: url,
+            type: 'POST',
+            data: JSON.stringify(payload),
+            contentType: 'application/json',
+            success: function (response) {
+                var token;
+
+                if (response) {
+                    if (response.error) {
+                        cb(new Error('JWT auth error:' + response.error));
+                    }
+
+                    if (response.status === 401 || response.status === 403) {
+                        cb(new Error('JWT auth error: Authentication failed! Status code: ' + response.code));
+                    }
+
+                    token = response[this.tokenPropertyName];
+
+                    if (!token) {
+                        cb(new Error('JWT auth error: Unable to find token from the response with property name: ' +
+                            this.tokenPropertyName));
+                    }
+
+                    try {
+                        this.token = this.parseToken(token);
+                    } catch (e) {
+                        cb(new Error('JWT auth error: Received invalid JWT token!'));
+                    }
+
+                    this.tokenString = token;
+
+                    cb(null, token);
+                }
+
+            }.bind(this),
+
+            error: function (response) {
+                cb(new Error('JWT auth error: Authentication failed! Status code: ' + response.status));
+            }
+        });
+    };
+
+    JwtAuthorization.prototype.parseToken = function (token) {
+        var tokenArr, base64;
+
+        // Skip the validation if atob() is not available, e.g. in IE8-IE10
+        // A proper polyfill should be provided outside of this module, if required.
+        if (!window.atob) {
+            return;
+        }
+
+        tokenArr = token.split('.');
+
+        if (tokenArr.length !== 3) {
+            throw new Error('JwtAuthorization::parseToken: Invalid JWT Token!')
+        }
+
+        base64 = tokenArr[1].replace('-', '+').replace('_', '/');
+
+        return JSON.parse(window.atob(base64))
+    };
+
+
+    namespace['JwtAuthorization'] = JwtAuthorization;
+
+}(window.SwaggerUi, $));

--- a/src/main/html/index.html
+++ b/src/main/html/index.html
@@ -26,6 +26,7 @@
   <script src='lib/jsoneditor.min.js' type='text/javascript'></script>
   <script src='lib/marked.js' type='text/javascript'></script>
   <script src='lib/swagger-oauth.js' type='text/javascript'></script>
+  <script src='lib/swagger-jwt-auth.js' type='text/javascript'></script>
 
   <!-- Some basic translations -->
   <!-- <script src='lang/translator.js' type='text/javascript'></script> -->

--- a/src/main/javascript/view/AuthView.js
+++ b/src/main/javascript/view/AuthView.js
@@ -24,7 +24,7 @@ SwaggerUi.Views.AuthView = Backbone.View.extend({
         authBtn: '.auth_submit__button'
     },
 
-    initialize: function(opts) {
+    initialize: function (opts) {
         this.options = opts || {};
         opts.data = opts.data || {};
         this.router = this.options.router;
@@ -74,6 +74,8 @@ SwaggerUi.Views.AuthView = Backbone.View.extend({
                 this.router.api.clientAuthorizations.add(auth.get('title'), basicAuth);
             } else if (type === 'oauth2') {
                 this.handleOauth2Login(auth);
+            } else if (type === 'jwt') {
+                basicAuth = this.handleJwtAuthLogin(auth);
             }
         }, this);
 
@@ -106,24 +108,24 @@ SwaggerUi.Views.AuthView = Backbone.View.extend({
         window.enabledScopes = scopes;
         var flow = auth.get('flow');
 
-        if(auth.get('type') === 'oauth2' && flow && (flow === 'implicit' || flow === 'accessCode')) {
+        if (auth.get('type') === 'oauth2' && flow && (flow === 'implicit' || flow === 'accessCode')) {
             dets = auth.attributes;
             url = dets.authorizationUrl + '?response_type=' + (flow === 'implicit' ? 'token' : 'code');
             window.swaggerUi.tokenName = dets.tokenName || 'access_token';
             window.swaggerUi.tokenUrl = (flow === 'accessCode' ? dets.tokenUrl : null);
             state = window.OAuthSchemeKey;
         }
-        else if(auth.get('type') === 'oauth2' && flow && (flow === 'application')) {
+        else if (auth.get('type') === 'oauth2' && flow && (flow === 'application')) {
             dets = auth.attributes;
             window.swaggerUi.tokenName = dets.tokenName || 'access_token';
             this.clientCredentialsFlow(scopes, dets.tokenUrl, window.OAuthSchemeKey);
             return;
         }
-        else if(auth.get('grantTypes')) {
+        else if (auth.get('grantTypes')) {
             // 1.2 support
             var o = auth.get('grantTypes');
-            for(var t in o) {
-                if(o.hasOwnProperty(t) && t === 'implicit') {
+            for (var t in o) {
+                if (o.hasOwnProperty(t) && t === 'implicit') {
                     dets = o[t];
                     ep = dets.loginEndpoint.url;
                     url = dets.loginEndpoint.url + '?response_type=token';
@@ -152,6 +154,74 @@ SwaggerUi.Views.AuthView = Backbone.View.extend({
         window.open(url);
     },
 
+    handleJwtAuthLogin: function (auth) {
+        var defs = auth.attributes;
+        var authUrl = defs.authorizationUrl;
+        var headerType = defs.authHeaderType || 'Bearer';
+        var tokenProperty = defs.tokenPropertyName || 'access_token';
+        var username = auth.get('username');
+        var password = auth.get('password');
+
+        var payload = {
+            username: username,
+            password: password
+        };
+
+        var JwtAuthorization = function JwtAuthorization(token, headerType, username) {
+            this.name = 'Authorization';
+            this.headerType = headerType;
+            this.token = token;
+            this.username = username || 'N/A';
+            this.password = 'nope';
+        };
+
+        JwtAuthorization.prototype.apply = function (obj) {
+            if (typeof obj.headers[this.name] === 'undefined') {
+                obj.headers[this.name] = this.headerType + ' ' + this.token;
+            }
+
+            return true;
+        };
+
+        $.ajax({
+            url: authUrl,
+            type: 'POST',
+            data: JSON.stringify(payload),
+            contentType: 'application/json',
+            success: function (response) {
+                var token;
+
+                if (response) {
+                    if (response.error) {
+                        console.error('JWT auth error:' + response.error);
+
+                        return;
+                    }
+
+                    token = response[tokenProperty];
+
+                    if (!token) {
+                        console.log('JWT auth error: Unable to find token data from the response with property name: ' +
+                            tokenProperty);
+
+                        return;
+                    }
+
+                    window.swaggerUi.api.clientAuthorizations.add(auth.get('title'),
+                        new JwtAuthorization(token, headerType, username));
+
+                    window.swaggerUi.load();
+
+                }
+
+            }.bind(this),
+            error: function (response) {
+                console.error('JWT auth error: ', response.status);
+            }
+        });
+
+    },
+
     // taken from lib/swagger-oauth.js
     clientCredentialsFlow: function (scopes, tokenUrl, OAuthSchemeKey) {
         var params = {
@@ -161,15 +231,13 @@ SwaggerUi.Views.AuthView = Backbone.View.extend({
             'grant_type': 'client_credentials'
         };
         $.ajax({
-            url : tokenUrl,
+            url: tokenUrl,
             type: 'POST',
             data: params,
-            success: function (data)
-            {
+            success: function (data) {
                 onOAuthComplete(data, OAuthSchemeKey);
             },
-            error: function ()
-            {
+            error: function () {
                 onOAuthComplete('');
             }
         });

--- a/src/main/javascript/view/AuthsCollection.js
+++ b/src/main/javascript/view/AuthsCollection.js
@@ -37,6 +37,9 @@ SwaggerUi.Collections.AuthsCollection = Backbone.Collection.extend({
                 case 'apiKey':
                     result = new SwaggerUi.Models.ApiKeyAuthModel(model);
                     break;
+                case 'jwt':
+                    result = new SwaggerUi.Models.JwtAuthModel(model);
+                    break;
                 default:
                     result = new Backbone.Model(model);
             }
@@ -69,7 +72,8 @@ SwaggerUi.Collections.AuthsCollection = Backbone.Collection.extend({
         var authz = Object.assign({}, window.swaggerUi.api.clientAuthorizations.authz);
 
         return _.map(data, function (auth, name) {
-            var isBasic = authz[name] && auth.type === 'basic' && authz[name].username && authz[name].password;
+            var isBasic = authz[name] && (auth.type === 'basic' || auth.type === 'jwt') &&
+                authz[name].username && authz[name].password;
 
             _.extend(auth, {
                 title: name

--- a/src/main/javascript/view/AuthsCollectionView.js
+++ b/src/main/javascript/view/AuthsCollectionView.js
@@ -33,6 +33,8 @@ SwaggerUi.Views.AuthsCollectionView = Backbone.View.extend({
             authViewName = 'BasicAuthView';
         } else if (type === 'oauth2') {
             authViewName = 'Oauth2View';
+        } else if (type === 'jwt') {
+            authViewName = 'JwtAuthView';
         }
 
         if (authViewName) {

--- a/src/main/javascript/view/JwtAuthModel.js
+++ b/src/main/javascript/view/JwtAuthModel.js
@@ -1,0 +1,21 @@
+'use strict';
+
+SwaggerUi.Models.JwtAuthModel = Backbone.Model.extend({
+    defaults: {
+        username: '',
+        password: '',
+        title: 'jwt'
+    },
+
+    initialize: function () {
+        this.on('change', this.validate);
+    },
+
+    validate: function () {
+        var valid = !!this.get('password') && !!this.get('username');
+
+        this.set('valid', valid);
+
+        return valid;
+    }
+});

--- a/src/main/javascript/view/JwtAuthView.js
+++ b/src/main/javascript/view/JwtAuthView.js
@@ -1,0 +1,53 @@
+'use strict';
+
+SwaggerUi.Views.JwtAuthView = Backbone.View.extend({
+
+    initialize: function (opts) {
+        this.options = opts || {};
+        this.router = this.options.router;
+    },
+
+    events: {
+        'change .auth_input': 'inputChange'
+    },
+
+    selectors: {
+        usernameInput: '.basic_auth__username',
+        passwordInput: '.basic_auth__password'
+    },
+
+    cls: {
+        error: 'error'
+    },
+
+    template: Handlebars.templates.jwt_auth,
+
+    render: function(){
+        $(this.el).html(this.template(this.model.toJSON()));
+
+        return this;
+    },
+
+    inputChange: function (e) {
+        var $el = $(e.target);
+        var val = $el.val();
+        var attr = $el.prop('name');
+
+        if (val) {
+            $el.removeClass(this.cls.error);
+        }
+
+        this.model.set(attr, val);
+
+    },
+
+    isValid: function () {
+        return this.model.validate();
+    },
+
+    highlightInvalid: function () {
+        if (!this.model.get('username')) {
+            this.$(this.selectors.usernameInput).addClass(this.cls.error);
+        }
+    }
+});

--- a/src/main/template/jwt_auth.handlebars
+++ b/src/main/template/jwt_auth.handlebars
@@ -1,0 +1,20 @@
+<div class='jwt_auth_container'>
+    <h3 class="auth__title">JWT Authentication{{#if isLogout}} - authorized{{/if}}</h3>
+    <form class="basic_input_container">
+        <div class="auth__description">{{description}}</div>
+        <div class="auth_label">
+            <span class="basic_auth__label" data-sw-translate>username:</span>
+            {{#if isLogout}}
+                <span class="basic_auth__value">{{username}}</span>
+            {{else}}
+                <input required placeholder="username" class="basic_auth__username auth_input" name="username" type="text"/>
+            {{/if}}
+        </div>
+        {{#unless isLogout}}
+            <div class="auth_label">
+                <span class="basic_auth__label" data-sw-translate>password:</span>
+                <input required placeholder="password" class="basic_auth__password auth_input" name="password" type="password"/>
+            </div>
+        {{/unless}}
+    </form>
+</div>


### PR DESCRIPTION
This pull request adds support for JWT token based authentication in Swagger UI. 

The motivation of adding this feature is that many organizations (including my organization) secure their apis with JWT based authentication. Earlier approaches in implementing this feature have been hacky at best, or they have modified the existing authorization schemes, such as the ApiKeyAuthorization. Many have to keep their custom code in a forked repository, which is cumbersome in the long run.

The beef of this feature is in separated and optional JwtAuthorization module that can be included in index.html if JWT authentication is required. So there are only minimal changes in the Swagger UI itself. The module has been included in the example index.html.

JwtAuthorization implements the following features: 1. Login with credentials 2. Fetch the JWT token from the login endpoint and perform a light token validation 3. Inject the token automatically in Swagger UI REST queries in the Authorization header.

One can activate the JWT authorization by using the securityDefinitions option in the swagger spec:
```JSON
"securityDefinitions": {
    "jwt": {
        "type": "jwt",
        "authHeaderType": "JWT",
        "tokenPropertyName": "access_token",
        "authorizationUrl": "your-authserver-url.com/auth",
        "description": "Please log in by using your email as an username."
    }
}
```
* The **"type"** option is *required*.
* Option **"authorizationUrl"** is required. This defines URL to the REST endpoint which is used for the JWT authentication. The option respects the "schemes" protocol definitions, i.e. if "scheme":"https" or "schemes": ["https"] is used, 'https://' is injected automatically in front of the authorizationUrl.
* Option **"authHeaderType"** is *optional*. It defines the token type of the injected Authorization header. The default value is *'Bearer'*, althought using *'JWT'* is adviced.
* Option **"tokenPropertyName"** is *optional*. This defines the property name which is used for getting the token data from the auth endpoint JSON response. The default value is *'access_token'*.

One can also customize how the login payload is structured in the client before it is sent to the server, by adding the following code snippet before loading the Swagger UI:
```JavaScript
// This is the default behaviour of the module. 
// As result, payload {"username":"yourUsername","password":"yourPassword"}' will be 
// sent to your authorization endpoint.
JwtAuthorization.prototype.createPayload = function (username, password) {
    return {
        username: username,
        password: password
    };
};

// You can modify it to serve your needs:
JwtAuthorization.prototype.createPayload = function (username, password) {
    return {
        email: username,
        pwd: password
    };
};

```


