### PR TITLE
Remove default of opening links in new tab in markdown content

### DIFF
--- a/src/core/components/providers/markdown.jsx
+++ b/src/core/components/providers/markdown.jsx
@@ -13,7 +13,7 @@ function Markdown({ source }) {
 
   return <div className="markdown">
     <Remarkable
-      options={{html: true, typographer: true, breaks: true, linkify: true, linkTarget: "_blank"}}
+      options={{html: true, typographer: true, breaks: true, linkify: true}}
       source={sanitized}
       ></Remarkable>
   </div>


### PR DESCRIPTION
Fixes #3473 
Remove default of opening links in new tab in markdown content