### PR TITLE
Use less generic pulse animation name (Fixes #3169)

### DIFF
--- a/src/style/_buttons.scss
+++ b/src/style/_buttons.scss
@@ -58,7 +58,7 @@
 
     &.execute
     {
-        animation: pulse 2s infinite;
+        animation: swagger-ui-pulse 2s infinite;
 
         color: #fff;
         border-color: #4990e2;
@@ -66,7 +66,7 @@
 }
 
 
-@keyframes pulse
+@keyframes swagger-ui-pulse
 {
     0%
     {


### PR DESCRIPTION
This PR simply renames the `pulse` animation to a less generic name (`swagger-ui-pulse`).

It reduces the chance of a conflict when Swagger UI is embedded into a larger page/site that may already define it's own `pulse` animation.