### PR TITLE
v3.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The OpenAPI Specification has undergone 5 revisions since initial creation in 20
 
 Swagger UI Version | Release Date | OpenAPI Spec compatibility | Notes
 ------------------ | ------------ | -------------------------- | -----
-3.1.3 | 2017-08-04 | 2.0, 3.0 | [tag v3.1.3](https://github.com/swagger-api/swagger-ui/tree/v3.1.3)
+3.1.4 | 2017-08-05 | 2.0, 3.0 | [tag v3.1.4](https://github.com/swagger-api/swagger-ui/tree/v3.1.4)
 3.0.21 | 2017-07-26 | 2.0 | [tag v3.0.21](https://github.com/swagger-api/swagger-ui/tree/v3.0.21)
 2.2.10 | 2017-01-04 | 1.1, 1.2, 2.0 | [tag v2.2.10](https://github.com/swagger-api/swagger-ui/tree/v2.2.10)
 2.1.5 | 2016-07-20 | 1.1, 1.2, 2.0 | [tag v2.1.5](https://github.com/swagger-api/swagger-ui/tree/v2.1.5)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-ui",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "main": "dist/swagger-ui.js",
   "repository": "git@github.com:swagger-api/swagger-ui.git",
   "contributors": [

--- a/src/core/components/object-model.jsx
+++ b/src/core/components/object-model.jsx
@@ -17,7 +17,8 @@ export default class ObjectModel extends Component {
   }
 
   render(){
-    let { schema, name, isRef, getComponent, depth, expandDepth, specSelectors, ...props } = this.props
+    let { schema, name, isRef, getComponent, depth, expandDepth, ...otherProps } = this.props
+    let { specSelectors } = otherProps
     let { isOAS3 } = specSelectors
 
     let description = schema.get("description")
@@ -82,7 +83,7 @@ export default class ObjectModel extends Component {
                           { key }{ isRequired && <span style={{ color: "red" }}>*</span> }
                         </td>
                         <td style={{ verticalAlign: "top" }}>
-                          <Model key={ `object-${name}-${key}_${value}` } { ...props }
+                          <Model key={ `object-${name}-${key}_${value}` } { ...otherProps }
                                  required={ isRequired }
                                  getComponent={ getComponent }
                                  schema={ value }
@@ -96,7 +97,7 @@ export default class ObjectModel extends Component {
                   : <tr>
                     <td>{ "< * >:" }</td>
                     <td>
-                      <Model { ...props } required={ false }
+                      <Model { ...otherProps } required={ false }
                              getComponent={ getComponent }
                              schema={ additionalProperties }
                              depth={ depth + 1 } />
@@ -109,7 +110,7 @@ export default class ObjectModel extends Component {
                     <td>{ "anyOf ->" }</td>
                     <td>
                       {anyOf.map((schema, k) => {
-                        return <div key={k}><Model { ...props } required={ false }
+                        return <div key={k}><Model { ...otherProps } required={ false }
                                  getComponent={ getComponent }
                                  schema={ schema }
                                  depth={ depth + 1 } /></div>
@@ -123,7 +124,7 @@ export default class ObjectModel extends Component {
                     <td>{ "oneOf ->" }</td>
                     <td>
                       {oneOf.map((schema, k) => {
-                        return <div key={k}><Model { ...props } required={ false }
+                        return <div key={k}><Model { ...otherProps } required={ false }
                                  getComponent={ getComponent }
                                  schema={ schema }
                                  depth={ depth + 1 } /></div>
@@ -137,7 +138,7 @@ export default class ObjectModel extends Component {
                     <td>{ "not ->" }</td>
                     <td>
                       {not.map((schema, k) => {
-                        return <div key={k}><Model { ...props } required={ false }
+                        return <div key={k}><Model { ...otherProps } required={ false }
                                  getComponent={ getComponent }
                                  schema={ schema }
                                  depth={ depth + 1 } /></div>


### PR DESCRIPTION
This is a hotfix release that fixes #3527.

[This master->feature merge commit](https://github.com/shockey/swagger-ui/commit/19e09c2296ca35b93086191bc467d112885d06b1#diff-e2f9bad009c5118ab66b94bdf8abaeeaR20) that I made yesterday when merging #3509 contained a subtle error.

## What happened

In `ObjectModel`, we destructure props at the top of `render()`, like we do in many components:

```js
let { schema, name, isRef, getComponent, depth, expandDepth, ...props } = this.props
```

There's two things going on here: we're grabbing some props from `this.props` that we want and adding them to the local scope, and storing the rest of the props in `props` with [destructuring rest syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#Rest_in_Object_Destructuring).

In the merge commit linked above, I added `specSelectors` to the destructuring statement, to support the object model anyOf/oneOf/not changes from #3513. Here's the props destructuring statement after the merge:

```js
let { schema, name, isRef, getComponent, depth, expandDepth, specSelectors, ...props } = this.props
```

Further down in the same render function, we pass `props` to child components (which end up being the right-hand side of the Model display, seen broken in the issue linked above):

```jsx
<Model 
  { ...props } // this is the important bit
  required={ false }
  getComponent={ getComponent }
  schema={ additionalProperties }
  depth={ depth + 1 }
 />
```

We're spreading our `props` object onto the child component with `{ ...props }`. 

Unfortunately, my merge commit that added `specSelectors` to the props destructuring statement (for use in the `ObjectModel` scope) had the side effect of removing `specSelectors` from the `props` object used here. This resulted in `Model` having no `specSelectors` prop, which it needs to work properly, especially with the OAS3 deprecated parameter support introduced this week in #3458.

---

There was no linter or test indication that something had gone wrong. I know this is a bit of a "perfect storm" situation, but this practice of using "rest of props" is fragile.

I propose we end use of rest syntax in props destructuring by implementing an ESLint rule. Instead, we should be verbose by creating objects specifically for use in spreading onto child props, or simply passing in each prop explicitly to the child. 

P.S.: It's worth noting that #3265 would have saved us from shipping this.