### PR TITLE
Flip operation auth button UI state.

### DIFF
--- a/src/core/components/auth/authorize-operation-btn.jsx
+++ b/src/core/components/auth/authorize-operation-btn.jsx
@@ -22,9 +22,9 @@ export default class AuthorizeOperationBtn extends React.Component {
     }
 
     return (
-      <button className={isAuthorized ? "authorization__btn locked" : "authorization__btn unlocked"} onClick={ this.onClick }>
+      <button className={isAuthorized ? "authorization__btn unlocked" : "authorization__btn locked"} onClick={ this.onClick }>
         <svg width="20" height="20">
-          <use xlinkHref={ isAuthorized ? "#locked" : "#unlocked" } />
+          <use xlinkHref={ isAuthorized ? "#unlocked" : "#locked" } />
         </svg>
       </button>
 


### PR DESCRIPTION
See #3322 - button state starts unlocked and goes to locked after authorization, which seems backwards.

This flips that logic, so that the button starts locked, but transitions to unlocked after authorization. 