### PR TITLE
Fixes #3706

### DIFF
--- a/src/core/components/operation.jsx
+++ b/src/core/components/operation.jsx
@@ -149,7 +149,7 @@ export default class Operation extends PureComponent {
     const isDeepLinkingEnabled = deepLinking && deepLinking !== "false"
 
     // Merge in Live Response
-    if(response && response.size > 0) {
+    if(responses && response && response.size > 0) {
       let notDocumented = !responses.get(String(response.get("status")))
       response = response.set("notDocumented", notDocumented)
     }

--- a/src/core/components/parameter-row.jsx
+++ b/src/core/components/parameter-row.jsx
@@ -30,7 +30,7 @@ export default class ParameterRow extends Component {
     let { specSelectors, pathMethod, param } = props
     let example = param.get("example")
     let defaultValue = param.get("default")
-    let parameter = specSelectors.getParameter(pathMethod, param.get("name"))
+    let parameter = specSelectors.getParameter(pathMethod, param.get("name"), param.get("in"))
     let paramValue = parameter ? parameter.get("value") : undefined
     let enumValue = parameter ? parameter.get("enum") : undefined
     let value


### PR DESCRIPTION
Fixes #3706 

Add missing "in" argument to `getParameter`. Also added check for `responses` variable in `operation.jsx` before accessing it.

I also checked the other calls to `getParameter`, and they all look good.