### PR TITLE
fix OAuth2 authorize issue + remove redundant parameters

### DIFF
--- a/src/core/oauth2-authorize.js
+++ b/src/core/oauth2-authorize.js
@@ -60,11 +60,11 @@ export default function authorize ( { auth, authActions, errActions, configs, au
 
   for (let key in additionalQueryStringParams) {
     if (typeof additionalQueryStringParams[key] !== "undefined") {
-      query.push([key, additionalQueryStringParams[key]].map(encodeURIComponent).join('='))
+      query.push([key, additionalQueryStringParams[key]].map(encodeURIComponent).join("="))
     }
   }
 
-  let url = [schema.get("authorizationUrl"), query.join('&')].join('?')
+  let url = [schema.get("authorizationUrl"), query.join("&")].join("?")
 
   // pass action authorizeOauth2 and authentication data through window
   // to authorize with oauth2

--- a/src/core/oauth2-authorize.js
+++ b/src/core/oauth2-authorize.js
@@ -3,26 +3,35 @@ import { btoa } from "core/utils"
 
 export default function authorize ( { auth, authActions, errActions, configs, authConfigs={} } ) {
   let { schema, scopes, name, clientId } = auth
-
-  let { additionalQueryStringParams } = authConfigs
-  let redirectUrl = configs.oauth2RedirectUrl
-  let scopeSeparator = authConfigs.scopeSeparator || " "
-  let state = btoa(new Date())
   let flow = schema.get("flow")
-  let url
+  let query = []
 
-  if (flow === "password") {
-    authActions.authorizePassword(auth)
-    return
+  switch (flow) {
+    case "password":
+      authActions.authorizePassword(auth)
+      return
+
+    case "application":
+      authActions.authorizeApplication(auth)
+      return
+
+    case "accessCode":
+      query.push("response_type=code")
+      break
+
+    case "implicit":
+      query.push("response_type=token")
+      break
   }
 
-  if (flow === "application") {
-    authActions.authorizeApplication(auth)
-    return
+  if (typeof clientId === "string") {
+    query.push("client_id=" + encodeURIComponent(clientId))
   }
+
+  let redirectUrl = configs.oauth2RedirectUrl
 
   // todo move to parser
-  if ( !redirectUrl ) {
+  if (typeof redirectUrl === "undefined") {
     errActions.newAuthErr( {
       authId: name,
       source: "validation",
@@ -31,20 +40,31 @@ export default function authorize ( { auth, authActions, errActions, configs, au
     })
     return
   }
+  query.push("redirect_uri=" + encodeURIComponent(redirectUrl))
 
-  if (flow === "implicit" || flow === "accessCode") {
-    url = schema.get("authorizationUrl") + "?response_type=" + (flow === "implicit" ? "token" : "code")
+  if (Array.isArray(scopes) && 0 < scopes.length) {
+    let scopeSeparator = authConfigs.scopeSeparator || " "
+
+    query.push("scope=" + encodeURIComponent(scopes.join(scopeSeparator)))
   }
 
-  url += "&redirect_uri=" + encodeURIComponent(redirectUrl)
-      + "&realm=" + encodeURIComponent(authConfigs.realm);
-      + "&scope=" + encodeURIComponent(scopes.join(scopeSeparator))
-      + "&state=" + encodeURIComponent(state)
-      + "&client_id=" + encodeURIComponent(clientId)
+  let state = btoa(new Date())
+
+  query.push("state=" + encodeURIComponent(state))
+
+  if (typeof authConfigs.realm !== "undefined") {
+    query.push("realm=" + encodeURIComponent(authConfigs.realm))
+  }
+
+  let { additionalQueryStringParams } = authConfigs
 
   for (let key in additionalQueryStringParams) {
-    url += "&" + key + "=" + encodeURIComponent(additionalQueryStringParams[key])
+    if (typeof additionalQueryStringParams[key] !== "undefined") {
+      query.push([key, additionalQueryStringParams[key]].map(encodeURIComponent).join('='))
+    }
   }
+
+  let url = [schema.get("authorizationUrl"), query.join('&')].join('?')
 
   // pass action authorizeOauth2 and authentication data through window
   // to authorize with oauth2


### PR DESCRIPTION
In swagger-ui 3.0.10 OAuth2 authorizations don't work.
swagger-ui doesn't send client_id and more parameters because there was misplaced semicolon.

I rewrite code assembles querystring instead of fixing a typo since similar problem shall occur again.