### PR TITLE
OAS3: Accept header control

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "base64-js": "^1.2.0",
     "brace": "0.7.0",
+    "classnames": "^2.2.5",
     "deep-extend": "0.4.1",
     "expect": "1.20.2",
     "getbase": "^2.8.2",

--- a/src/core/components/operation.jsx
+++ b/src/core/components/operation.jsx
@@ -117,7 +117,8 @@ export default class Operation extends PureComponent {
       specSelectors,
       authActions,
       authSelectors,
-      getConfigs
+      getConfigs,
+      oas3Actions
     } = this.props
 
     let summary = operation.get("summary")
@@ -265,6 +266,7 @@ export default class Operation extends PureComponent {
                     getComponent={ getComponent }
                     getConfigs={ getConfigs }
                     specSelectors={ specSelectors }
+                    oas3Actions={oas3Actions}
                     specActions={ specActions }
                     produces={ produces }
                     producesValue={ operation.get("produces_value") }

--- a/src/core/components/operation.jsx
+++ b/src/core/components/operation.jsx
@@ -28,6 +28,7 @@ export default class Operation extends PureComponent {
     authSelectors: PropTypes.object,
     specActions: PropTypes.object.isRequired,
     specSelectors: PropTypes.object.isRequired,
+    oas3Actions: PropTypes.object.isRequired,
     layoutActions: PropTypes.object.isRequired,
     layoutSelectors: PropTypes.object.isRequired,
     fn: PropTypes.object.isRequired,

--- a/src/core/components/operations.jsx
+++ b/src/core/components/operations.jsx
@@ -9,6 +9,7 @@ export default class Operations extends React.Component {
   static propTypes = {
     specSelectors: PropTypes.object.isRequired,
     specActions: PropTypes.object.isRequired,
+    oas3Actions: PropTypes.object.isRequired,
     getComponent: PropTypes.func.isRequired,
     layoutSelectors: PropTypes.object.isRequired,
     layoutActions: PropTypes.object.isRequired,
@@ -21,6 +22,7 @@ export default class Operations extends React.Component {
     let {
       specSelectors,
       specActions,
+      oas3Actions,
       getComponent,
       layoutSelectors,
       layoutActions,
@@ -146,6 +148,8 @@ export default class Operations extends React.Component {
 
                           specActions={ specActions }
                           specSelectors={ specSelectors }
+
+                          oas3Actions={oas3Actions}
 
                           layoutActions={ layoutActions }
                           layoutSelectors={ layoutSelectors }

--- a/src/core/components/response.jsx
+++ b/src/core/components/response.jsx
@@ -48,12 +48,23 @@ export default class Response extends React.Component {
     specSelectors: PropTypes.object.isRequired,
     fn: PropTypes.object.isRequired,
     contentType: PropTypes.string,
-    controlsAcceptHeader: PropTypes.bool
+    controlsAcceptHeader: PropTypes.bool,
+    onContentTypeChange: PropTypes.func
   }
 
   static defaultProps = {
     response: fromJS({}),
+    onContentTypeChange: () => {}
   };
+
+  _onContentTypeChange = (value) => {
+    const { onContentTypeChange, controlsAcceptHeader } = this.props
+    this.setState({ responseContentType: value })
+    onContentTypeChange({
+      value: value,
+      controlsAcceptHeader
+    })
+  }
 
   render() {
     let {
@@ -116,7 +127,7 @@ export default class Response extends React.Component {
               <ContentType
                   value={this.state.responseContentType}
                   contentTypes={ response.get("content") ? response.get("content").keySeq() : Seq() }
-                  onChange={(val) => this.setState({ responseContentType: val })}
+                  onChange={this._onContentTypeChange}
                   />
                 { controlsAcceptHeader ? <small>Controls <code>Accept</code> header.</small> : null }
             </div>

--- a/src/core/components/response.jsx
+++ b/src/core/components/response.jsx
@@ -1,5 +1,6 @@
 import React from "react"
 import PropTypes from "prop-types"
+import cx from "classnames"
 import { fromJS, Seq } from "immutable"
 import { getSampleSchema, fromJSOrdered } from "core/utils"
 
@@ -46,7 +47,8 @@ export default class Response extends React.Component {
     getComponent: PropTypes.func.isRequired,
     specSelectors: PropTypes.object.isRequired,
     fn: PropTypes.object.isRequired,
-    contentType: PropTypes.string
+    contentType: PropTypes.string,
+    controlsAcceptHeader: PropTypes.bool
   }
 
   static defaultProps = {
@@ -61,7 +63,8 @@ export default class Response extends React.Component {
       fn,
       getComponent,
       specSelectors,
-      contentType
+      contentType,
+      controlsAcceptHeader
     } = this.props
 
     let { inferSchema } = fn
@@ -106,11 +109,18 @@ export default class Response extends React.Component {
             <Markdown source={ response.get( "description" ) } />
           </div>
 
-          { isOAS3 ? <ContentType
-              value={this.state.responseContentType}
-              contentTypes={ response.get("content") ? response.get("content").keySeq() : Seq() }
-              onChange={(val) => this.setState({ responseContentType: val })}
-              className="response-content-type" /> : null }
+          { isOAS3 ?
+            <div className={cx("response-content-type", {
+              "controls-accept-header": controlsAcceptHeader
+            })}>
+              <ContentType
+                  value={this.state.responseContentType}
+                  contentTypes={ response.get("content") ? response.get("content").keySeq() : Seq() }
+                  onChange={(val) => this.setState({ responseContentType: val })}
+                  />
+                { controlsAcceptHeader ? <small>Controls <code>Accept</code> header.</small> : null }
+            </div>
+             : null }
 
           { example ? (
             <ModelExample

--- a/src/core/components/responses.jsx
+++ b/src/core/components/responses.jsx
@@ -29,6 +29,16 @@ export default class Responses extends React.Component {
 
   onChangeProducesWrapper = ( val ) => this.props.specActions.changeProducesValue(this.props.pathMethod, val)
 
+  onResponseContentTypeChange = ({ controlsAcceptHeader, value }) => {
+    const { oas3Actions, pathMethod } = this.props
+    if(controlsAcceptHeader) {
+      oas3Actions.setResponseContentType({
+        value,
+        pathMethod
+      })
+    }
+  }
+
   render() {
     let {
       responses,
@@ -93,7 +103,6 @@ export default class Responses extends React.Component {
             <tbody>
               {
                 responses.entrySeq().map( ([code, response]) => {
-
                   let className = tryItOutResponse && tryItOutResponse.get("status") == code ? "response_current" : ""
                   return (
                     <Response key={ code }
@@ -104,6 +113,7 @@ export default class Responses extends React.Component {
                               response={ response }
                               specSelectors={ specSelectors }
                               controlsAcceptHeader={response === acceptControllingResponse}
+                              onContentTypeChange={this.onResponseContentTypeChange}
                               contentType={ producesValue }
                               getComponent={ getComponent }/>
                     )

--- a/src/core/components/responses.jsx
+++ b/src/core/components/responses.jsx
@@ -14,6 +14,7 @@ export default class Responses extends React.Component {
     getComponent: PropTypes.func.isRequired,
     specSelectors: PropTypes.object.isRequired,
     specActions: PropTypes.object.isRequired,
+    oas3Actions: PropTypes.object.isRequired,
     pathMethod: PropTypes.array.isRequired,
     displayRequestDuration: PropTypes.bool.isRequired,
     fn: PropTypes.object.isRequired,

--- a/src/core/components/responses.jsx
+++ b/src/core/components/responses.jsx
@@ -1,7 +1,7 @@
 import React from "react"
 import PropTypes from "prop-types"
 import { fromJS } from "immutable"
-import { defaultStatusCode } from "core/utils"
+import { defaultStatusCode, getAcceptControllingResponse } from "core/utils"
 
 export default class Responses extends React.Component {
 
@@ -30,7 +30,17 @@ export default class Responses extends React.Component {
   onChangeProducesWrapper = ( val ) => this.props.specActions.changeProducesValue(this.props.pathMethod, val)
 
   render() {
-    let { responses, request, tryItOutResponse, getComponent, getConfigs, specSelectors, fn, producesValue, displayRequestDuration } = this.props
+    let {
+      responses,
+      request,
+      tryItOutResponse,
+      getComponent,
+      getConfigs,
+      specSelectors,
+      fn,
+      producesValue,
+      displayRequestDuration
+    } = this.props
     let defaultCode = defaultStatusCode( responses )
 
     const ContentType = getComponent( "contentType" )
@@ -38,6 +48,11 @@ export default class Responses extends React.Component {
     const Response = getComponent( "response" )
 
     let produces = this.props.produces && this.props.produces.size ? this.props.produces : Responses.defaultProps.produces
+
+    const isSpecOAS3 = specSelectors.isOAS3()
+
+    const acceptControllingResponse = isSpecOAS3 ?
+      getAcceptControllingResponse(responses) : null
 
     return (
       <div className="responses-wrapper">
@@ -88,6 +103,7 @@ export default class Responses extends React.Component {
                               code={ code }
                               response={ response }
                               specSelectors={ specSelectors }
+                              controlsAcceptHeader={response === acceptControllingResponse}
                               contentType={ producesValue }
                               getComponent={ getComponent }/>
                     )

--- a/src/core/plugins/oas3/actions.js
+++ b/src/core/plugins/oas3/actions.js
@@ -4,6 +4,7 @@
 export const UPDATE_SELECTED_SERVER = "oas3_set_servers"
 export const UPDATE_REQUEST_BODY_VALUE = "oas3_set_request_body_value"
 export const UPDATE_REQUEST_CONTENT_TYPE = "oas3_set_request_content_type"
+export const UPDATE_RESPONSE_CONTENT_TYPE = "oas3_set_response_content_type"
 export const UPDATE_SERVER_VARIABLE_VALUE = "oas3_set_server_variable_value"
 
 export function setSelectedServer (selectedServerUrl) {
@@ -23,6 +24,13 @@ export function setRequestBodyValue ({ value, pathMethod }) {
 export function setRequestContentType ({ value, pathMethod }) {
   return {
     type: UPDATE_REQUEST_CONTENT_TYPE,
+    payload: { value, pathMethod }
+  }
+}
+
+export function setResponseContentType ({ value, pathMethod }) {
+  return {
+    type: UPDATE_RESPONSE_CONTENT_TYPE,
     payload: { value, pathMethod }
   }
 }

--- a/src/core/plugins/oas3/reducers.js
+++ b/src/core/plugins/oas3/reducers.js
@@ -2,7 +2,8 @@ import {
   UPDATE_SELECTED_SERVER,
   UPDATE_REQUEST_BODY_VALUE,
   UPDATE_REQUEST_CONTENT_TYPE,
-  UPDATE_SERVER_VARIABLE_VALUE
+  UPDATE_SERVER_VARIABLE_VALUE,
+  UPDATE_RESPONSE_CONTENT_TYPE
 } from "./actions"
 
 export default {
@@ -16,6 +17,10 @@ export default {
   [UPDATE_REQUEST_CONTENT_TYPE]: (state, { payload: { value, pathMethod } } ) =>{
     let [path, method] = pathMethod
     return state.setIn( [ "requestData", path, method, "requestContentType" ], value)
+  },
+  [UPDATE_RESPONSE_CONTENT_TYPE]: (state, { payload: { value, pathMethod } } ) =>{
+    let [path, method] = pathMethod
+    return state.setIn( [ "requestData", path, method, "responseContentType" ], value)
   },
   [UPDATE_SERVER_VARIABLE_VALUE]: (state, { payload: { server, key, val } } ) =>{
     return state.setIn( [ "serverVariableValues", server, key ], val)

--- a/src/core/plugins/oas3/selectors.js
+++ b/src/core/plugins/oas3/selectors.js
@@ -30,6 +30,11 @@ export const requestContentType = onlyOAS3((state, path, method) => {
   }
 )
 
+export const responseContentType = onlyOAS3((state, path, method) => {
+    return state.getIn(["requestData", path, method, "responseContentType"]) || null
+  }
+)
+
 export const serverVariableValue = onlyOAS3((state, server, key) => {
     return state.getIn(["serverVariableValues", server, key]) || null
   }

--- a/src/core/plugins/spec/actions.js
+++ b/src/core/plugins/spec/actions.js
@@ -218,6 +218,7 @@ export const executeRequest = (req) =>
       req.server = oas3Selectors.selectedServer()
       req.serverVariables = oas3Selectors.serverVariables(req.server).toJS()
       req.requestContentType = oas3Selectors.requestContentType(pathName, method)
+      req.responseContentType = oas3Selectors.responseContentType(pathName, method) || "*/*"
       const requestBody = oas3Selectors.requestBodyValue(pathName, method)
 
       if(isJSONObject(requestBody)) {

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -675,5 +675,5 @@ export function getAcceptControllingResponse(responses) {
   return suitable2xxResponse || suitableDefaultResponse
 }
 
-export const createDeepLinkPath = (str) => str ? str.replace(/\s/g, "_") : ""
+export const createDeepLinkPath = (str) => typeof str == "string" || str instanceof String ? str.trim().replace(/\s/g, "_") : ""
 export const escapeDeepLinkPath = (str) => cssEscape( createDeepLinkPath(str) )

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -650,3 +650,26 @@ export const shallowEqualKeys = (a,b, keys) => {
     return eq(a[key], b[key])
   })
 }
+
+export function getAcceptControllingResponse(responses) {
+  if(!Im.OrderedMap.isOrderedMap(responses)) {
+    // wrong type!
+    return null
+  }
+
+  if(!responses.size) {
+    // responses is empty
+    return null
+  }
+
+  const suitable2xxResponse = responses.find((res, k) => {
+    return k.startsWith("2") && Object.keys(res.get("content") || {}).length > 0
+  })
+
+  // try to find a suitable `default` responses
+  const defaultResponse = responses.get("default") || Im.OrderedMap()
+  const defaultResponseMediaTypes = (defaultResponse.get("content") || Im.OrderedMap()).keySeq().toJS()
+  const suitableDefaultResponse = defaultResponseMediaTypes.length ? defaultResponse : null
+
+  return suitable2xxResponse || suitableDefaultResponse
+}

--- a/src/style/_layout.scss
+++ b/src/style/_layout.scss
@@ -775,6 +775,17 @@
 
 .response-content-type {
   padding-top: 1em;
+
+  &.controls-accept-header {
+    select {
+      border-color: green;
+    }
+
+    small {
+      color: green;
+      font-size: .7em;
+    }
+  }
 }
 
 @keyframes blinker

--- a/test/core/utils.js
+++ b/test/core/utils.js
@@ -2,7 +2,7 @@
 import expect from "expect"
 import { fromJS, OrderedMap } from "immutable"
 import { mapToList, validateNumber, validateInteger, validateParam, validateFile, fromJSOrdered, getAcceptControllingResponse, createDeepLinkPath, escapeDeepLinkPath } from "core/utils"
-
+import win from "core/window"
 
 describe("utils", function() {
 


### PR DESCRIPTION
Fixes #3654.
CC #3641.

Adds ability to control `Accept` header.

Introduces the concept of a "blessed" response that dictates the Accept header value.

Logic is as follows:

```
if responses has a 2xx response code with media types defined
  use first 2xx response's media types as Accept options
else if responses has a default response with media types defined
  use default response's media types as Accept options
else
  use `*/*` as Accept value
```

Looks like:

<img width="1389" alt="messages image 2039238910" src="https://user-images.githubusercontent.com/680248/30508550-4ac28654-9a4e-11e7-9c18-ccb62a45129a.png">
