### PR TITLE
Leverage additionalQueryStringParams for flow === 'application' type

### DIFF
--- a/lib/swagger-oauth.js
+++ b/lib/swagger-oauth.js
@@ -147,7 +147,7 @@ function handleLogin() {
         else if(authSchemes[key].type === 'oauth2' && flow && (flow === 'application')) {
             var dets = authSchemes[key];
             window.swaggerUi.tokenName = getTokenName(dets) || 'access_token';
-            clientCredentialsFlow(scopes, dets.tokenUrl, key);
+            clientCredentialsFlow(scopes, dets.tokenUrl, key, additionalQueryStringParams);
             return;
         }        
         else if(authSchemes[key].grantTypes) {
@@ -234,13 +234,17 @@ function initOAuth(opts) {
   });
 }
 
-function clientCredentialsFlow(scopes, tokenUrl, OAuthSchemeKey) {
+function clientCredentialsFlow(scopes, tokenUrl, OAuthSchemeKey, additionalQueryStringParams) {
     var params = {
       'client_id': clientId,
       'client_secret': clientSecret,
       'scope': scopes.join(' '),
       'grant_type': 'client_credentials'
     }
+    for (var key in additionalQueryStringParams) {
+        params[key] = additionalQueryStringParams[key];
+    }
+
     $.ajax(
     {
       url : tokenUrl,


### PR DESCRIPTION
Related to issue #2671 that I opened.  Thinking the solution could look something like this PR.  It allows passing ad-hoc HTTP POST params in the application flow via the pre-existing `additionalQueryStringParams`.  This is needed for things like Auth0's `Audience` HTTP POST parameter.