### PR TITLE
Avoid using Facebook garbage fragment to complete login

### DIFF
--- a/src/main/html/o2c.html
+++ b/src/main/html/o2c.html
@@ -1,6 +1,6 @@
 <script>
 var qp = null;
-if(window.location.hash) {
+if(window.location.hash && window.location.hash !== "#_=_") {
   qp = location.hash.substring(1);
 }
 else {


### PR DESCRIPTION
Facebook adds a nonsense fragment to all redirect URIs when returning a code, to stop fragments being surreptitiously passed through the authorization flow.

See http://stackoverflow.com/questions/7131909/facebook-callback-appends-to-return-url

Before this change to o2c.html, the presence of Facebook's garbage fragment would break the Swagger UI complete page, as having any fragment value at all will cause the complete page to ignore the query string. This change avoids using the fragment if it looks to be useless.