### PR TITLE
Fix font src attribute

### DIFF
--- a/src/main/html/css/typography.css
+++ b/src/main/html/css/typography.css
@@ -3,12 +3,12 @@
   font-family: 'Droid Sans';
   font-style: normal;
   font-weight: 400;
-  src: local('Droid Sans'), local('DroidSans'), url('../fonts/DroidSans.ttf'), format('truetype');
+  src: local('Droid Sans'), local('DroidSans'), url('../fonts/DroidSans.ttf') format('truetype');
 }
 /* Google Font's Droid Sans Bold */
 @font-face {
   font-family: 'Droid Sans';
   font-style: normal;
   font-weight: 700;
-  src: local('Droid Sans Bold'), local('DroidSans-Bold'), url('../fonts/DroidSans-Bold.ttf'), format('truetype');
+  src: local('Droid Sans Bold'), local('DroidSans-Bold'), url('../fonts/DroidSans-Bold.ttf') format('truetype');
 }


### PR DESCRIPTION
The `format('truetype')` bit should not be preceded by a comma. It breaks in Chrome (at least).

See https://css-tricks.com/snippets/css/using-font-face/ for an example.