### PR TITLE
Fix escaping resource name.

### DIFF
--- a/src/main/javascript/view/MainView.js
+++ b/src/main/javascript/view/MainView.js
@@ -111,7 +111,7 @@ SwaggerUi.Views.MainView = Backbone.View.extend({
 
   addResource: function(resource, auths){
     // Render a resource and add it to resources li
-    resource.id = resource.id.replace(/\s/g, '_');
+    resource.id = resource.id.replace(/[[\]{}()*+?,\\/^$|#\s]/g, '_');
 
     // Make all definitions available at the root of the resource so that they can
     // be loaded by the JSonEditor


### PR DESCRIPTION
This pull request is related to issue #2372.

When resource name has special characters (forward slash in my case), it is not properly escaped.
This causes problems while expanding operations under a resource. More details are provided in the issue.