### PR TITLE
Fixed bug in module export name for absolute path in swagger-ui-dist

### DIFF
--- a/swagger-ui-dist-package/index.js
+++ b/swagger-ui-dist-package/index.js
@@ -10,4 +10,4 @@ try {
   // for more information.
 }
 
-module.exports.absolutePath = require("./absolute-path.js")
+module.exports.getAbsoluteFSPath = require("./absolute-path.js")

--- a/swagger-ui-dist-package/index.js
+++ b/swagger-ui-dist-package/index.js
@@ -10,4 +10,8 @@ try {
   // for more information.
 }
 
+// `absolutePath` and `getAbsoluteFSPath` are both here because at one point,
+// we documented having one and actually implemented the other.
+// They were both retained so we don't break anyone's code.
+module.exports.absolutePath = require("./absolute-path.js")
 module.exports.getAbsoluteFSPath = require("./absolute-path.js")


### PR DESCRIPTION
There was a small bug that I noticed in this PR: #3218. If you follow the example usage in the [Readme for swagger-ui-dist-package](https://github.com/swagger-api/swagger-ui/tree/master/swagger-ui-dist-package), you will notice that calling `require("swagger-ui-dist").getAbsoluteFSPath()` does not work, but `require("swagger-ui-dist").absolutePath()` does.

This PR simply renames the export to fix this issue.