### PR TITLE
Support enum values as property items type. Fixes #1381.

### DIFF
--- a/src/main/javascript/view/partials/signature.js
+++ b/src/main/javascript/view/partials/signature.js
@@ -263,6 +263,10 @@ SwaggerUi.partials.signature = (function () {
         html += ' = <span class="propVals">[\'' + schema.enum.join('\', \'') + '\']</span>';
       }
 
+      if (schema.items && schema.items.enum) {
+        html += ' = <span class="propVals">[\'' + schema.items.enum.join('\', \'') + '\']</span>';
+      }
+
       if (isArray) {
         if (_.isPlainObject(schema.items) && !_.isUndefined(schema.items.type)) {
           type = schema.items.type;
@@ -334,15 +338,11 @@ SwaggerUi.partials.signature = (function () {
 
       if (_.isUndefined(schema.items)) {
         if (_.isArray(schema.enum)) {
-          var enumString;
-
-          if (type === 'number' || type === 'integer') {
-            enumString = schema.enum.join(', ');
-          } else {
-            enumString = '"' + schema.enum.join('", "') + '"';
-          }
-
-          options += optionHtml('Enum', enumString);
+          options += enumToOptionsHTML(schema);
+        }
+      } else {
+        if (schema.items && _.isArray(schema.items.enum)) {
+          options += enumToOptionsHTML(schema.items);
         }
       }
 
@@ -351,6 +351,20 @@ SwaggerUi.partials.signature = (function () {
       }
 
       return html;
+    }
+
+    function enumToOptionsHTML(schema) {
+      var type = schema.type || 'object';
+
+      var enumString;
+
+      if (type === 'number' || type === 'integer') {
+        enumString = schema.enum.join(', ');
+      } else {
+        enumString = '"' + schema.enum.join('", "') + '"';
+      }
+
+      return optionHtml('Enum', enumString);
     }
 
     function processModel(schema, name) {


### PR DESCRIPTION
**0. Schema**

```
{
  "swagger": "2.0",
  "info": {
    "description": "Api Documentation",
    "version": "1.0",
    "title": "Api Documentation",
    "termsOfService": "urn:tos",
    "contact": {},
    "license": {
      "name": "Apache 2.0",
      "url": "http://www.apache.org/licenses/LICENSE-2.0"
    }
  },
  "host": "localhost:9042",
  "basePath": "/",
  "tags": [
    {
      "name": "Product Entity",
      "description": "Repository Entity Controller"
    }
  ],
  "paths": {
    "/products": {
      "post": {
        "tags": [
          "Product Entity"
        ],
        "summary": "postCollectionResource",
        "operationId": "postCollectionResourceUsingPOST",
        "consumes": [
          "application/json"
        ],
        "produces": [
          "application/*+json;charset=UTF-8",
          "application/json",
          "application/hal+json"
        ],
        "parameters": [
          {
            "in": "body",
            "name": "payload",
            "description": "payload",
            "required": true,
            "schema": {
              "$ref": "#/definitions/Product"
            }
          }
        ],
        "responses": {
          "201": {
            "description": "Created"
          },
          "401": {
            "description": "Unauthorized"
          },
          "403": {
            "description": "Forbidden"
          },
          "404": {
            "description": "Not Found"
          }
        }
      }
    }
  },
  "definitions": {
    "Product": {
      "type": "object",
      "properties": {
        "channels": {
          "type": "array",
          "items": {
            "type": "string",
            "enum": [
              "DELIVERY",
              "DROPSHIP",
              "TAKEAWAY"
            ]
          }
        },
        "visibility": {
          "type": "string",
          "enum": [
            "HIDDEN",
            "PUBLIC"
          ]
        }
      }
    }
  }
}

```

**1. Current status**

Rendering of the following properties differs in swagger-ui:

1. property `channels` with `type: array`, `items` of `type: string` and `enum: [...]`
2. property `visibility` with `type: string` and `enum: [...]`

```
Product {
    channels (Array[string], optional),
    visibility (string, optional) = ['HIDDEN', 'PUBLIC']
}
```

**2. Expected status**

Rendering should be similar, showing allowed values in both cases.

```
Product {
    channels (Array[string], optional) = ['DELIVERY', 'DROPSHIP', 'TAKEAWAY'],
    visibility (string, optional) = ['HIDDEN', 'PUBLIC']
}
```

**3. Related issues**

Addresses #1381.

This might be related to https://github.com/swagger-api/swagger-js/issues/198 and especially what @kevinconaway was reporting [from this comment](https://github.com/swagger-api/swagger-js/issues/198#issuecomment-121431941) onwards.