### PR TITLE
[CSS] Remove refs to images that don't exist anymore.

### DIFF
--- a/src/main/less/style.less
+++ b/src/main/less/style.less
@@ -4,7 +4,6 @@
   font-size: 1.5em;
   font-weight: bold;
   text-decoration: none;
-  background: transparent url(../images/logo.png) no-repeat left center;
   padding: 20px 0 20px 40px;
 }
 
@@ -84,7 +83,6 @@
 width: 1500px;
 margin: auto;
 margin-top: 0;
-background-image: url('../images/shield.png');
 background-repeat: no-repeat;
 background-position: -40px -20px;
 margin-bottom: 210px;


### PR DESCRIPTION
Apparently, `logo.png` and `shield.png` got deleted at some point from this repo, but styles weren't updated, which in turn causes problems with static files versioning mechanisms provided by Python's Django (`django.contrib.staticfiles.storage.CachedStaticFilesStorage` and friends).