### PR TITLE
Fix code inside tables

### DIFF
--- a/src/main/less/specs.less
+++ b/src/main/less/specs.less
@@ -372,7 +372,7 @@
         border: 1px solid #aaa;
     }
 
-    .markdown p code, .markdown li code {
+    .markdown code {
         font-family: "Anonymous Pro", "Menlo", "Consolas", "Bitstream Vera Sans Mono", "Courier New", monospace;
         background-color: #f0f0f0;
         color: black;


### PR DESCRIPTION
```
A | B
--- | ---
`a` | `b`
```

This table renders without the code styles and looks like this:

A | B
--- | ---
a | b

But should be:

A | B
--- | ---
`a` | `b`
