### PR TITLE
Fixes #3032 - Wrong property order

### DIFF
--- a/src/core/components/parameter-row.jsx
+++ b/src/core/components/parameter-row.jsx
@@ -81,12 +81,11 @@ export default class ParameterRow extends Component {
     const Markdown = getComponent("Markdown")
 
     let schema = param.get("schema")
-
     let type = isOAS3 && isOAS3() ? param.getIn(["schema", "type"]) : param.get("type")
     let isFormData = inType === "formData"
     let isFormDataSupported = "FormData" in win
     let required = param.get("required")
-    let itemType =  param.getIn(isOAS3 && isOAS3() ? ["schema", "items", "type"] : ["items", "type"])
+    let itemType = param.getIn(isOAS3 && isOAS3() ? ["schema", "items", "type"] : ["items", "type"])
     let parameter = specSelectors.getParameter(pathMethod, param.get("name"))
     let value = parameter ? parameter.get("value") : ""
 

--- a/src/core/components/response.jsx
+++ b/src/core/components/response.jsx
@@ -1,7 +1,7 @@
 import React from "react"
 import PropTypes from "prop-types"
 import { fromJS, Seq } from "immutable"
-import { getSampleSchema } from "core/utils"
+import { getSampleSchema, fromJSOrdered } from "core/utils"
 
 const getExampleComponent = ( sampleResponse, examples, HighlightCode ) => {
   if ( examples && examples.size ) {
@@ -58,7 +58,6 @@ export default class Response extends React.Component {
       code,
       response,
       className,
-
       fn,
       getComponent,
       specSelectors,
@@ -117,7 +116,7 @@ export default class Response extends React.Component {
             <ModelExample
               getComponent={ getComponent }
               specSelectors={ specSelectors }
-              schema={ fromJS(schema, (key, value) => value.toOrderedMap() ) }
+              schema={ fromJSOrdered(schema) }
               example={ example }/>
           ) : null}
 

--- a/src/core/components/response.jsx
+++ b/src/core/components/response.jsx
@@ -117,7 +117,7 @@ export default class Response extends React.Component {
             <ModelExample
               getComponent={ getComponent }
               specSelectors={ specSelectors }
-              schema={ fromJS(schema) }
+              schema={ fromJS(schema, (key, value) => value.toOrderedMap() ) }
               example={ example }/>
           ) : null}
 

--- a/test/components/response.js
+++ b/test/components/response.js
@@ -46,7 +46,7 @@ describe("<Response />", function() {
         code: "200"
     }
 
-    it.only("renders the model-example schema properties in order", function() {
+    it("renders the model-example schema properties in order", function() {
         const wrapper = shallow(<Response {...props}/>)
         const renderedModelExample = wrapper.find(ModelExample)
         expect(renderedModelExample.length).toEqual(1)

--- a/test/components/response.js
+++ b/test/components/response.js
@@ -1,0 +1,58 @@
+import React from "react"
+import expect from "expect"
+import { shallow } from "enzyme"
+import { fromJS } from "immutable"
+import Response from "components/response"
+import ModelExample from "components/model-example"
+import { inferSchema } from "corePlugins/samples/fn"
+
+describe("<Response />", function() {
+    const dummyComponent = () => null
+    const components = {
+        headers: dummyComponent,
+        highlightCode: dummyComponent,
+        modelExample: ModelExample,
+        Markdown: dummyComponent,
+        operationLink: dummyComponent,
+        contentType: dummyComponent
+    }
+    const props = {
+        getComponent: c => components[c],
+        specSelectors: {
+            isOAS3() {
+                return false
+            }
+        },
+        fn: {
+            inferSchema
+        },
+        contentType: "application/json",
+        className: "for-test",
+        response: fromJS({
+            type: "object",
+            properties: {
+                // Note reverse order: c, b, a
+                "c": {
+                    type: "integer"
+                },
+                "b": {
+                    type: "boolean"
+                },
+                "a": {
+                    type: "string"
+                }
+            }
+        }),
+        code: "200"
+    }
+
+    it.only("renders the model-example schema properties in order", function() {
+        const wrapper = shallow(<Response {...props}/>)
+        const renderedModelExample = wrapper.find(ModelExample)
+        expect(renderedModelExample.length).toEqual(1)
+
+        // Assert the schema's properties have maintained their order
+        const modelExampleSchemaProperties = renderedModelExample.props().schema.toJS().properties
+        expect( Object.keys(modelExampleSchemaProperties) ).toEqual(["c", "b", "a"])
+    })
+})


### PR DESCRIPTION
Fixes #3032 

`fromJS` does not maintain the order of the properties in the object. Instead, we use the optional [`reviver` function](https://facebook.github.io/immutable-js/docs/#/fromJS) to parse each property in the original `schema` object as an `OrderedMap`.