### PR TITLE
Add custom namespace to config whitelist

### DIFF
--- a/src/core/index.js
+++ b/src/core/index.js
@@ -25,8 +25,8 @@ module.exports = function SwaggerUI(opts) {
     url: "",
     layout: "BaseLayout",
     validatorUrl: "https://online.swagger.io/validator",
-    configs: {
-    },
+    configs: {},
+    custom: {},
 
     // Initial set of plugins ( TODO rename this, or refactor - we don't need presets _and_ plugins. Its just there for performance.
     // Instead, we can compile the first plugin ( it can be a collection of plugins ), then batch the rest.

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -8,7 +8,7 @@ import { parseSeach, filterConfigs } from "core/utils"
 
 const CONFIGS = [ "url", "spec", "validatorUrl", "onComplete", "onFailure", "authorizations", "docExpansion",
     "apisSorter", "operationsSorter", "supportedSubmitMethods", "highlightSizeThreshold", "dom_id",
-    "defaultModelRendering", "oauth2RedirectUrl", "showRequestHeaders" ]
+    "defaultModelRendering", "oauth2RedirectUrl", "showRequestHeaders", "custom" ]
 
 // eslint-disable-next-line no-undef
 const { GIT_DIRTY, GIT_COMMIT, PACKAGE_VERSION } = buildInfo


### PR DESCRIPTION
Fixes #3061 
Unblocks #3103 

Allows users to provide custom config values via the `custom` namespace.