### PR TITLE
Error styling updates / added missing operation colors

### DIFF
--- a/src/core/components/operations.jsx
+++ b/src/core/components/operations.jsx
@@ -59,12 +59,6 @@ export default class Operations extends React.Component {
                         </small>
                     }
 
-                    <button className="expand-methods" title="Expand all methods">
-                      <svg className="expand" width="20" height="20">
-                        <use xlinkHref="#expand" />
-                      </svg>
-                    </button>
-
                     <button className="expand-operation" title="Expand operation" onClick={() => layoutActions.show(isShownKey, !showTag)}>
                       <svg className="arrow" width="20" height="20">
                         <use xlinkHref={showTag ? "#large-arrow-down" : "#large-arrow"} />

--- a/src/style/_errors.scss
+++ b/src/style/_errors.scss
@@ -9,13 +9,18 @@
     border-radius: 4px;
     background: rgba($_color-delete, .1);
 
+    .error-wrapper
+    {
+        margin: 0 0 10px 0;
+    }
+
     .errors
     {
         h4
         {
             font-size: 14px;
 
-            margin: 0 0 10px 0;
+            margin: 0;
 
             @include text_code();
         }

--- a/src/style/_layout.scss
+++ b/src/style/_layout.scss
@@ -286,6 +286,21 @@ body
         @include method($_color-get);
     }
 
+    &.opblock-patch
+    {
+        @include method($_color-patch);
+    }
+
+    &.opblock-head
+    {
+        @include method($_color-head);
+    }
+
+    &.opblock-options
+    {
+        @include method($_color-options);
+    }
+
     &.opblock-deprecated
     {
         opacity: .6;


### PR DESCRIPTION
- removed Expand all methods icon (no functionality implemented yet)
- updated error wrapper once again
- added missing operation colors