### PR TITLE
Trigger setScheme when a new set of schemes come in

### DIFF
--- a/src/core/components/schemes.jsx
+++ b/src/core/components/schemes.jsx
@@ -20,6 +20,12 @@ export default class Schemes extends React.Component {
     this.setScheme( e.target.value )
   }
 
+  componentWillReceiveProps(nextProps) {
+    if(nextProps.schemes !== this.props.schemes) {
+      this.setScheme(nextProps.schemes.first())
+    }
+  }
+
   setScheme =( value ) => {
     let { path, method, specActions } = this.props
 


### PR DESCRIPTION
Fixes #3166.

Causes the default scheme to be updated when a new spec loads.