### PR TITLE
Re-add the ability to specify the url of the spec in the path

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -69,9 +69,15 @@
 <script src="/dist/SwaggerUIStandalonePreset.js"> </script>
 <script>
 window.onload = function() {
+  var url = window.location.search.match(/url=([^&]+)/);
+  if (url && url.length > 1) {
+    url = decodeURIComponent(url[1]);
+  } else {
+    url = "http://petstore.swagger.io/v2/swagger.json";
+  }
   // Build a system
   const ui = SwaggerUIBundle({
-    url: "http://petstore.swagger.io/v2/swagger.json",
+    url: url,
     dom_id: '#swagger-ui',
     presets: [
       SwaggerUIBundle.presets.apis,

--- a/public/index.html
+++ b/public/index.html
@@ -70,9 +70,15 @@
 <script src="../dist/swagger-ui-standalone-preset.js"> </script>
 <script>
 window.onload = function() {
+  var url = window.location.search.match(/url=([^&]+)/);
+  if (url && url.length > 1) {
+    url = decodeURIComponent(url[1]);
+  } else {
+    url = "http://petstore.swagger.io/v2/swagger.json";
+  }
   // Build a system
   const ui = SwaggerUIBundle({
-    url: "http://petstore.swagger.io/v2/swagger.json",
+    url: url,
     dom_id: '#swagger-ui',
     presets: [
       SwaggerUIBundle.presets.apis,


### PR DESCRIPTION
This feature was really useful in the old version of the swagger UI.

Unsure why this feature was removed.

Perhaps trying to prevent cross site scripting?