### PR TITLE
Add tasks to gulpfile to minify all CSS and JS libs when building dist, removes 11000 lines from dist

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -142,7 +142,7 @@ gulp.task('uglify-libs', function() {
      */
     gulp.src('./dist/lib/*.js')
         .pipe(uglify())
-        .pipe(gulp.dest('./dist/lib'))
+        .pipe(gulp.dest('./dist/lib'));
 });
 
 /**

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,9 +13,9 @@ var connect = require('gulp-connect');
 var header = require('gulp-header');
 var order = require('gulp-order');
 var jshint = require('gulp-jshint');
-var pkg = require('./package.json');
 var runSequence = require('run-sequence');
 var cssnano = require('gulp-cssnano');
+var pkg = require('./package.json');
 
 var banner = ['/**',
   ' * <%= pkg.name %> - <%= pkg.description %>',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,6 +14,8 @@ var header = require('gulp-header');
 var order = require('gulp-order');
 var jshint = require('gulp-jshint');
 var pkg = require('./package.json');
+var runSequence = require('run-sequence');
+var cssnano = require('gulp-cssnano');
 
 var banner = ['/**',
   ' * <%= pkg.name %> - <%= pkg.description %>',
@@ -126,6 +128,23 @@ gulp.task('copy-local-specs', function () {
     .on('error', log);
 });
 
+gulp.task('minify-css', function() {
+    /** Minify all CSS within dist folder, runs after dist process*/
+
+    return gulp.src('./dist/css/*.css')
+        .pipe(cssnano())
+        .pipe(gulp.dest('./dist/css'));
+});
+
+gulp.task('uglify-libs', function() {
+    /**
+     * Minify all JS libs within the dist folder.  A nice TODO would be to use versions from CDN
+     */
+    gulp.src('./dist/lib/*.js')
+        .pipe(uglify())
+        .pipe(gulp.dest('./dist/lib'))
+});
+
 /**
  * Watch for changes and recompile
  */
@@ -162,7 +181,11 @@ gulp.task('handlebars', function () {
         .on('error', log);
 });
 
-gulp.task('default', ['dist', 'copy']);
+gulp.task('default', function(callback) {
+    runSequence(['dist', 'copy'],
+                ['uglify-libs', 'minify-css'],
+                callback);
+});
 gulp.task('serve', ['connect', 'watch']);
 gulp.task('dev', ['default'], function () {
   gulp.start('serve');

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "gulp-clean": "^0.3.1",
     "gulp-concat": "^2.5.2",
     "gulp-connect": "^2.2.0",
+    "gulp-cssnano": "^2.1.2",
     "gulp-declare": "^0.3.0",
     "gulp-header": "^1.2.2",
     "gulp-jshint": "^1.10.0",
@@ -58,6 +59,7 @@
     "less": "^2.4.0",
     "mocha": "^2.1.0",
     "phantomjs": "1.9.19",
+    "run-sequence": "^1.2.2",
     "selenium-webdriver": "^2.45.0",
     "sinon-chai": "2.8.0",
     "swagger-client": "2.1.23"


### PR DESCRIPTION
When working with the generated dist, I noticed the some of the libs in the JS libs folder and all the CSS are not minimized.  Local testing showed this removes over 11,000 lines from dist 😄 

This PR adds tasks to the gulpfile to ensure that everything gets minimized, which should help perf.

I've tested this locally and am happy the dist still functions as expected.  It's not the most beautiful solution to the problem, but it works :-) I'll create a seperate PR containing the new minimzed Dist.