### PR TITLE
cleaned up the presentation of the 'info' section (license, contact, externalDocs)

### DIFF
--- a/src/main/less/specs.less
+++ b/src/main/less/specs.less
@@ -154,6 +154,11 @@
         font-size: 25px;
     }
 
+    .info_sub_title {
+        font-weight: bold;
+        font-size: 16px;
+    }    
+
     .footer {
         margin-top: 20px;
     }

--- a/src/main/template/main.handlebars
+++ b/src/main/template/main.handlebars
@@ -2,15 +2,30 @@
   {{#if info}}
   <div class="info_title">{{{sanitize info.title}}}</div>
   <div class="info_description markdown">{{{sanitize info.description}}}</div>
-  {{#if externalDocs}}
-  <p>{{{sanitize externalDocs.description}}}</p>
-  <a href="{{{escape externalDocs.url}}}" target="_blank">{{{escape externalDocs.url}}}</a>
+  
+  {{#if info.termsOfService}}
+  <div class='info_sub_title'><a target="_blank" href="{{{escape info.termsOfService}}}" data-sw-translate>Terms of Service</a></div>
+  <br/>
   {{/if}}
-  {{#if info.termsOfServiceUrl}}<div class="info_tos"><a target="_blank" href="{{{escape info.termsOfServiceUrl}}}" data-sw-translate>Terms of service</a></div>{{/if}}
-  {{#if info.contact.name}}<div><div class='info_name' style="display: inline" data-sw-translate>Created by </div> {{{escape info.contact.name}}}</div>{{/if}}
-  {{#if info.contact.url}}<div class='info_url' data-sw-translate>See more at <a href="{{{escape info.contact.url}}}">{{{escape info.contact.url}}}</a></div>{{/if}}
-  {{#if info.contact.email}}<div class='info_email'><a target="_parent" href="mailto:{{{escape info.contact.email}}}?subject={{{escape info.title}}}" data-sw-translate>Contact the developer</a></div>{{/if}}
-  {{#if info.license}}<div class='info_license'><a target="_blank" href='{{{escape info.license.url}}}'>{{{escape info.license.name}}}</a></div>{{/if}}
+
+  {{#if info.license}}
+  <div><span class='info_sub_title'>License:</span> <a target="_blank" href='{{{escape info.license.url}}}'>{{{escape info.license.name}}}</a></div>
+  <br/>
+  {{/if}}
+  
+  {{#if info.contact}}
+  <div class="info_sub_title">Contact Information</div>
+  {{#if info.contact.name}}<div><span class='info_name' style="display: inline" data-sw-translate>Contact Name: </span> {{{escape info.contact.name}}}</div>{{/if}}
+  {{#if info.contact.email}}<div><span class='info_email'>Email: <a target="_parent" href="mailto:{{{escape info.contact.email}}}?subject={{{escape info.title}}}" data-sw-translate>{{{escape info.contact.email}}}</a></span></div>{{/if}}
+  {{#if info.contact.url}}<div><span class='info_url' data-sw-translate>Website: <a href="{{{escape info.contact.url}}}">{{{escape info.contact.url}}}</a></span></div>{{/if}}
+  <br/>
+  {{/if}}
+
+  {{#if externalDocs}}
+  <span class="info_sub_title">External Documentation:</span> <a href="{{{escape externalDocs.url}}}" target="_blank">{{{sanitize externalDocs.description}}}</a>  
+  <br/>
+  {{/if}}
+
   {{/if}}
 </div>
 <div class='container' id='resources_container'>


### PR DESCRIPTION
this patch addresses swagger-ui issue #2673.  

it also sets all links in the info section to open in new tabs, which addresses swagger-ui issue #1446.

Some examples of the new info section rendering:

![image](https://cloud.githubusercontent.com/assets/1737873/23087746/7cfe73e4-f52b-11e6-9b6c-9bdc13bafffb.png)

and

![image](https://cloud.githubusercontent.com/assets/1737873/23087740/6d23c56e-f52b-11e6-9b2a-3fa11739393e.png)

