### PR TITLE
Fixes #3375 - Change order of logic for selecting requestContentType

### DIFF
--- a/src/core/plugins/spec/selectors.js
+++ b/src/core/plugins/spec/selectors.js
@@ -277,12 +277,13 @@ export function parametersIncludeType(parameters, typeValue="") {
 export function contentTypeValues(state, pathMethod) {
   let op = spec(state).getIn(["paths", ...pathMethod], fromJS({}))
   const parameters = op.get("parameters") || new List()
-  const requestContentType = (
-      parametersIncludeType(parameters, "file") ? "multipart/form-data"
-    : parametersIncludeIn(parameters, "formData") ? "application/x-www-form-urlencoded"
-    : op.get("consumes_value")
-  )
 
+  const requestContentType = (
+    op.get("consumes_value") ? op.get("consumes_value")
+      : parametersIncludeType(parameters, "file") ? "multipart/form-data"
+      : parametersIncludeType(parameters, "formData") ? "application/x-www-form-urlencoded"
+      : undefined
+  )
 
   return fromJS({
     requestContentType,

--- a/test/core/plugins/spec/selectors.js
+++ b/test/core/plugins/spec/selectors.js
@@ -52,7 +52,6 @@ describe("spec plugin - selectors", function(){
   })
 
   describe("contentTypeValues", function(){
-
     it("should return { requestContentType, responseContentType } from an operation", function(){
       // Given
       let state = fromJS({
@@ -75,6 +74,73 @@ describe("spec plugin - selectors", function(){
         requestContentType: "one",
         responseContentType: "two"
       })
+    })
+
+    it("should prioritize consumes value first from an operation", function(){
+      // Given
+      let state = fromJS({
+        resolved: {
+          paths: {
+            "/one": {
+              get: {
+                "consumes_value": "one",
+                "parameters": [{  
+                  "type": "file"
+                }],
+              }
+            }
+          }
+        }
+      })
+
+      // When
+      let contentTypes = contentTypeValues(state, [ "/one", "get" ])
+      // Then
+      expect(contentTypes.toJS().requestContentType).toEqual("one")
+    })
+
+    it("should fallback to multipart/form-data if there is no consumes value but there is a file parameter", function(){
+      // Given
+      let state = fromJS({
+        resolved: {
+          paths: {
+            "/one": {
+              get: {
+                "parameters": [{  
+                  "type": "file"
+                }],
+              }
+            }
+          }
+        }
+      })
+
+      // When
+      let contentTypes = contentTypeValues(state, [ "/one", "get" ])
+      // Then
+      expect(contentTypes.toJS().requestContentType).toEqual("multipart/form-data")
+    })
+
+    it("should fallback to application/x-www-form-urlencoded if there is no consumes value, no file parameter, but there is a formData parameter", function(){
+      // Given
+      let state = fromJS({
+        resolved: {
+          paths: {
+            "/one": {
+              get: {
+                "parameters": [{  
+                  "type": "formData"
+                }],
+              }
+            }
+          }
+        }
+      })
+
+      // When
+      let contentTypes = contentTypeValues(state, [ "/one", "get" ])
+      // Then
+      expect(contentTypes.toJS().requestContentType).toEqual("application/x-www-form-urlencoded")
     })
 
     it("should be ok, if no operation found", function(){


### PR DESCRIPTION
Fixes #3375 

Change order of logic for selecting `requestContentType` to prioritize `consumes_value` first and then fallback to parameter values.