### PR TITLE
Fix tag names in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ The OpenAPI Specification has undergone 4 revisions since initial creation in 20
 
 Swagger UI Version | Release Date | OpenAPI Spec compatibility | Notes | Status
 ------------------ | ------------ | -------------------------- | ----- | ------
-2.2.6              | 2016-10-14   | 1.1, 1.2, 2.0              | [tag v.2.2.6](https://github.com/swagger-api/swagger-ui/tree/v2.2.6) |
-2.1.5              | 2016-07-20   | 1.1, 1.2, 2.0              | [tag v.2.1.5](https://github.com/swagger-api/swagger-ui/tree/v2.1.5) |
+2.2.6              | 2016-10-14   | 1.1, 1.2, 2.0              | [tag v2.2.6](https://github.com/swagger-api/swagger-ui/tree/v2.2.6) |
+2.1.5              | 2016-07-20   | 1.1, 1.2, 2.0              | [tag v2.1.5](https://github.com/swagger-api/swagger-ui/tree/v2.1.5) |
 2.0.24             | 2014-09-12   | 1.1, 1.2 | [tag v2.0.24](https://github.com/swagger-api/swagger-ui/tree/v2.0.24) |
 1.0.13             | 2013-03-08   | 1.1, 1.2 | [tag v1.0.13](https://github.com/swagger-api/swagger-ui/tree/v1.0.13) |
 1.0.1              | 2011-10-11   | 1.0, 1.1 | [tag v1.0.1](https://github.com/swagger-api/swagger-ui/tree/v1.0.1)   |


### PR DESCRIPTION
The repo's tag names don't start with a `.`.