### PR TITLE
Use gulp-sourcemaps to generate a sourcemap

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,6 +14,8 @@ var header = require('gulp-header');
 var order = require('gulp-order');
 var jshint = require('gulp-jshint');
 var pkg = require('./package.json');
+var sourcemaps = require('gulp-sourcemaps');
+
 
 var banner = ['/**',
   ' * <%= pkg.name %> - <%= pkg.description %>',
@@ -58,10 +60,12 @@ function _dist() {
         .src(['./src/main/template/templates.js'])
         .on('error', log)
     )
+    .pipe(sourcemaps.init({loadMaps: true}))
     .pipe(order(['scripts.js', 'templates.js']))
     .pipe(concat('swagger-ui.js'))
     .pipe(wrap('(function(){<%= contents %>}).call(this);'))
     .pipe(header(banner, { pkg: pkg }))
+    .pipe(sourcemaps.write())
     .pipe(gulp.dest('./dist'))
     .pipe(uglify())
     .on('error', log)

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "gulp-less": "^3.0.1",
     "gulp-order": "^1.1.1",
     "gulp-rename": "^1.2.0",
+    "gulp-sourcemaps": "^2.2.0",
     "gulp-uglify": "^1.1.0",
     "gulp-watch": "^4.1.1",
     "gulp-wrap": "^0.11.0",


### PR DESCRIPTION
Chrome gets very confused by the sourceMappingURL from swagger-client.js. Use
gulp-sourcemaps to generate our own sourcemap which it is happier with (and
means that the other bits of swagger-ui.js are also correctly sourcemapped).