### PR TITLE
Fix #3541 &  #3470 remove unnecessary componentWillReceiveProps

### DIFF
--- a/src/core/components/schemes.jsx
+++ b/src/core/components/schemes.jsx
@@ -18,13 +18,6 @@ export default class Schemes extends React.Component {
     this.setScheme(schemes.first())
   }
 
-  componentWillReceiveProps(nextProps) {
-    if ( !this.props.operationScheme || !nextProps.schemes.has(this.props.operationScheme) ) {
-      // if we don't have a selected operationScheme or if our selected scheme is no longer an option,
-      // then fire 'change' event and select the first scheme in the list of options
-      this.setScheme(nextProps.schemes.first())
-    }
-  }
 
   onChange =( e ) => {
     this.setScheme( e.target.value )

--- a/test/components/schemes.js
+++ b/test/components/schemes.js
@@ -28,12 +28,9 @@ describe("<Schemes/>", function(){
 
     // Then operationScheme should default to first scheme in options list
     expect(props.specActions.setScheme).toHaveBeenCalledWith("http", "/test" , "get")
-
-    // When the operationScheme is no longer in the list of options
-    props.schemes = fromJS([
-      "https"
-    ])
-    wrapper.setProps(props)
+    
+    // Call onChange, mimic selecting from dropdown
+    wrapper.props().children[1].props.onChange({target: {value: "https"}})
 
     // Then operationScheme should default to first scheme in options list
     expect(props.specActions.setScheme).toHaveBeenCalledWith("https", "/test", "get")


### PR DESCRIPTION
Fix #3541 &  #3470 by removing componentWillReceiveProps (couldn't find a use case that actually needs this. The Mount will take care of the initial scheme and onChange will handle the rest.

The issue was `componentWillReceiveProps` changes the scheme back to the one that's first in the array directly after setScheme is called (overriding the scheme value back to whatever is first)