### PR TITLE
CSS fixes for operationId display

### DIFF
--- a/src/core/components/operation.jsx
+++ b/src/core/components/operation.jsx
@@ -167,7 +167,7 @@ export default class Operation extends React.Component {
                 </div>
             }
 
-            { displayOperationId && operationId ? <span className="opblock-summary-path">{operationId}</span> : null }
+            { displayOperationId && operationId ? <span className="opblock-summary-operation-id">{operationId}</span> : null }
 
             {
               (!security || !security.count()) ? null :

--- a/src/style/_layout.scss
+++ b/src/style/_layout.scss
@@ -212,7 +212,7 @@ body
     .opblock-summary-operation-id,
     .opblock-summary-path__deprecated
     {
-        font-size: 13px;
+        font-size: 16px;
 
         display: flex;
 
@@ -248,14 +248,9 @@ body
         text-decoration: line-through;
     }
 
-    .opblock-summary-path
-    {
-        font-size: 13px;
-    }
-
     .opblock-summary-operation-id
     {
-        font-size: 16px;
+        font-size: 14px;
     }
 
     .opblock-summary-description


### PR DESCRIPTION
Succeeds #3152.

Gives operation summaries 16px font size, except for operationIds, which get 14px.