### PR TITLE
Fixes #3511 - 2nd attempt - Query & formData parameters together 

### DIFF
--- a/src/core/components/parameter-row.jsx
+++ b/src/core/components/parameter-row.jsx
@@ -26,10 +26,6 @@ export default class ParameterRow extends Component {
     }
   }
 
-  shouldComponentUpdate(nextProps) {
-    return nextProps.param !== this.props.param
-  }
-
   componentWillReceiveProps(props) {
     let { specSelectors, pathMethod, param } = props
     let example = param.get("example")


### PR DESCRIPTION
Remove `shouldComponentUpdate` from `parameter-row` component. It will be put back in eventually as part of the performance optimizations once the parameter components are converted to the smart/dumb approach.