### PR TITLE
don't use ES6 syntax in a dist package

### DIFF
--- a/swagger-ui-dist-package/absolute-path.js
+++ b/swagger-ui-dist-package/absolute-path.js
@@ -3,7 +3,7 @@
  * @return {string} When run in NodeJS env, returns the absolute path to the current directory
  *                  When run outside of NodeJS, will return an error message
  */
-const getAbsoluteFSPath = () => {
+const getAbsoluteFSPath = function () {
   // detect whether we are running in a browser or nodejs
   if (typeof module !== "undefined" && module.exports) {
     return require("path").resolve(__dirname)


### PR DESCRIPTION
using ES6 syntax will cause trouble unless you transpile before use (which is something you should not be required to do in a dist package)