### PR TITLE
Fixes #3299 - default required integer validation

### DIFF
--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -450,15 +450,15 @@ export const propChecker = (props, nextProps, objectList=[], ignoreList=[]) => {
     || objectList.some( objectPropName => !eq(props[objectPropName], nextProps[objectPropName])))
 }
 
-const validateNumber = ( val ) => {
-  if ( !/^-?\d+(.?\d+)?$/.test(val)) {
+export const validateNumber = ( val ) => {
+  if ( !/^-?\d+(\.?\d+)?$/.test(val)) {
     return "Value must be a number"
   }
 }
 
-const validateInteger = ( val ) => {
+export const validateInteger = ( val ) => {
   if ( !/^-?\d+$/.test(val)) {
-    return "Value must be integer"
+    return "Value must be an integer"
   }
 }
 
@@ -469,12 +469,13 @@ export const validateParam = (param, isXml) => {
   let required = param.get("required")
   let type = param.get("type")
 
-  if ( required && (!value || (type==="array" && Array.isArray(value) && !value.length ))) {
+  let stringCheck = type === "string" && !value
+  let arrayCheck = type === "array" && Array.isArray(value) && !value.length
+  let listCheck = type === "array" && Im.List.isList(value) && !value.count()
+  if ( required && (stringCheck || arrayCheck || listCheck) ) {
     errors.push("Required field is not provided")
     return errors
   }
-
-  if ( !value ) return errors
 
   if ( type === "number" ) {
     let err = validateNumber(value)

--- a/test/core/utils.js
+++ b/test/core/utils.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 import expect from "expect"
 import { fromJS } from "immutable"
-import { mapToList } from "core/utils"
+import { mapToList, validateNumber, validateInteger, validateParam } from "core/utils"
 
 describe("utils", function(){
 
@@ -67,9 +67,181 @@ describe("utils", function(){
 
       // Then
       expect(aList.toJS()).toEqual([])
-
     })
 
   })
 
+  describe("validateNumber", function() {
+    let errorMessage = "Value must be a number"
+
+    it("doesn't return for whole numbers", function() {
+      expect(validateNumber(0)).toBeFalsy()
+      expect(validateNumber(1)).toBeFalsy()
+      expect(validateNumber(20)).toBeFalsy()
+      expect(validateNumber(5000000)).toBeFalsy()
+      expect(validateNumber("1")).toBeFalsy()
+      expect(validateNumber("2")).toBeFalsy()
+      expect(validateNumber(-1)).toBeFalsy()
+      expect(validateNumber(-20)).toBeFalsy()
+      expect(validateNumber(-5000000)).toBeFalsy()
+    })
+
+    it("doesn't return for negative numbers", function() {
+      expect(validateNumber(-1)).toBeFalsy()
+      expect(validateNumber(-20)).toBeFalsy()
+      expect(validateNumber(-5000000)).toBeFalsy()
+    })
+
+    it("doesn't return for decimal numbers", function() {
+      expect(validateNumber(1.1)).toBeFalsy()
+      expect(validateNumber(2.5)).toBeFalsy()
+      expect(validateNumber(-30.99)).toBeFalsy()
+    })
+
+    it("returns a message for strings", function() {
+      expect(validateNumber("")).toEqual(errorMessage)
+      expect(validateNumber(" ")).toEqual(errorMessage)
+      expect(validateNumber("test")).toEqual(errorMessage)
+    })
+
+    it("returns a message for invalid input", function() {
+      expect(validateNumber(undefined)).toEqual(errorMessage)
+      expect(validateNumber(null)).toEqual(errorMessage)
+      expect(validateNumber({})).toEqual(errorMessage)
+      expect(validateNumber([])).toEqual(errorMessage)
+      expect(validateNumber(true)).toEqual(errorMessage)
+      expect(validateNumber(false)).toEqual(errorMessage)
+    })
+  })
+
+  describe("validateInteger", function() {
+    let errorMessage = "Value must be an integer"
+
+    it("doesn't return for positive integers", function() {
+      expect(validateInteger(0)).toBeFalsy()
+      expect(validateInteger(1)).toBeFalsy()
+      expect(validateInteger(20)).toBeFalsy()
+      expect(validateInteger(5000000)).toBeFalsy()
+      expect(validateInteger("1")).toBeFalsy()
+      expect(validateInteger("2")).toBeFalsy()
+      expect(validateInteger(-1)).toBeFalsy()
+      expect(validateInteger(-20)).toBeFalsy()
+      expect(validateInteger(-5000000)).toBeFalsy()
+    })
+
+    it("doesn't return for negative integers", function() {
+      expect(validateInteger(-1)).toBeFalsy()
+      expect(validateInteger(-20)).toBeFalsy()
+      expect(validateInteger(-5000000)).toBeFalsy()
+    })
+
+    it("returns a message for decimal values", function() {
+      expect(validateInteger(1.1)).toEqual(errorMessage)
+      expect(validateInteger(2.5)).toEqual(errorMessage)
+      expect(validateInteger(-30.99)).toEqual(errorMessage)
+    })
+
+    it("returns a message for strings", function() {
+      expect(validateInteger("")).toEqual(errorMessage)
+      expect(validateInteger(" ")).toEqual(errorMessage)
+      expect(validateInteger("test")).toEqual(errorMessage)
+    })
+
+    it("returns a message for invalid input", function() {
+      expect(validateInteger(undefined)).toEqual(errorMessage)
+      expect(validateInteger(null)).toEqual(errorMessage)
+      expect(validateInteger({})).toEqual(errorMessage)
+      expect(validateInteger([])).toEqual(errorMessage)
+      expect(validateInteger(true)).toEqual(errorMessage)
+      expect(validateInteger(false)).toEqual(errorMessage)
+    })
+  })
+
+  describe("validateParam", function() {
+    let param = null
+    let result = null
+
+    it("validates required strings", function() {
+      param = fromJS({
+        required: true,
+        type: "string",
+        value: ""
+      })
+      result = validateParam( param, false )
+      expect( result ).toEqual( ["Required field is not provided"] )
+    })
+
+    it("validates required arrays", function() {
+      param = fromJS({
+        required: true,
+        type: "array",
+        value: []
+      })
+      result = validateParam( param, false )
+      expect( result ).toEqual( ["Required field is not provided"] )
+
+      param = fromJS({
+        required: true,
+        type: "array",
+        value: []
+      })
+      result = validateParam( param, false )
+      expect( result ).toEqual( ["Required field is not provided"] )
+    })
+
+    it("validates numbers", function() {
+      param = fromJS({
+        required: false,
+        type: "number",
+        value: "test"
+      })
+      result = validateParam( param, false )
+      expect( result ).toEqual( ["Value must be a number"] )
+    })
+
+    it("validates integers", function() {
+      param = fromJS({
+        required: false,
+        type: "integer",
+        value: "test"
+      })
+      result = validateParam( param, false )
+      expect( result ).toEqual( ["Value must be an integer"] )
+    })
+
+    it("validates arrays", function() {
+      // empty array
+      param = fromJS({
+        required: false,
+        type: "array",
+        value: []
+      })
+      result = validateParam( param, false )
+      expect( result ).toEqual( [] )
+
+      // numbers
+      param = fromJS({
+        required: false,
+        type: "array",
+        value: ["number"],
+        items: {
+          type: "number"
+        }
+      })
+      result = validateParam( param, false )
+      expect( result ).toEqual( [{index: 0, error: "Value must be a number"}] )
+
+      // integers
+      param = fromJS({
+        required: false,
+        type: "array",
+        value: ["not", "numbers"],
+        items: {
+          type: "integer"
+        }
+      })
+      result = validateParam( param, false )
+      expect( result ).toEqual( [{index: 0, error: "Value must be an integer"}, {index: 1, error: "Value must be an integer"}] )
+    })
+  })
 })


### PR DESCRIPTION
Fixes #3299 

Export validateNumber and validateInteger for easy reuse and testing.
Broke validateParam required check onto multiple lines. 
Added tests for validateNumber, validateInteger, and validateParam.