### PR TITLE
Prevent long words in parameter descriptions from stretching table

### DIFF
--- a/src/main/less/specs.less
+++ b/src/main/less/specs.less
@@ -44,6 +44,26 @@
     table {
         border-collapse: collapse;
         border-spacing: 0;
+       .param-name-col {
+          width: 100px; 
+          max-width: 100px;
+        }
+        .param-value-col {
+          width: 310px; 
+          max-width: 310px;
+        }
+        .param-description-col {
+          width: 200px; 
+          max-width: 200px;
+        }
+        .param-type-col {
+          width: 100px; 
+          max-width: 100px;
+        }
+        .param-data-type-col {
+          width: 220px; 
+          max-width: 230px;
+        }
         thead {
             tr {
                 th {

--- a/src/main/template/operation.handlebars
+++ b/src/main/template/operation.handlebars
@@ -72,11 +72,11 @@
           <table class='fullwidth parameters'>
           <thead>
             <tr>
-            <th style="width: 100px; max-width: 100px" data-sw-translate>Parameter</th>
-            <th style="width: 310px; max-width: 310px" data-sw-translate>Value</th>
-            <th style="width: 200px; max-width: 200px" data-sw-translate>Description</th>
-            <th style="width: 100px; max-width: 100px" data-sw-translate>Parameter Type</th>
-            <th style="width: 220px; max-width: 230px" data-sw-translate>Data Type</th>
+            <th class="param-name-col" data-sw-translate>Parameter</th>
+            <th class="param-value-col" data-sw-translate>Value</th>
+            <th class="param-description-col" data-sw-translate>Description</th>
+            <th class="param-type-col" data-sw-translate>Parameter Type</th>
+            <th class="param-data-type-col" data-sw-translate>Data Type</th>
             </tr>
           </thead>
           <tbody class="operation-params">

--- a/src/main/template/param.handlebars
+++ b/src/main/template/param.handlebars
@@ -29,7 +29,7 @@
 	{{/if}}
 
 </td>
-<td class="markdown">{{{sanitize description}}}</td>
+<td class="markdown param-description-col">{{{sanitize description}}}</td>
 <td>{{{escape paramType}}}</td>
 <td>
 	<span class="model-signature"></span>

--- a/src/main/template/param_list.handlebars
+++ b/src/main/template/param_list.handlebars
@@ -14,6 +14,6 @@
 
   </select>
 </td>
-<td class="markdown">{{#if required}}<strong>{{/if}}{{{description}}}{{#if required}}</strong>{{/if}}</td>
+<td class="markdown param-description-col">{{#if required}}<strong>{{/if}}{{{description}}}{{#if required}}</strong>{{/if}}</td>
 <td>{{{escape paramType}}}</td>
 <td><span class="model-signature"></span></td>

--- a/src/main/template/param_readonly.handlebars
+++ b/src/main/template/param_readonly.handlebars
@@ -11,6 +11,6 @@
         {{/if}}
     {{/if}}
 </td>
-<td class="markdown">{{{sanitize description}}}</td>
+<td class="markdown param-description-col">{{{sanitize description}}}</td>
 <td>{{{escape paramType}}}</td>
 <td><span class="model-signature"></span></td>

--- a/src/main/template/param_readonly_required.handlebars
+++ b/src/main/template/param_readonly_required.handlebars
@@ -10,6 +10,6 @@
         {{/if}}
     {{/if}}
 </td>
-<td class="markdown">{{{sanitize description}}}</td>
+<td class="markdown param-description-col">{{{sanitize description}}}</td>
 <td>{{{escape paramType}}}</td>
 <td><span class="model-signature"></span></td>

--- a/src/main/template/param_required.handlebars
+++ b/src/main/template/param_required.handlebars
@@ -26,7 +26,7 @@
 	{{/if}}
 </td>
 <td>
-	<strong><span class="markdown">{{{sanitize description}}}</span></strong>
+	<strong><span class="markdown param-description-col">{{{sanitize description}}}</span></strong>
 </td>
 <td>{{{escape paramType}}}</td>
 <td><span class="model-signature"></span></td>


### PR DESCRIPTION
The new behavior is that the long content just spills into the adjacent column.

Before:

![image](https://cloud.githubusercontent.com/assets/1737873/23088314/45b3b926-f530-11e6-92b7-66a24222b786.png)

After:

![image](https://cloud.githubusercontent.com/assets/1737873/23088316/4a8faf40-f530-11e6-8fec-21a691504d97.png)

This patch addresses swagger-ui [Issue 2676](https://github.com/swagger-api/swagger-ui/issues/2676)