### PR TITLE
Fixes #3422 - Expand/collapse arrows fix

### DIFF
--- a/src/core/components/models.jsx
+++ b/src/core/components/models.jsx
@@ -24,8 +24,8 @@ export default class Models extends Component {
     return <section className={ showModels ? "models is-open" : "models"}>
       <h4 onClick={() => layoutActions.show("models", !showModels)}>
         <span>Models</span>
-        <svg width="20" height="20">
-          <use xlinkHref="#large-arrow" />
+        <svg className="arrow" width="20" height="20">
+          <use xlinkHref={showModels ? "#large-arrow-down" : "#large-arrow"} />
         </svg>
       </h4>
       <Collapse isOpened={showModels}>


### PR DESCRIPTION
Fixes #3422 

Fixed regression bug on models.jsx expand/collapse arrows due to bad merge