### PR TITLE
click the elemtent which class is 'toggleOperation' can't expand detail when the description is chinese

### DIFF
--- a/dist/swagger-ui.js
+++ b/dist/swagger-ui.js
@@ -336,7 +336,7 @@ templates['operation'] = template({"1":function(container,depth0,helpers,partial
     + "' class=\"toggleOperation\"><span class=\"markdown\">"
     + ((stack1 = (helpers.escape || (depth0 && depth0.escape) || alias2).call(alias1,(depth0 != null ? depth0.summary : depth0),{"name":"escape","hash":{},"data":data})) != null ? stack1 : "")
     + "</span></a>\n          </li>\n        </ul>\n      </div>\n      <div class='content' id='"
-    + alias3((helpers.sanitize || (depth0 && depth0.sanitize) || alias2).call(alias1,(depth0 != null ? depth0.encodedParentId : depth0),{"name":"sanitize","hash":{},"data":data}))
+    + alias3((helpers.sanitize || (depth0 && depth0.sanitize) || alias2).call(alias1,(depth0 != null ? depth0.parentId : depth0),{"name":"sanitize","hash":{},"data":data}))
     + "_"
     + alias3((helpers.sanitize || (depth0 && depth0.sanitize) || alias2).call(alias1,(depth0 != null ? depth0.nickname : depth0),{"name":"sanitize","hash":{},"data":data}))
     + "_content' style='display:none'>\n"


### PR DESCRIPTION
see issue description at https://github.com/springfox/springfox/issues/1518

eg.
        ul class="options">
          li>
          a href="#!/%E7%94%A8%E6%88%B7%E6%A8%A1%E5%9D%97/infoUsingGET" class="toggleOperation"><span class="markdown"><p>用户信息</p>
/span></a>
          /li>
        /ul>
      /div>

/////!-------------------------------there is the bug------------------------------------------------------->
/////!-------------------------------there is the bug------------------------------------------------------->
      div class="content"    id="%E7%94%A8%E6%88%B7%E6%A8%A1%E5%9D%97_infoUsingGET_content"

////!----------- id should be  '用户模块__infoUsingGET_content' --------------------->
/////!-------------------------------------------------------------------------------------------------->

        h4span data-sw-translate="">Implementation Notes /span></h4>
        div class="markdown"> p>获取用户信息</p>
div>
   .....................