### PR TITLE
Fix global state issues with Schemes component

### DIFF
--- a/src/core/components/layouts/base.jsx
+++ b/src/core/components/layouts/base.jsx
@@ -69,7 +69,10 @@ export default class BaseLayout extends React.Component {
               <div className="scheme-container">
                 <Col className="schemes wrapper" mobile={12}>
                   { schemes && schemes.size ? (
-                    <Schemes schemes={ schemes } specActions={ specActions } />
+                    <Schemes
+                      operationScheme={specSelectors.operationScheme()}
+                      schemes={ schemes }
+                      specActions={ specActions } />
                   ) : null }
 
                   { securityDefinitions ? (

--- a/src/core/components/layouts/base.jsx
+++ b/src/core/components/layouts/base.jsx
@@ -70,7 +70,7 @@ export default class BaseLayout extends React.Component {
                 <Col className="schemes wrapper" mobile={12}>
                   { schemes && schemes.size ? (
                     <Schemes
-                      operationScheme={specSelectors.operationScheme()}
+                      currentScheme={specSelectors.operationScheme()}
                       schemes={ schemes }
                       specActions={ specActions } />
                   ) : null }

--- a/src/core/components/operation.jsx
+++ b/src/core/components/operation.jsx
@@ -229,7 +229,7 @@ export default class Operation extends PureComponent {
                              path={ path }
                              method={ method }
                              specActions={ specActions }
-                             operationScheme={ operationScheme } />
+                             currentScheme={ operationScheme } />
                   </div> : null
               }
 

--- a/src/core/components/schemes.jsx
+++ b/src/core/components/schemes.jsx
@@ -19,7 +19,7 @@ export default class Schemes extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if ( !this.props.operationScheme || !nextProps.schemes.has(this.props.operationScheme) ) {
+    if ( !this.props.operationScheme || !nextProps.schemes.includes(this.props.operationScheme) ) {
       // if we don't have a selected operationScheme or if our selected scheme is no longer an option,
       // then fire 'change' event and select the first scheme in the list of options
       this.setScheme(nextProps.schemes.first())

--- a/src/core/components/schemes.jsx
+++ b/src/core/components/schemes.jsx
@@ -6,9 +6,9 @@ export default class Schemes extends React.Component {
   static propTypes = {
     specActions: PropTypes.object.isRequired,
     schemes: PropTypes.object.isRequired,
+    operationScheme: PropTypes.string.isRequired,
     path: PropTypes.string,
     method: PropTypes.string,
-    operationScheme: PropTypes.string
   }
 
   componentWillMount() {

--- a/src/core/components/schemes.jsx
+++ b/src/core/components/schemes.jsx
@@ -6,7 +6,7 @@ export default class Schemes extends React.Component {
   static propTypes = {
     specActions: PropTypes.object.isRequired,
     schemes: PropTypes.object.isRequired,
-    operationScheme: PropTypes.string.isRequired,
+    currentScheme: PropTypes.string.isRequired,
     path: PropTypes.string,
     method: PropTypes.string,
   }
@@ -19,8 +19,8 @@ export default class Schemes extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if ( !this.props.operationScheme || !nextProps.schemes.includes(this.props.operationScheme) ) {
-      // if we don't have a selected operationScheme or if our selected scheme is no longer an option,
+    if ( !this.props.currentScheme || !nextProps.schemes.includes(this.props.currentScheme) ) {
+      // if we don't have a selected currentScheme or if our selected scheme is no longer an option,
       // then fire 'change' event and select the first scheme in the list of options
       this.setScheme(nextProps.schemes.first())
     }

--- a/test/components/schemes.js
+++ b/test/components/schemes.js
@@ -7,7 +7,7 @@ import { fromJS } from "immutable"
 import Schemes from "components/schemes"
 
 describe("<Schemes/>", function(){
-  it("calls props.specActions.setScheme() when no operationScheme is selected", function(){
+  it("calls props.specActions.setScheme() when no currentScheme is selected", function(){
 
     let setSchemeSpy = createSpy()
 
@@ -20,7 +20,7 @@ describe("<Schemes/>", function(){
         "http",
         "https"
       ]),
-      operationScheme: undefined,
+      currentScheme: undefined,
       path: "/test",
       method: "get"
     }
@@ -28,16 +28,16 @@ describe("<Schemes/>", function(){
     // When
     let wrapper = shallow(<Schemes {...props}/>)
 
-    // Then operationScheme should default to first scheme in options list
+    // Then currentScheme should default to first scheme in options list
     expect(props.specActions.setScheme).toHaveBeenCalledWith("http", "/test" , "get")
 
-    // When the operationScheme is no longer in the list of options
+    // When the currentScheme is no longer in the list of options
     props.schemes = fromJS([
       "https"
     ])
     wrapper.setProps(props)
 
-    // Then operationScheme should default to first scheme in options list
+    // Then currentScheme should default to first scheme in options list
     expect(props.specActions.setScheme).toHaveBeenCalledWith("https", "/test", "get")
   })
 
@@ -54,7 +54,7 @@ describe("<Schemes/>", function(){
         "http",
         "https"
       ]),
-      operationScheme: "https"
+      currentScheme: "https"
     }
 
     // When
@@ -66,7 +66,7 @@ describe("<Schemes/>", function(){
     // After an update
     wrapper.instance().componentWillReceiveProps(props)
 
-    // Should not be called again, since `operationScheme` is in schemes
+    // Should not be called again, since `currentScheme` is in schemes
     expect(setSchemeSpy.calls.length).toEqual(1)
   })
 })

--- a/test/components/schemes.js
+++ b/test/components/schemes.js
@@ -41,7 +41,7 @@ describe("<Schemes/>", function(){
     expect(props.specActions.setScheme).toHaveBeenCalledWith("https", "/test", "get")
   })
 
-  it.only("doesn't call props.specActions.setScheme() when schemes hasn't changed", function(){
+  it("doesn't call props.specActions.setScheme() when schemes hasn't changed", function(){
 
     let setSchemeSpy = createSpy()
 

--- a/test/components/schemes.js
+++ b/test/components/schemes.js
@@ -37,7 +37,7 @@ describe("<Schemes/>", function(){
     ])
     wrapper.setProps(props)
 
-    // Then currentScheme should default to first scheme in options list
+    // Then currentScheme should default to first scheme in options list, again
     expect(props.specActions.setScheme).toHaveBeenCalledWith("https", "/test", "get")
   })
 

--- a/test/components/schemes.js
+++ b/test/components/schemes.js
@@ -9,10 +9,12 @@ import Schemes from "components/schemes"
 describe("<Schemes/>", function(){
   it("calls props.specActions.setScheme() when no operationScheme is selected", function(){
 
+    let setSchemeSpy = createSpy()
+
     // Given
     let props = {
       specActions: {
-        setScheme: createSpy()
+        setScheme: setSchemeSpy
       },
       schemes: fromJS([
         "http",
@@ -22,7 +24,7 @@ describe("<Schemes/>", function(){
       path: "/test",
       method: "get"
     }
-    
+
     // When
     let wrapper = shallow(<Schemes {...props}/>)
 
@@ -37,5 +39,34 @@ describe("<Schemes/>", function(){
 
     // Then operationScheme should default to first scheme in options list
     expect(props.specActions.setScheme).toHaveBeenCalledWith("https", "/test", "get")
+  })
+
+  it.only("doesn't call props.specActions.setScheme() when schemes hasn't changed", function(){
+
+    let setSchemeSpy = createSpy()
+
+    // Given
+    let props = {
+      specActions: {
+        setScheme: setSchemeSpy
+      },
+      schemes: fromJS([
+        "http",
+        "https"
+      ]),
+      operationScheme: "https"
+    }
+
+    // When
+    let wrapper = shallow(<Schemes {...props}/>)
+
+    // Should be called initially, to set the global state
+    expect(setSchemeSpy.calls.length).toEqual(1)
+
+    // After an update
+    wrapper.instance().componentWillReceiveProps(props)
+
+    // Should not be called again, since `operationScheme` is in schemes
+    expect(setSchemeSpy.calls.length).toEqual(1)
   })
 })


### PR DESCRIPTION
Fixes #3541, fixes #3470.

Supersedes #3548.

Adds one previously-failing test.

---

The problem here was twofold:
1) The global `<Schemes>` component was not getting an `operationScheme` prop.
2) the comparator in `componentWillReceiveProps` was using `ImmutableList.has` (for keys) instead of `ImmutableList.includes` (for values).

---
Confirmed working:
- Global scheme switcher
- Operation-specific scheme switcher
- Example in #3541
- No regressions from #3166 