### PR TITLE
Set default oauth scope separator to whitespace

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -59,7 +59,7 @@
               clientSecret: "your-client-secret-if-required",
               realm: "your-realms",
               appName: "your-app-name",
-              scopeSeparator: ",",
+              scopeSeparator: " ",
               additionalQueryStringParams: {}
             });
           }


### PR DESCRIPTION
Fix #1598