### PR TITLE
Remove config filtering

### DIFF
--- a/src/core/index.js
+++ b/src/core/index.js
@@ -4,34 +4,7 @@ import System from "core/system"
 import win from "core/window"
 import ApisPreset from "core/presets/apis"
 import * as AllPlugins from "core/plugins/all"
-import { parseSearch, filterConfigs } from "core/utils"
-
-const CONFIGS = [
-  "url",
-  "urls",
-  "urls.primaryName",
-  "spec",
-  "validatorUrl",
-  "onComplete",
-  "onFailure",
-  "authorizations",
-  "docExpansion",
-  "tagsSorter",
-  "maxDisplayedTags",
-  "filter",
-  "operationsSorter",
-  "supportedSubmitMethods",
-  "dom_id",
-  "defaultModelRendering",
-  "oauth2RedirectUrl",
-  "showRequestHeaders",
-  "custom",
-  "modelPropertyMacro",
-  "parameterMacro",
-  "displayOperationId",
-  "displayRequestDuration",
-  "deepLinking",
- ]
+import { parseSearch } from "core/utils"
 
 // eslint-disable-next-line no-undef
 const { GIT_DIRTY, GIT_COMMIT, PACKAGE_VERSION, HOSTNAME, BUILD_TIME } = buildInfo
@@ -126,7 +99,7 @@ module.exports = function SwaggerUI(opts) {
 
     let localConfig = system.specSelectors.getLocalConfig ? system.specSelectors.getLocalConfig() : {}
     let mergedConfig = deepExtend({}, localConfig, constructorConfig, fetchedConfig || {}, queryConfig)
-    store.setConfigs(filterConfigs(mergedConfig, CONFIGS))
+    store.setConfigs(mergedConfig)
 
     if (fetchedConfig !== null) {
       if (!queryConfig.url && typeof mergedConfig.spec === "object" && Object.keys(mergedConfig.spec).length) {

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -597,18 +597,6 @@ export const buildFormData = (data) => {
   return formArr.join("&")
 }
 
-export const filterConfigs = (configs, allowed) => {
-    let i, filteredConfigs = {}
-
-    for (i in configs) {
-        if (allowed.indexOf(i) !== -1) {
-            filteredConfigs[i] = configs[i]
-        }
-    }
-
-    return filteredConfigs
-}
-
 // Is this really required as a helper? Perhaps. TODO: expose the system of presets.apis in docs, so we know what is supported
 export const shallowEqualKeys = (a,b, keys) => {
   return !!find(keys, (key) => {


### PR DESCRIPTION
This PR makes arbitrary config items possible without nesting under the `custom` key.