### PR TITLE
Improve large data set performance

### DIFF
--- a/src/main/javascript/view/ResourceView.js
+++ b/src/main/javascript/view/ResourceView.js
@@ -15,37 +15,46 @@ SwaggerUi.Views.ResourceView = Backbone.View.extend({
   },
 
   render: function(){
-    var methods = {};
-
-
     $(this.el).html(Handlebars.templates.resource(this.model));
-
-    // Render each operation
-    for (var i = 0; i < this.model.operationsArray.length; i++) {
-      var operation = this.model.operationsArray[i];
-      var counter = 0;
-      var id = operation.nickname;
-
-      while (typeof methods[id] !== 'undefined') {
-        id = id + '_' + counter;
-        counter += 1;
-      }
-
-      methods[id] = operation;
-
-      operation.nickname = id;
-      operation.parentId = this.model.id;
-      operation.definitions = this.model.definitions; // make Json Schema available for JSonEditor in this operation
-      this.addOperation(operation);
-    }
-
-    $('.toggleEndpointList', this.el).click(this.callDocs.bind(this, 'toggleEndpointListForResource'));
-    $('.collapseResource', this.el).click(this.callDocs.bind(this, 'collapseOperationsForResource'));
-    $('.expandResource', this.el).click(this.callDocs.bind(this, 'expandOperationsForResource'));
-
+    $('.toggleEndpointList', this.el).click(this.renderOperations.bind(this, 'toggleEndpointListForResource'));
+    $('.collapseResource', this.el).click(this.renderOperations.bind(this, 'collapseOperationsForResource'));
+    $('.expandResource', this.el).click(this.renderOperations.bind(this, 'expandOperationsForResource'));
     return this;
   },
-
+  renderOperations: function (fnName, e) {
+      e.preventDefault();
+      var data = e.currentTarget;
+      if ($('.endpoints', this.el).children().length === 0) {
+          var methods = {};
+          // Render each operation
+          for (var i = 0; i < this.model.operationsArray.length; i++) {
+              var operation = this.model.operationsArray[i];
+              var counter = 0;
+              var id = operation.nickname;
+              while (typeof methods[id] !== 'undefined') {
+                  id = id + '_' + counter;
+                  counter += 1;
+              }
+              methods[id] = operation;
+              operation.nickname = id;
+              operation.parentId = this.model.id;
+              operation.number = this.number;
+              operation.definitions = this.model.definitions; // make Json Schema available for JSonEditor in this operation
+              // Render an operation and add it to operations li
+              var operationView = new SwaggerUi.Views.OperationView({
+                  model: operation,
+                  router: this.router,
+                  tagName: 'li',
+                  className: 'endpoint',
+                  swaggerOptions: this.options.swaggerOptions,
+                  auths: this.auths
+              });
+              $('.endpoints', this.el).append(operationView.render().el);
+              this.number++;
+          }
+      }
+      Docs[fnName](data.getAttribute('data-id'));
+  },
   addOperation: function(operation) {
 
     operation.number = this.number;


### PR DESCRIPTION
Issue: When a large amount of routes (100+) are exposed, and a number of requests are contained under the route the JavaScript rendering can hang the load of the page. 

Pull Request Change: This request improves large data set performance when rendering a large amount of operations (> 100 API routes and a minimum of 5 request types per API). This allows only rendering the header row, and then upon click, renders the operations, hence improving the speed.