### PR TITLE
Add option "showOperationIds"

### DIFF
--- a/src/main/html/index.html
+++ b/src/main/html/index.html
@@ -74,7 +74,8 @@
         docExpansion: "none",
         jsonEditor: false,
         defaultModelRendering: 'schema',
-        showRequestHeaders: false
+        showRequestHeaders: false,
+        showOperationIds: false
       });
 
       window.swaggerUi.load();

--- a/src/main/javascript/view/OperationView.js
+++ b/src/main/javascript/view/OperationView.js
@@ -27,6 +27,10 @@ SwaggerUi.Views.OperationView = Backbone.View.extend({
       if (opts.swaggerOptions.showRequestHeaders) {
         this.model.showRequestHeaders = true;
       }
+
+      if (opts.swaggerOptions.showOperationIds) {
+        this.model.showOperationIds = true;
+      }
     }
     return this;
   },

--- a/src/main/less/specs.less
+++ b/src/main/less/specs.less
@@ -708,6 +708,11 @@
                                                 padding: 0;
                                                 line-height: inherit;
                                             }
+                                            .nickname {
+                                                color: #aaaaaa;
+                                                padding: 0;
+                                                line-height: inherit;
+                                            }
                                         }
                                     }
                                 }

--- a/src/main/template/operation.handlebars
+++ b/src/main/template/operation.handlebars
@@ -10,6 +10,11 @@
           </span>
         </h3>
         <ul class='options'>
+          {{#if showOperationIds}}
+          <li>
+          <a href='#!/{{sanitize encodedParentId}}/{{sanitize nickname}}' class="toggleOperation"><span class="nickname">{{{escape nickname}}}()</span></a>
+          </li>
+          {{/if}}
           <li>
           <a href='#!/{{sanitize encodedParentId}}/{{sanitize nickname}}' class="toggleOperation"><span class="markdown">{{{escape summary}}}</span></a>
           </li>


### PR DESCRIPTION
When swagger-codegen is used, the operation-Ids are used to generate method names for the target language. At the moment those operation-Id are not visible in swagger-ui. Displaying the operation-Id would ease development a lot.

This patch displays the operation Id on the right side of the operation summary. 
The variable "showRequestHeaders" in index.html must be set to true to enable this feature.