### PR TITLE
Fixes #3435 - Fix rendering of image/* content types

### DIFF
--- a/src/core/components/response-body.jsx
+++ b/src/core/components/response-body.jsx
@@ -40,7 +40,7 @@ export default class ResponseBody extends React.Component {
 
       // Image
     } else if (/^image\//i.test(contentType)) {
-      bodyEl = <img src={ url } />
+      bodyEl = <img src={ window.URL.createObjectURL(content) } />
 
       // Audio
     } else if (/^audio\//i.test(contentType)) {


### PR DESCRIPTION
Fixes #3435 

When rendering a response with content-type "image/*" we were just inserting the URL of the request into the `<img>` element. This would cause the browser to make a `GET` request to the URL.

Now, instead of inserting the URL into the `<img>` element, we take the returned response, assume it is an image (JS [Blob](https://developer.mozilla.org/en/docs/Web/API/Blob) because of the returned content-type), and then insert a [`URL.createObjectURL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL). 

Also added the `max-width` style to ensure rendered images to do not extend past the edge of their parent.

<img width="831" alt="screen shot 2017-07-21 at 8 48 15 pm" src="https://user-images.githubusercontent.com/791222/28487774-f379575c-6e55-11e7-8457-b8c23e63c66c.png">

<img width="1042" alt="screen shot 2017-07-21 at 8 25 09 pm" src="https://user-images.githubusercontent.com/791222/28487776-f91e0dec-6e55-11e7-8631-32bc49d4ba8e.png">
