### PR TITLE
Fixes #3434 - Change link style color

### DIFF
--- a/src/style/_layout.scss
+++ b/src/style/_layout.scss
@@ -508,6 +508,15 @@ body
         {
             margin: 0;
         }
+
+        a
+        {
+            @include text_code(#89bf04);
+            text-decoration: underline;
+            &:hover {
+                color: #81b10c;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #3434 

<img width="189" alt="screen shot 2017-07-21 at 6 40 01 pm" src="https://user-images.githubusercontent.com/791222/28486933-1603433e-6e45-11e7-9423-383d45683d00.png">
