### PR TITLE
Update README.md - clarify Dockerfile location

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,11 @@ Use `npm run serve` to make a new build, watch for changes, and serve the result
 
 ### Build using Docker
 
-To build swagger-ui using a docker container:
+To build swagger-ui using a docker container.
+
+1. git clone https://github.com/swagger-api/swagger-ui.git or download (see above)
+2. cd swagger-ui
+3. build via `docker build` as follows:
 
 ```
 docker build -t swagger-ui-builder .


### PR DESCRIPTION
Clarify Dockerfile location used in `docker build` step.  

There is not a reference (near the instructions) on where the Dockerfile comes from.  This hopefully makes it apparent without tying it down to a fixed location (swagger-ui/Dockerfile.)  Many people understand to look in the repo, but many don't (copy / paste crowd.)

Keep up the good work!
