### PR TITLE
Fix issue #2238

### DIFF
--- a/src/main/javascript/view/AuthButtonView.js
+++ b/src/main/javascript/view/AuthButtonView.js
@@ -39,6 +39,10 @@ SwaggerUi.Views.AuthButtonView = Backbone.View.extend({
             content: this.$authEl
         };
 
+        // The content of the popup is removed and all events unbound after clicking the 'Cancel' button of the popup.
+        // We'll have to re-render the contents before creating a new popup view.
+        this.render();
+
         this.popup = new SwaggerUi.Views.PopupView({model: authsModel});
         this.popup.render();
     },


### PR DESCRIPTION
This pull request fixes #2238. 
I encountered this issue as well, when doing changes related to authorization schemes.

The cause of the issue is in the PopupView 'cancel' button click event handler. It will invoke 'this.remove()', which removes all the child elements of the popup and will also unbind all the events bound to the child elements. By re-rendering the AuthButtonView before creating a new PopupView object, we rebind all the unbound button events.