### PR TITLE
Only polyfill `Promise` if it doesn't exist at all

### DIFF
--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -1,2 +1,5 @@
 // Promise global, Used ( at least ) by 'whatwg-fetch'. And required by IE 11
-require("core-js/fn/promise")
+
+if(!window.Promise) {
+  require("core-js/fn/promise")
+}


### PR DESCRIPTION
Fixes #3586.

Adding this conditional overrides the test in core-js that overwrites `window.Promise` if the Promise implementation isn't standard (discussion: https://github.com/zloirock/core-js/issues/283, https://github.com/angular/zone.js/issues/783).

This _may_ open us up to issues with non-standard browsers, and applications that use funky Promise implementations, but the risk isn't widespread.

TODO:
- [x] Test with IE11