### PR TITLE
Fix #2369 - include js-yaml in index.html so string examples don't fail

### DIFF
--- a/src/main/html/index.html
+++ b/src/main/html/index.html
@@ -24,6 +24,7 @@
   <script src='lib/highlight.9.1.0.pack.js' type='text/javascript'></script>
   <script src='lib/highlight.9.1.0.pack_extended.js' type='text/javascript'></script>
   <script src='lib/jsoneditor.min.js' type='text/javascript'></script>
+  <script src='lib/js-yaml.min.js' type='text/javascript'></script>
   <script src='lib/marked.js' type='text/javascript'></script>
   <script src='lib/swagger-oauth.js' type='text/javascript'></script>
 

--- a/src/main/javascript/view/partials/signature.js
+++ b/src/main/javascript/view/partials/signature.js
@@ -561,7 +561,13 @@ SwaggerUi.partials.signature = (function () {
         if(key.indexOf('application/json') === 0) {
           var example = value.examples[key];
           if (_.isString(example)) {
-            example = jsyaml.safeLoad(example);
+            try {
+              example = jsyaml.safeLoad(example);
+            } catch (e) {
+              if (console) {
+                (console.error || console.log).call(console, e);
+              }
+            }
           }
           value.definition.example = example;
           return schemaToJSON(value.definition, example, modelsToIgnore, value.modelPropertyMacro);
@@ -573,7 +579,13 @@ SwaggerUi.partials.signature = (function () {
       value = _.cloneDeep(value);
       var example = value.examples;
       if (_.isString(example)) {
-        example = jsyaml.safeLoad(example);
+        try {
+          example = jsyaml.safeLoad(example);
+        } catch (e) {
+          if (console) {
+            (console.error || console.log).call(console, e);
+          }
+        }
       }
       value.definition.example = example;
       return schemaToJSON(value.definition, example, modelsToIgnore, value.modelPropertyMacro);


### PR DESCRIPTION
Fixes #2369.  Add back js-yaml to index.html and make parsing of strings tolerant of bad data.
