### PR TITLE
Feature: add responseHooks option for callbacks on responses

### DIFF
--- a/src/main/javascript/view/OperationView.js
+++ b/src/main/javascript/view/OperationView.js
@@ -788,6 +788,11 @@ SwaggerUi.Views.OperationView = Backbone.View.extend({
       $('.request_headers', $(this.el)).html('<pre>' + _.escape(JSON.stringify(requestHeaders, null, '  ')).replace(/\n/g, '<br>') + '</pre>');
     }
 
+    // Call user-defined hook
+    if (opts.responseHooks && opts.responseHooks[this.nickname]) {
+      opts.responseHooks[this.nickname](response, this);
+    }
+
     var response_body_el = $('.response_body', $(this.el))[0];
     // only highlight the response if response is less than threshold, default state is highlight response
     if (opts.highlightSizeThreshold && typeof response.data !== 'undefined' && response.data.length > opts.highlightSizeThreshold) {


### PR DESCRIPTION
Add a `responseHooks` option that allows the user to process the response of an API call.
The `responseHooks` option is an object where key is an `operationId` (`nickname`) and value is a function that receives the XHR response object and the `OperationView` object.

Use case: process authentication requests done with the "Try out!" button to inject apiKey in the AuthView and the router on success. I've been able to successfully implement this.
