### PR TITLE
support multiple swaggerUI / resource views on same page

### DIFF
--- a/src/main/javascript/view/MainView.js
+++ b/src/main/javascript/view/MainView.js
@@ -126,7 +126,7 @@ SwaggerUi.Views.MainView = Backbone.View.extend({
       auths: auths,
       swaggerOptions: this.options.swaggerOptions
     });
-    $('#resources', this.el).append(resourceView.render().el);
+    this.$('#resources', this.el).append(resourceView.render().el);
   },
 
   clear: function(){


### PR DESCRIPTION
When there are multiple SwaggerUi instances on one page, the MainView renders all resources into the same `#resource` DOM element, even if the SwaggerUi instances are attached to a different `dom_id`.  

This fixes the problem by using the fact that Backbone views have a scoped jquery instance available as `this.$`. Unfortunately I don't have the time available to produce a fully working example.
