### PR TITLE
Remove unnecessary escaping of model signature

### DIFF
--- a/src/main/template/signature.handlebars
+++ b/src/main/template/signature.handlebars
@@ -9,7 +9,7 @@
 
 <div class="signature-container">
   <div class="description">
-    {{{escape signature}}}
+    {{{signature}}}
   </div>
 
   <div class="snippet">


### PR DESCRIPTION
Signature body was not being formatted correctly since the HTML was being escaped. Example as follows:

<img width="981" alt="invalidformatting" src="https://cloud.githubusercontent.com/assets/609977/17917390/5e496434-69ff-11e6-8c8a-53785bace0e1.png">
