### PR TITLE
Fix problems regarding request body display

### DIFF
--- a/src/core/plugins/oas3/auth-extensions/wrap-selectors.js
+++ b/src/core/plugins/oas3/auth-extensions/wrap-selectors.js
@@ -1,4 +1,5 @@
 import { createSelector } from "reselect"
+import { List } from "immutable"
 import { isOAS3 as isOAS3Helper } from "../helpers"
 
 
@@ -23,6 +24,6 @@ const OAS3NullSelector = onlyOAS3(nullSelector)
 export const shownDefinitions = OAS3NullSelector
 export const definitionsToAuthorize = OAS3NullSelector
 export const getDefinitionsByNames = OAS3NullSelector
-export const authorized = OAS3NullSelector
+export const authorized = onlyOAS3(() => List())
 export const isAuthorized = OAS3NullSelector
 export const getConfigs = OAS3NullSelector

--- a/src/core/plugins/oas3/components/request-body.jsx
+++ b/src/core/plugins/oas3/components/request-body.jsx
@@ -6,6 +6,7 @@ import { OrderedMap } from "immutable"
 const RequestBody = ({
   requestBody,
   getComponent,
+  getConfigs,
   specSelectors,
   contentType,
   isExecute,
@@ -27,6 +28,7 @@ const RequestBody = ({
     }
     <ModelExample
       getComponent={ getComponent }
+      getConfigs={ getConfigs }
       specSelectors={ specSelectors }
       expandDepth={1}
       isExecute={isExecute}
@@ -46,6 +48,7 @@ const RequestBody = ({
 RequestBody.propTypes = {
   requestBody: ImPropTypes.orderedMap.isRequired,
   getComponent: PropTypes.func.isRequired,
+  getConfigs: PropTypes.func.isRequired,
   specSelectors: PropTypes.object.isRequired,
   contentType: PropTypes.string.isRequired,
   isExecute: PropTypes.bool.isRequired,


### PR DESCRIPTION
Fixes #3718!

Adds a missing `getConfigs` prop to an invocation of `<ModelExample>`, and modifies one of the OAS3 authorization overrides to return an empty Immutable List instead of `null`.