### PR TITLE
Bugfix for #3610

### DIFF
--- a/src/core/components/operation.jsx
+++ b/src/core/components/operation.jsx
@@ -161,12 +161,18 @@ export default class Operation extends PureComponent {
           <div className={`opblock-summary opblock-summary-${method}`} onClick={this.toggleShown} >
               <span className="opblock-summary-method">{method.toUpperCase()}</span>
               <span className={ deprecated ? "opblock-summary-path__deprecated" : "opblock-summary-path" } >
-                <a
-                  className="nostyle"
-                  onClick={(e) => e.preventDefault()}
-                  href={ isDeepLinkingEnabled ? `#/${isShownKey[1]}/${isShownKey[2]}` : ""} >
-                  <span>{path}</span>
-                </a>
+                {
+                  isDeepLinkingEnabled ? 
+                    <a
+                      className="nostyle"
+                      onClick={(e) => e.preventDefault()}
+                      href={`#/${isShownKey[1]}/${isShownKey[2]}`}>
+                      <span>{path}</span>
+                    </a> :
+                    <a className="nostyle">
+                      <span>{path}</span>
+                    </a>
+                }
                 <JumpToPath path={jumpToKey} />
               </span>
 

--- a/src/core/components/operation.jsx
+++ b/src/core/components/operation.jsx
@@ -161,18 +161,12 @@ export default class Operation extends PureComponent {
           <div className={`opblock-summary opblock-summary-${method}`} onClick={this.toggleShown} >
               <span className="opblock-summary-method">{method.toUpperCase()}</span>
               <span className={ deprecated ? "opblock-summary-path__deprecated" : "opblock-summary-path" } >
-                {
-                  isDeepLinkingEnabled ? 
-                    <a
-                      className="nostyle"
-                      onClick={(e) => e.preventDefault()}
-                      href={`#/${isShownKey[1]}/${isShownKey[2]}`}>
-                      <span>{path}</span>
-                    </a> :
-                    <a className="nostyle">
-                      <span>{path}</span>
-                    </a>
-                }
+              <a
+                className="nostyle"
+                onClick={isDeepLinkingEnabled ? (e) => e.preventDefault() : null}
+                href={isDeepLinkingEnabled ? `#/${isShownKey[1]}/${isShownKey[2]}` : null}>
+                <span>{path}</span>
+              </a>
                 <JumpToPath path={jumpToKey} />
               </span>
 

--- a/src/core/components/operations.jsx
+++ b/src/core/components/operations.jsx
@@ -79,18 +79,12 @@ export default class Operations extends React.Component {
                     onClick={() => layoutActions.show(isShownKey, !showTag)}
                     className={!tagDescription ? "opblock-tag no-desc" : "opblock-tag" }
                     id={isShownKey.join("-")}>
-                    { 
-                      isDeepLinkingEnabled ? 
-                        <a
-                          className="nostyle"
-                          onClick={(e) => e.preventDefault()}
-                          href= {`#/${tag}`}>
-                          <span>{tag}</span>
-                        </a>:
-                        <a className="nostyle">
-                          <span>{tag}</span>
-                        </a>
-                    }
+                    <a
+                      className="nostyle"
+                      onClick={isDeepLinkingEnabled ? (e) => e.preventDefault() : null}
+                      href= {isDeepLinkingEnabled ? `#/${tag}` : null}>
+                      <span>{tag}</span>
+                    </a>
                     { !tagDescription ? null :
                         <small>
                           { tagDescription }

--- a/src/core/components/operations.jsx
+++ b/src/core/components/operations.jsx
@@ -79,12 +79,18 @@ export default class Operations extends React.Component {
                     onClick={() => layoutActions.show(isShownKey, !showTag)}
                     className={!tagDescription ? "opblock-tag no-desc" : "opblock-tag" }
                     id={isShownKey.join("-")}>
-                    <a
-                      className="nostyle"
-                      onClick={(e) => e.preventDefault()}
-                      href={ isDeepLinkingEnabled ? `#/${tag}` : ""}>
-                      <span>{tag}</span>
-                    </a>
+                    { 
+                      isDeepLinkingEnabled ? 
+                        <a
+                          className="nostyle"
+                          onClick={(e) => e.preventDefault()}
+                          href= {`#/${tag}`}>
+                          <span>{tag}</span>
+                        </a>:
+                        <a className="nostyle">
+                          <span>{tag}</span>
+                        </a>
+                    }
                     { !tagDescription ? null :
                         <small>
                           { tagDescription }

--- a/src/style/_layout.scss
+++ b/src/style/_layout.scss
@@ -726,12 +726,12 @@ section
 a.nostyle {
   text-decoration: inherit;
   color: inherit;
-  cursor: auto;
+  cursor: pointer;
   display: inline;
 
   &:visited {
     text-decoration: inherit;
     color: inherit;
-    cursor: auto;
+    cursor: pointer;
   }
 }


### PR DESCRIPTION
Fixes #3610 

If deeplinking is disabled, removed the href attribute from the anchor tag fix because empty href points to the base location of the website which causes problems in any SPA.

A side effect is that when an anchor tag has no href it is no longer a hyperlink hence browsers do not show the hand pointer when we hover over it, so setting the pointer to default explicitly.