### PR TITLE
Add deep access guard to operation update reducer

### DIFF
--- a/src/core/plugins/spec/reducers.js
+++ b/src/core/plugins/spec/reducers.js
@@ -97,7 +97,11 @@ export default {
   },
 
   [UPDATE_OPERATION_VALUE]: (state, { payload: { path, value, key } }) => {
-    return state.setIn(["resolved", "paths", ...path, key], fromJS(value))
+    let operationPath = ["resolved", "paths", ...path]
+    if(!state.getIn(operationPath)) {
+      return state
+    }
+    return state.setIn([...operationPath, key], fromJS(value))
   },
 
   [CLEAR_RESPONSE]: (state, { payload: { path, method } } ) =>{

--- a/test/core/plugins/spec-reducer.js
+++ b/test/core/plugins/spec-reducer.js
@@ -1,0 +1,72 @@
+/* eslint-env mocha */
+import expect from "expect"
+import { fromJS } from "immutable"
+import reducer from "corePlugins/spec/reducers"
+
+describe("spec plugin - reducer", function(){
+
+  describe("update operation value", function() {
+    it("should update the operation at the specified key", () => {
+      const updateOperationValue = reducer["spec_update_operation_value"]
+
+      const state = fromJS({
+        resolved: {
+          "paths": {
+            "/pet": {
+              "post": {
+                "description": "my operation"
+              }
+            }
+          }
+        }
+      })
+
+      let result = updateOperationValue(state, {
+        payload: {
+          path: ["/pet", "post"],
+          value: "application/json",
+          key: "consumes_value"
+        }
+      })
+
+      let expectedResult = {
+        resolved: {
+          "paths": {
+            "/pet": {
+              "post": {
+                "description": "my operation",
+                "consumes_value": "application/json"
+              }
+            }
+          }
+        }
+      }
+
+      expect(result.toJS()).toEqual(expectedResult)
+    })
+
+    it("shouldn't throw an error if we try to update the consumes_value of a null operation", () => {
+      const updateOperationValue = reducer["spec_update_operation_value"]
+
+      const state = fromJS({
+        resolved: {
+          "paths": {
+            "/pet": {
+              "post": null
+            }
+          }
+        }
+      })
+
+      let result = updateOperationValue(state, {
+        payload: {
+          path: ["/pet", "post"],
+          value: "application/json",
+          key: "consumes_value"
+        }
+      })
+
+      expect(result.toJS()).toEqual(state.toJS())
+    })
+  })
+})


### PR DESCRIPTION
Fixes #2918.

Includes a control and test case for the reducer in the tests.