### PR TITLE
packaging: fix swagger-ui-dist entry point

### DIFF
--- a/swagger-ui-dist-package/README.md
+++ b/swagger-ui-dist-package/README.md
@@ -1,3 +1,8 @@
 This directory is used to build the `swagger-ui-dist` npm package.
 
+`SwaggerUIBundle` and `SwaggerUIStandalonePreset` can be imported from it:
+```javascript
+  import { SwaggerUIBundle, SwaggerUIStandalonePreset } from 'swagger-ui-dist'
+```
+
 For anything else, check the [Swagger-UI](https://github.com/swagger-api/swagger-ui) repository.

--- a/swagger-ui-dist-package/deploy.sh
+++ b/swagger-ui-dist-package/deploy.sh
@@ -18,4 +18,4 @@ else
   npm pack .
 fi
 
-find . -not -name .npmignore -not -name .npmrc -not -name deploy.sh -not -name package.json -not -name README.md -not -name *.tgz -delete 
+find . -not -name .npmignore -not -name .npmrc -not -name deploy.sh -not -name index.js -not -name package.json -not -name README.md -not -name *.tgz -delete

--- a/swagger-ui-dist-package/index.js
+++ b/swagger-ui-dist-package/index.js
@@ -1,0 +1,2 @@
+module.exports.SwaggerUIBundle = require('./swagger-ui-bundle.js')
+module.exports.SwaggerUIStandalonePreset = require('./swagger-ui-standalone-preset.js')

--- a/swagger-ui-dist-package/package.json
+++ b/swagger-ui-dist-package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "swagger-ui-dist",
   "version": "$$VERSION",
-  "main": "dist/swagger-ui.js",
+  "main": "index.js",
   "repository": "git@github.com:swagger-api/swagger-ui.git",
   "contributors": [
     "(in alphabetical order)",


### PR DESCRIPTION
Entry point was missing. This change allows importing SwaggerUIBundle
and SwaggerUIStandalonePreset directly from package. Correct entry point
is also needed for module bundlers like webpack to perform tree-shaking.