### PR TITLE
Fix li.operation div.content overflow

### DIFF
--- a/src/main/less/specs.less
+++ b/src/main/less/specs.less
@@ -733,6 +733,7 @@
                                 -khtml-border-bottom-right-radius: 6px;
                                 border-bottom-right-radius: 6px;
                                 margin: 0 0 20px;
+                                overflow-x: auto;
                                 h4 {
                                     font-size: 1.1em;
                                     margin: 0;


### PR DESCRIPTION
When a description of an operation was too long, it overflows box without possibility to scroll the content (on page .../swagger/ui/index.html). This pull request fix the problem and add poissibity to scroll x-overflow if it overflows.