### PR TITLE
Adding support for operation versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 npm-debug.log*
 .eslintcache
 package-lock.json
+*.iml

--- a/src/core/components/operation.jsx
+++ b/src/core/components/operation.jsx
@@ -119,6 +119,7 @@ export default class Operation extends PureComponent {
       authSelectors
     } = this.props
 
+    let version = operation.get("version")
     let summary = operation.get("summary")
     let description = operation.get("description")
     let deprecated = operation.get("deprecated")
@@ -164,6 +165,12 @@ export default class Operation extends PureComponent {
                 <div className="opblock-summary-description">
                   { summary }
                 </div>
+            }
+
+            { !version ? null :
+              <span className="opblock-summary-version">
+                <span>{version}</span>
+              </span>
             }
 
             { displayOperationId && operationId ? <span className="opblock-summary-operation-id">{operationId}</span> : null }

--- a/src/style/_layout.scss
+++ b/src/style/_layout.scss
@@ -208,6 +208,18 @@ body
         @include text_headline(#fff);
     }
 
+    .opblock-summary-version
+    {
+        color: white;
+        margin: 0 0 0 10px;
+        padding: 2px 4px;
+        font-size: 12px;
+        background: #3b4151;
+        font-family: 'Source Code Pro', monospace;
+        font-weight: 600;
+        border-radius: .25rem;
+    }
+
     .opblock-summary-path,
     .opblock-summary-operation-id,
     .opblock-summary-path__deprecated


### PR DESCRIPTION
This PR enables operation versioning (https://github.com/OAI/OpenAPI-Specification/pull/1240).

Until the v3 spec, this won't be enabled in swagger-ui, but one can get it to work by manually updating the local v2 spec like https://github.com/OAI/OpenAPI-Specification/pull/1239