### PR TITLE
On complete, ignore fragments that don't contain useful information

### DIFF
--- a/src/main/html/o2c.html
+++ b/src/main/html/o2c.html
@@ -1,6 +1,6 @@
 <script>
 var qp = null;
-if(window.location.hash && window.location.hash !== "#_=_") {
+if(/code|token|error/.test(window.location.hash)) {
   qp = location.hash.substring(1);
 }
 else {


### PR DESCRIPTION
Auth providers like Facebook and Google tend to add garbage fragments onto OAuth 2.0 redirect URIs to stop malicious fragments being maintained through the flow. This change ensures that those fragments aren't mistakenly used to attempt to complete login.

If the fragment contains a code, token or error, it is assumed to be the correct place to find data provided by the auth provider.

As discussed in #2489, this change provides a more complete solution to the problem.