### PR TITLE
#3110 - Fix Models down arrow icon in firefox

### DIFF
--- a/src/core/components/models.jsx
+++ b/src/core/components/models.jsx
@@ -24,8 +24,8 @@ export default class Models extends Component {
     return <section className={ showModels ? "models is-open" : "models"}>
       <h4 onClick={() => layoutActions.show("models", !showModels)}>
         <span>Models</span>
-        <svg width="20" height="20">
-          <use xlinkHref="#large-arrow" />
+        <svg className="arrow" width="20" height="20">
+          <use xlinkHref={showModels ? "#large-arrow-down" : "#large-arrow"} />
         </svg>
       </h4>
       <Collapse isOpened={showModels} animated>

--- a/src/style/_models.scss
+++ b/src/style/_models.scss
@@ -95,14 +95,7 @@ section.models
         h4
         {
             margin: 0 0 5px 0;
-
             border-bottom: 1px solid rgba(#3b4151, .3);
-
-
-            svg
-            {
-                transform: rotate(90deg);
-            }
         }
     }
     h4


### PR DESCRIPTION
Fixes #3110 

This is a ridiculous 13 yr old bug in Firefox (which they've just resolved 7 days ago): https://stackoverflow.com/questions/35407415/firefox-svg-symbol-transform and https://bugzilla.mozilla.org/show_bug.cgi?id=265894

TLDR: You can't use a `svg { }` selector to apply transforms. Instead, you must use another selector (such as class or id, etc) to select the `<svg>` element.

I changed our code to not rely on CSS and instead use a separate icon to display the down arrow (like the operations do). I believe this approach is more pure, regardless of the Firefox bug.

<img width="1677" alt="screen shot 2017-06-27 at 8 54 22 pm" src="https://user-images.githubusercontent.com/791222/27618914-3635db70-5b7c-11e7-80f0-d5b50f1320fc.png">
