### PR TITLE
show operation id in operations heading

### DIFF
--- a/src/main/template/operation.handlebars
+++ b/src/main/template/operation.handlebars
@@ -11,7 +11,7 @@
         </h3>
         <ul class='options'>
           <li>
-          <a href='#!/{{encodedParentId}}/{{nickname}}' class="toggleOperation">{{{summary}}}</a>
+          <a href='#!/{{encodedParentId}}/{{nickname}}' class="toggleOperation">{{{summary}}}{{#if nickname}} ({{nickname}}){{/if}}</a>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
The operationId is important to know if one uses for example swagger-js.
