### PR TITLE
Fix wrong path to absolute-path.js

### DIFF
--- a/swagger-ui-dist-package/index.js
+++ b/swagger-ui-dist-package/index.js
@@ -1,4 +1,3 @@
 module.exports.SwaggerUIBundle = require("./swagger-ui-bundle.js")
 module.exports.SwaggerUIStandalonePreset = require("./swagger-ui-standalone-preset.js")
-module.exports.absolutePath = require("./.absolute-path.js")
-
+module.exports.absolutePath = require("./absolute-path.js")


### PR DESCRIPTION
Path should be "./absolute-path.js" not "./.absolute-path.js". This caused webpack to throw an error "/node-modules/swagger-ui-dist/.absolute-path.js doesn't exist"