### PR TITLE
Remove unused legacy clear class (Fixes #3167)

### DIFF
--- a/src/core/components/layout-utils.jsx
+++ b/src/core/components/layout-utils.jsx
@@ -70,7 +70,7 @@ export class Col extends React.Component {
       }
     }
 
-    let classes = xclass(rest.className, "clear", ...classesAr)
+    let classes = xclass(rest.className, ...classesAr)
 
     return (
       <section {...rest} style={{display: hide ? "none": null}} className={classes}/>


### PR DESCRIPTION
This PR simply removes the `clear` class from the `<Col>` component, since it is no longer used.

It reduces the chance of a conflict when Swagger UI is embedded into a larger page/site that may already define it's own `clear` class.