### PR TITLE
Upgrade to alpine:3.4 and fix issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM alpine:3.3
+FROM alpine:3.4
 
 MAINTAINER Roman Tarnavski
 
 RUN apk add --update nginx
+RUN mkdir -p /run/nginx
 
 COPY nginx.conf /etc/nginx/
 ADD ./dist/ /usr/share/nginx/html

--- a/nginx.conf
+++ b/nginx.conf
@@ -17,7 +17,7 @@ http {
     server_name       localhost;
 
     location / {
-      root            html;
+      root            /usr/share/nginx/html;
       index           index.html index.htm;
       if ($request_method = 'OPTIONS') {
           add_header 'Access-Control-Allow-Origin' '*';


### PR DESCRIPTION
- Upgraded to alpine:3.4 from alpine:3.3.
- Bug fix: create required directory for nginx pid. Otherwise, the "no such file or directory" error will occur.
- Bug fix: the default root directory is determined by --prefix argument of nginx. It is not same as current "/usr/share/nginx/html". So we need use absolute root directory in nginx.conf.

