### PR TITLE
Remove fallback to name for array model title (Fixes #3424)

### DIFF
--- a/src/core/components/array-model.jsx
+++ b/src/core/components/array-model.jsx
@@ -15,9 +15,9 @@ export default class ArrayModel extends Component {
   }
 
   render(){
-    let { getComponent, required, schema, depth, expandDepth } = this.props
+    let { getComponent, required, schema, depth, expandDepth, name } = this.props
     let items = schema.get("items")
-    let title = schema.get("title")
+    let title = schema.get("title") || name
     let properties = schema.filter( ( v, key) => ["type", "items", "$$ref"].indexOf(key) === -1 )
 
     const ModelCollapse = getComponent("ModelCollapse")

--- a/src/core/components/array-model.jsx
+++ b/src/core/components/array-model.jsx
@@ -17,13 +17,13 @@ export default class ArrayModel extends Component {
   render(){
     let { getComponent, required, schema, depth, expandDepth } = this.props
     let items = schema.get("items")
-    let title = schema.get("title") || name
+    let title = schema.get("title")
     let properties = schema.filter( ( v, key) => ["type", "items", "$$ref"].indexOf(key) === -1 )
 
     const ModelCollapse = getComponent("ModelCollapse")
     const Model = getComponent("Model")
 
-    const titleEl = title && 
+    const titleEl = title &&
       <span className="model-title">
         <span className="model-title__text">{ title }</span>
       </span>


### PR DESCRIPTION
In `<ArrayModel>`, removes the fallback to `name` when no title is specified.

This fixes an issue where the name of the parent `<iframe>` is incorrectly displayed when swagger-ui is embedded in an iframe.

See #3424 for a full description of the issue and the fix.