### PR TITLE
Do not merge, discussion requested - onComplete callback

### DIFF
--- a/src/core/plugins/spec/wrap-actions.js
+++ b/src/core/plugins/spec/wrap-actions.js
@@ -1,3 +1,5 @@
+import { delay } from "lodash"
+
 export const updateSpec = (ori, {specActions}) => (...args) => {
   ori(...args)
   specActions.parseToJson(...args)
@@ -6,6 +8,13 @@ export const updateSpec = (ori, {specActions}) => (...args) => {
 export const updateJsonSpec = (ori, {specActions}) => (...args) => {
   ori(...args)
   specActions.resolveSpec(...args)
+}
+
+// Wrap `updateResolved` so we can call `configs.onComplete` when a spec has loaded
+export const updateResolved = (ori, {triggerOnComplete}) => (...args) => {
+  ori(...args)
+  // Ew a delay... our state is updated but we need to give the UI time to render
+  delay( triggerOnComplete, 500 )
 }
 
 // Log the request ( just for debugging, shouldn't affect prod )

--- a/src/core/system.js
+++ b/src/core/system.js
@@ -97,6 +97,7 @@ export default class Store {
       getComponents: this.getComponents.bind(this),
       getState: this.getStore().getState,
       getConfigs: this._getConfigs.bind(this),
+      triggerOnComplete: this.triggerOnComplete.bind(this),
       Im
     }, this.system.rootInjects || {})
   }
@@ -259,6 +260,13 @@ export default class Store {
     return (dispatch) => {
       return deepExtend({}, this.getWrappedAndBoundActions(dispatch), this.getFn(), extras)
     }
+  }
+
+  triggerOnComplete() {
+    const fn = this.getConfigs().configs.onComplete
+    if ( isFunc(fn) ) {
+      fn( this )
+    } 
   }
 
 }


### PR DESCRIPTION
Ping @shockey @webron 

First off, to Ron: What's the desired functionality here? Should this work when UI is used with Editor? My current implementation calls the `onComplete` function whenever the spec URL changes. 

To Kyle: I don't like my approach. I think it's dirty (in more ways than one), but I'm not familiar enough with the system yet to know exactly how to tackle this. How would you approach adding the `onComplete` callback?