### PR TITLE
Update and pin yaml-js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "whatwg-fetch": "0.11.1",
     "worker-loader": "^0.7.1",
     "xml": "1.0.1",
-    "yaml-js": "^0.1.3"
+    "yaml-js": "0.2.0"
   },
   "devDependencies": {
     "autoprefixer": "6.6.1",


### PR DESCRIPTION
This takes advantage of the changes made in https://github.com/connec/yaml-js/issues/37#issuecomment-310246279, which resolves issues with Webpack throwing warnings about the yaml-js package.

May also solve Webpack 2 problems in https://github.com/swagger-api/swagger-ui/issues/3046 and in a user's codebase https://github.com/openfisca/legislation-explorer/pull/94, since the yaml-js change no longer leans on the `fs` module by default.