### PR TITLE
OAuth2 access token name as vendor property

### DIFF
--- a/lib/swagger-oauth.js
+++ b/lib/swagger-oauth.js
@@ -130,7 +130,7 @@ function handleLogin() {
      * @return the name of the access token parameter
      */
     function getTokenName(dets) {
-        return dets['x-tokenName'] || dets.tokenName;
+        return dets.vendorExtensions['x-tokenName'] || dets.tokenName;
     }
 
     for (var key in authSchemes) { 

--- a/lib/swagger-oauth.js
+++ b/lib/swagger-oauth.js
@@ -130,7 +130,7 @@ function handleLogin() {
      * @return the name of the access token parameter
      */
     function getTokenName(dets) {
-        return dets.tokenName;
+        return dets['x-tokenName'] || dets.tokenName;
     }
 
     for (var key in authSchemes) { 

--- a/lib/swagger-oauth.js
+++ b/lib/swagger-oauth.js
@@ -121,7 +121,18 @@ function handleLogin() {
     //TODO: merge not replace if scheme is different from any existing 
     //(needs to be aware of schemes to do so correctly)
     window.enabledScopes=scopes;    
-    
+
+    /**
+     * Returns the name of the access token parameter returned by the server.
+     *
+     * @param dets
+     *     The authorisation scheme configuration.
+     * @return the name of the access token parameter
+     */
+    function getTokenName(dets) {
+        return dets.tokenName;
+    }
+
     for (var key in authSchemes) { 
       if (authSchemes.hasOwnProperty(key) && OAuthSchemeKeys.indexOf(key) != -1) { //only look at keys that match this scope.
         var flow = authSchemes[key].flow;
@@ -129,13 +140,13 @@ function handleLogin() {
         if(authSchemes[key].type === 'oauth2' && flow && (flow === 'implicit' || flow === 'accessCode')) {
           var dets = authSchemes[key];
           url = dets.authorizationUrl + '?response_type=' + (flow === 'implicit' ? 'token' : 'code');
-          window.swaggerUi.tokenName = dets.tokenName || 'access_token';
+          window.swaggerUi.tokenName = getTokenName(dets) || 'access_token';
           window.swaggerUi.tokenUrl = (flow === 'accessCode' ? dets.tokenUrl : null);
           state = key;
         }
         else if(authSchemes[key].type === 'oauth2' && flow && (flow === 'application')) {
             var dets = authSchemes[key];
-            window.swaggerUi.tokenName = dets.tokenName || 'access_token';
+            window.swaggerUi.tokenName = getTokenName(dets) || 'access_token';
             clientCredentialsFlow(scopes, dets.tokenUrl, key);
             return;
         }        
@@ -147,13 +158,13 @@ function handleLogin() {
               var dets = o[t];
               var ep = dets.loginEndpoint.url;
               url = dets.loginEndpoint.url + '?response_type=token';
-              window.swaggerUi.tokenName = dets.tokenName;
+              window.swaggerUi.tokenName = getTokenName(dets);
             }
             else if (o.hasOwnProperty(t) && t === 'accessCode') {
               var dets = o[t];
               var ep = dets.tokenRequestEndpoint.url;
               url = dets.tokenRequestEndpoint.url + '?response_type=code';
-              window.swaggerUi.tokenName = dets.tokenName;
+              window.swaggerUi.tokenName = getTokenName(dets);
             }
           }
         }

--- a/src/main/javascript/view/AuthView.js
+++ b/src/main/javascript/view/AuthView.js
@@ -109,22 +109,33 @@ SwaggerUi.Views.AuthView = Backbone.View.extend({
         window.enabledScopes = scopes;
         var flow = auth.get('flow');
 
+        /**
+         * Returns the name of the access token parameter returned by the server.
+         *
+         * @param dets
+         *     The authorisation scheme configuration.
+         * @return the name of the access token parameter
+         */
+        function getTokenName(dets) {
+            return dets.tokenName;
+        }
+
         if(auth.get('type') === 'oauth2' && flow && (flow === 'implicit' || flow === 'accessCode')) {
             dets = auth.attributes;
             url = dets.authorizationUrl + '?response_type=' + (flow === 'implicit' ? 'token' : 'code');
-            container.tokenName = dets.tokenName || 'access_token';
+            container.tokenName = getTokenName(dets) || 'access_token';
             container.tokenUrl = (flow === 'accessCode' ? dets.tokenUrl : null);
             state = container.OAuthSchemeKey;
         }
         else if(auth.get('type') === 'oauth2' && flow && (flow === 'application')) {
             dets = auth.attributes;
-            container.tokenName = dets.tokenName || 'access_token';
+            container.tokenName = getTokenName(dets) || 'access_token';
             this.clientCredentialsFlow(scopes, dets, container.OAuthSchemeKey);
             return;
         }
         else if(auth.get('type') === 'oauth2' && flow && (flow === 'password')) {
             dets = auth.attributes;
-            container.tokenName = dets.tokenName || 'access_token';
+            container.tokenName = getTokenName(dets) || 'access_token';
             this.passwordFlow(scopes, dets, container.OAuthSchemeKey);
             return;
         }
@@ -136,13 +147,13 @@ SwaggerUi.Views.AuthView = Backbone.View.extend({
                     dets = o[t];
                     ep = dets.loginEndpoint.url;
                     url = dets.loginEndpoint.url + '?response_type=token';
-                    container.tokenName = dets.tokenName;
+                    container.tokenName = getTokenName(dets);
                 }
                 else if (o.hasOwnProperty(t) && t === 'accessCode') {
                     dets = o[t];
                     ep = dets.tokenRequestEndpoint.url;
                     url = dets.tokenRequestEndpoint.url + '?response_type=code';
-                    container.tokenName = dets.tokenName;
+                    container.tokenName = getTokenName(dets);
                 }
             }
         }

--- a/src/main/javascript/view/AuthView.js
+++ b/src/main/javascript/view/AuthView.js
@@ -117,7 +117,7 @@ SwaggerUi.Views.AuthView = Backbone.View.extend({
          * @return the name of the access token parameter
          */
         function getTokenName(dets) {
-            return dets.tokenName;
+            return dets.vendorExtensions['x-tokenName'] || dets.tokenName;
         }
 
         if(auth.get('type') === 'oauth2' && flow && (flow === 'implicit' || flow === 'accessCode')) {


### PR DESCRIPTION
# Overview

This pull request adds support for using a *vendor property* to set the name of the *OAuth2 access token name* read from the server.


# Summary

The current code contains a means of specifying the name of the access token passed from the server by adding `tokenName` to `swagger.json` for an *OAuth2 security definition*. These commits slightly modify this behaviour to prefer `x-tokenName` before falling back to `tokenName`.


# Reason

According to [the swagger spec](http://swagger.io/specification/#securityDefinitionsObject), `tokenName` is not a recognised attribute of `securityDefinitions` items. The definition does support custom attributes however, as long as their names are prefixed with `x-`.

When generating `swagger.json` programmatically, many tools support adding custom vendor properties, but generally not other properties; this is an attempt to allow automatically generating an API definition without having to fall back on post-processing.