### PR TITLE
Use the minified version of swagger-ui

### DIFF
--- a/src/main/html/index.html
+++ b/src/main/html/index.html
@@ -20,7 +20,7 @@
   <script src='lib/handlebars-4.0.5.js' type='text/javascript'></script>
   <script src='lib/lodash.min.js' type='text/javascript'></script>
   <script src='lib/backbone-min.js' type='text/javascript'></script>
-  <script src='swagger-ui.js' type='text/javascript'></script>
+  <script src='swagger-ui.min.js' type='text/javascript'></script>
   <script src='lib/highlight.9.1.0.pack.js' type='text/javascript'></script>
   <script src='lib/highlight.9.1.0.pack_extended.js' type='text/javascript'></script>
   <script src='lib/jsoneditor.min.js' type='text/javascript'></script>


### PR DESCRIPTION
I'm not really sure if I'm missing something but I noticed that by default, index.html uses the non minified `swagger-ui.js`. Since this file is included in the dist folder and that the dist folder is advertised as 'ready to be used as is', shouldn't using the minified file be a default?