### PR TITLE
Added support for passing through a basePath override.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ swaggerUi.load();
 Parameter Name | Description
 --- | ---
 url | The url pointing to `swagger.json` (Swagger 2.0) or the resource listing (earlier versions) as per [OpenAPI Spec](https://github.com/OAI/OpenAPI-Specification/).
+basePath | An override value for the base path of the API.  This should not be necessary unless the API is served from behind a reverse proxy that maps a different path to the basePath given in the specification.
 authorizations | An authorization object to be passed to swagger-js.  Setting it here will trigger inclusion of any authorization or custom signing logic when fetching the swagger description file.  Note the object structure should be `{ key: AuthorizationObject }`
 spec | A JSON object describing the OpenAPI Specification. When used, the `url` parameter will not be parsed. This is useful for testing manually-generated specifications without hosting them. Works for Swagger 2.0 specs only.
 validatorUrl | By default, Swagger-UI attempts to validate specs against swagger.io's online validator. You can use this parameter to set a different validator URL, for example for locally deployed validators ([Validator Badge](https://github.com/swagger-api/validator-badge)). Setting it to `null` will disable validation. This parameter is relevant for Swagger 2.0 specs only.

--- a/src/main/javascript/SwaggerUi.js
+++ b/src/main/javascript/SwaggerUi.js
@@ -139,6 +139,12 @@ window.SwaggerUi = Backbone.Router.extend({
   render: function(){
     var authsModel;
     this.showMessage('Finished Loading Resource Information. Rendering Swagger UI...');
+    // If the basePath given in the spec needs to be overridden, we have to do it after
+    // the client object is fully initialized, which is to say here:
+    if (this.options.basePath) {
+      this.api.setBasePath(this.options.basePath);
+    }
+
     this.mainView = new SwaggerUi.Views.MainView({
       model: this.api,
       el: $('#' + this.dom_id),


### PR DESCRIPTION
For cases where the API is being served from behind a reverse proxy, added support for setting the basePath of the SwaggerClient object using an option in SwaggerUI construction.

Since this needs to happen after the client has parsed the specification, the update is hooked into the "render" method, despite that sounding kind of weird when you write it down.
