### PR TITLE
Add support for docExpansion flag to models

### DIFF
--- a/src/core/components/models.jsx
+++ b/src/core/components/models.jsx
@@ -6,7 +6,8 @@ export default class Models extends Component {
     getComponent: PropTypes.func,
     specSelectors: PropTypes.object,
     layoutSelectors: PropTypes.object,
-    layoutActions: PropTypes.object
+    layoutActions: PropTypes.object,
+    getConfigs: PropTypes.func.isRequired
   }
 
   render(){

--- a/src/core/components/models.jsx
+++ b/src/core/components/models.jsx
@@ -10,9 +10,10 @@ export default class Models extends Component {
   }
 
   render(){
-    let { specSelectors, getComponent, layoutSelectors, layoutActions } = this.props
+    let { specSelectors, getComponent, layoutSelectors, layoutActions, getConfigs } = this.props
     let definitions = specSelectors.definitions()
-    let showModels = layoutSelectors.isShown("models", true)
+    let { docExpansion } = getConfigs()
+    let showModels = layoutSelectors.isShown("models", docExpansion === "full" || docExpansion === "list" )
 
     const Model = getComponent("model")
     const Collapse = getComponent("Collapse")


### PR DESCRIPTION
Show a more compressed view if docExpansion is set to "none"

With this change, if docExpansion is "none", the initial view appears thus:

![image](https://user-images.githubusercontent.com/314188/26857173-dd165416-4b7c-11e7-8453-e09bbbef71d9.png)
