### PR TITLE
Fixes #3633 - PrimitiveModel titles

### DIFF
--- a/src/core/components/array-model.jsx
+++ b/src/core/components/array-model.jsx
@@ -41,7 +41,7 @@ export default class ArrayModel extends Component {
         {
           properties.size ? <span>
               { properties.entrySeq().map( ( [ key, v ] ) => <span key={`${key}-${v}`} style={propStyle}>
-                <br />{ `${key}:`}{ String(v) }</span>)
+                <br />{ key }: { String(v) }</span>)
               }<br /></span>
             : null
         }

--- a/src/core/components/primitive-model.jsx
+++ b/src/core/components/primitive-model.jsx
@@ -23,6 +23,7 @@ export default class Primitive extends Component {
     let format = schema.get("format")
     let xml = schema.get("xml")
     let enumArray = schema.get("enum")
+    let title = schema.get("title") || name
     let description = schema.get("description")
     let properties = schema.filter( ( v, key) => ["enum", "type", "format", "description", "$$ref"].indexOf(key) === -1 )
     const Markdown = getComponent("Markdown")
@@ -30,7 +31,7 @@ export default class Primitive extends Component {
 
     return <span className="model">
       <span className="prop">
-        { name && <span className={`${depth === 1 && "model-title"} prop-name`}>{ name }</span> }
+        { name && <span className={`${depth === 1 && "model-title"} prop-name`}>{ title }</span> }
         <span className="prop-type">{ type }</span>
         { format && <span className="prop-format">(${format})</span>}
         {

--- a/src/style/_models.scss
+++ b/src/style/_models.scss
@@ -237,7 +237,8 @@ span
 .prop-name
 {
     display: inline-block;
-    width: 100px;
+    margin-right: 1em;
+    width: 8em;
 }
 
 .prop-type

--- a/test/components/primitive-model.js
+++ b/test/components/primitive-model.js
@@ -1,0 +1,49 @@
+/* eslint-env mocha */
+import React from "react"
+import expect from "expect"
+import { shallow } from "enzyme"
+import { fromJS } from "immutable"
+import PrimitiveModel from "components/primitive-model"
+
+describe("<PrimitiveModel/>", function() {
+    describe("Model name", function() {
+        const dummyComponent = () => null
+        const components = {
+            Markdown: dummyComponent,
+            EnumModel: dummyComponent
+        }
+        const props = {
+            getComponent: c => components[c],
+            name: "Name from props",
+            depth: 1,
+            schema: fromJS({
+                type: "string",
+                title: "Custom model title"
+            })
+        }
+
+        it("renders the schema's title", function() {
+            // When
+            const wrapper = shallow(<PrimitiveModel {...props}/>)
+            const modelTitleEl = wrapper.find("span.model-title")
+            expect(modelTitleEl.length).toEqual(1)
+
+            // Then
+            expect( modelTitleEl.text() ).toEqual( "Custom model title" )
+        })
+
+        it("falls back to the passed-in `name` prop for the title", function() {
+            // When
+            props.schema = fromJS({
+                type: "string"
+            })
+            const wrapper = shallow(<PrimitiveModel {...props}/>)
+            const modelTitleEl = wrapper.find("span.model-title")
+            expect(modelTitleEl.length).toEqual(1)
+
+            // Then
+            expect( modelTitleEl.text() ).toEqual( "Name from props" )
+        })
+
+    })
+} )

--- a/test/core/utils.js
+++ b/test/core/utils.js
@@ -583,7 +583,7 @@ describe("utils", function() {
     })
   })
 
-  describe.only("getAcceptControllingResponse", () => {
+  describe("getAcceptControllingResponse", () => {
     it("should return the first 2xx response with a media type", () => {
       const responses = fromJSOrdered({
         "200": {


### PR DESCRIPTION
Fixes #3633 

- Fix alignment in array-model for properties
- Increase fix width in property names and change units to `em`
- Fix fallback to `name` prop in PrimitiveModel and add enzyme test

![screen shot 2017-09-17 at 9 31 07 am](https://user-images.githubusercontent.com/791222/30522470-b706df28-9b8d-11e7-924b-531154eff209.png)
