### PR TITLE
fixing Non-ascii character class name

### DIFF
--- a/src/core/components/parameter-row.jsx
+++ b/src/core/components/parameter-row.jsx
@@ -94,7 +94,7 @@ export default class ParameterRow extends Component {
             { param.get("name") }
             { !required ? null : <span style={{color: "red"}}>&nbsp;*</span> }
           </div>
-          <div className="parаmeter__type">{ param.get("type") } { itemType && `[${itemType}]` }</div>
+          <div className="parameter__type">{ param.get("type") } { itemType && `[${itemType}]` }</div>
           <div className="parameter__in">({ param.get("in") })</div>
         </td>
 

--- a/src/style/_layout.scss
+++ b/src/style/_layout.scss
@@ -113,7 +113,7 @@ body
     }
 }
 
-.parаmeter__type
+.parameter__type
 {
     font-size: 12px;
 


### PR DESCRIPTION
Fixed to LATIN SMALL LETTER A because class name contained CYRILLIC
SMALL LETTER A.
ref issue #3104