### PR TITLE
Fix length issue in OrderedMaps

### DIFF
--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -41,7 +41,7 @@ export function fromJSOrdered (js) {
   return !isObject(js) ? js :
     Array.isArray(js) ?
       Im.Seq(js).map(fromJSOrdered).toList() :
-      Im.Seq(js).map(fromJSOrdered).toOrderedMap()
+      Im.OrderedMap(js).map(fromJSOrdered)
 }
 
 export function bindToState(obj, state) {

--- a/test/core/utils.js
+++ b/test/core/utils.js
@@ -1,10 +1,10 @@
 /* eslint-env mocha */
 import expect from "expect"
 import { fromJS } from "immutable"
-import { mapToList, validateNumber, validateInteger, validateParam, validateFile } from "core/utils"
+import { mapToList, validateNumber, validateInteger, validateParam, validateFile, fromJSOrdered } from "core/utils"
 import win from "core/window"
 
-describe("utils", function(){
+describe("utils", function() {
 
   describe("mapToList", function(){
 
@@ -306,4 +306,31 @@ describe("utils", function(){
       expect( result ).toEqual( [{index: 0, error: "Value must be an integer"}, {index: 1, error: "Value must be an integer"}] )
     })
   })
+
+  describe("fromJSOrdered", () => {
+    it("should create an OrderedMap from an object", () => {
+      const param = {
+        value: "test"
+      }
+
+      const result = fromJSOrdered(param).toJS()
+      expect( result ).toEqual( { value: "test" } )
+    })
+
+    it("should not use an object's length property for Map size", () => {
+      const param = {
+        length: 5
+      }
+
+      const result = fromJSOrdered(param).toJS()
+      expect( result ).toEqual( { length: 5 } )
+    })
+
+    it("should create an OrderedMap from an array", () => {
+      const param = [1, 1, 2, 3, 5, 8]
+
+      const result = fromJSOrdered(param).toJS()
+      expect( result ).toEqual( [1, 1, 2, 3, 5, 8] )
+    })
+    })
 })


### PR DESCRIPTION
Previously, a definiton with a 'length' property with numeric value
would result in an OrderedMap of that length.

This is now fixed and covered by tests

This is the failing test case before this fix:
```
1) utils fromJSOrdered should not use an object's length property for Map size:

      Error: Expected { 0: undefined, 1: undefined, 2: undefined, 3: undefined, 4: undefined } to equal { length: 5 }
      + expected - actual

       {
      -  "0": [undefined]
      -  "1": [undefined]
      -  "2": [undefined]
      -  "3": [undefined]
      -  "4": [undefined]
      +  "length": 5
       }
```