### PR TITLE
Attach nginx process to PID 1 so the container can be stopped properly.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ ADD ./dist/ /usr/share/nginx/html
 
 EXPOSE 8080
 
-CMD nginx -g 'daemon off;'
+CMD exec nginx -g 'daemon off;'


### PR DESCRIPTION
When running

```
docker build -t swagger-ui-builder .
docker run -p 80:8080 swagger-ui-builder
```
you can't currently stop the process by pressing `Ctrl + C`.

This PR fixes that.