### PR TITLE
Allow swaggerRequestHeaders as url parameter to index.html

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -35,6 +35,7 @@
       } else {
         url = "http://petstore.swagger.io/v2/swagger.json";
       }
+      var swaggerRequestHeaders = window.location.search.match(/swaggerRequestHeaders=([^&]+)/);
 
       // Pre load translate...
       if(window.SwaggerTranslator) {
@@ -42,6 +43,7 @@
       }
       window.swaggerUi = new SwaggerUi({
         url: url,
+        swaggerRequestHeaders: swaggerRequestHeaders,
         dom_id: "swagger-ui-container",
         supportedSubmitMethods: ['get', 'post', 'put', 'delete', 'patch'],
         onComplete: function(swaggerApi, swaggerUi){

--- a/src/main/html/index.html
+++ b/src/main/html/index.html
@@ -35,6 +35,7 @@
       } else {
         url = "http://petstore.swagger.io/v2/swagger.json";
       }
+      var swaggerRequestHeaders = window.location.search.match(/swaggerRequestHeaders=([^&]+)/);
 
       // Pre load translate...
       if(window.SwaggerTranslator) {
@@ -42,6 +43,7 @@
       }
       window.swaggerUi = new SwaggerUi({
         url: url,
+        swaggerRequestHeaders: swaggerRequestHeaders,
         dom_id: "swagger-ui-container",
         supportedSubmitMethods: ['get', 'post', 'put', 'delete', 'patch'],
         onComplete: function(swaggerApi, swaggerUi){


### PR DESCRIPTION
It's nice if you can have a running swagger-ui somewhere and just url-link to a swagger-spec
you have in source control. That would look like this:

https://acme.com/swaggerui/?url=../bitbucket/repos/spec/browse/spec.json?raw

Sadly this breaks for bitbucket and similar tools, because swagger-ui requests the spec as 'application/json' by default.

The new url-parameter 'swaggerRequestHeaders' solves this problem by using the existing
configuration option 'swaggerRequestHeaders'. For example like so:

https://acme.com/swaggerui/?swaggerRequestHeaders=text/html&url=../bitbucket/repos/spec/browse/spec.json?raw
