### PR TITLE
Allow render operation summary as Markdown

### DIFF
--- a/src/core/components/operation.jsx
+++ b/src/core/components/operation.jsx
@@ -172,7 +172,7 @@ export default class Operation extends PureComponent {
 
             { !showSummary ? null :
                 <div className="opblock-summary-description">
-                  { summary }
+                  <Markdown source={ summary } />
                 </div>
             }
 


### PR DESCRIPTION
This change allow using markdown for operation summary. 

![markdown_summary](https://user-images.githubusercontent.com/5052414/29220599-3d9d4eaa-7ec4-11e7-8db9-99797e530e0f.png)

