### PR TITLE
Fixes #3271 - Trimming parameter values

### DIFF
--- a/src/core/components/param-body.jsx
+++ b/src/core/components/param-body.jsx
@@ -49,10 +49,11 @@ export default class ParamBody extends PureComponent {
     let { specSelectors, pathMethod, param, isExecute, consumesValue="" } = props
     let parameter = specSelectors ? specSelectors.getParameter(pathMethod, param.get("name")) : {}
     let isXml = /xml/i.test(consumesValue)
+    let isJson = /json/i.test(consumesValue)
     let paramValue = isXml ? parameter.get("value_xml") : parameter.get("value")
 
     if ( paramValue !== undefined ) {
-      let val = !paramValue && !isXml ? "{}" : paramValue
+      let val = !paramValue && isJson ? "{}" : paramValue
       this.setState({ value: val })
       this.onChange(val, {isXml: isXml, isEditBox: isExecute})
     } else {
@@ -79,8 +80,11 @@ export default class ParamBody extends PureComponent {
   _onChange = (val, isXml) => { (this.props.onChange || NOOP)(this.props.param, val, isXml) }
 
   handleOnChange = e => {
-    let {consumesValue} = this.props
-    this.onChange(e.target.value.trim(), {isXml: /xml/i.test(consumesValue)})
+    const {consumesValue} = this.props
+    const isJson = /json/i.test(consumesValue)
+    const isXml = /xml/i.test(consumesValue)
+    const inputValue = isJson ? e.target.value.trim() : e.target.value
+    this.onChange(inputValue, {isXml})
   }
 
   toggleIsEditBox = () => this.setState( state => ({isEditBox: !state.isEditBox}))


### PR DESCRIPTION
Fixes #3271 

Only trim parameter values if the parameter's content type is JSON. Change default value of parameter inputs to be '{}' only if the parameter's content type is JSON.

<img width="220" alt="screen shot 2017-07-06 at 7 48 51 pm" src="https://user-images.githubusercontent.com/791222/27939941-0625dbc8-6285-11e7-9268-cf9b711c3aa8.png">

<img width="217" alt="screen shot 2017-07-06 at 7 48 49 pm" src="https://user-images.githubusercontent.com/791222/27939944-09820a12-6285-11e7-8252-9f1dcb7e1f53.png">

