### PR TITLE
Fixes #3734 - Markdown headings

### DIFF
--- a/src/core/components/providers/markdown.jsx
+++ b/src/core/components/providers/markdown.jsx
@@ -29,7 +29,7 @@ Markdown.propTypes = {
 export default Markdown
 
 const sanitizeOptions = {
-    allowedTags: sanitize.defaults.allowedTags.concat([ "img" ]),
+    allowedTags: sanitize.defaults.allowedTags.concat([ "h1", "h2", "img" ]),
     textFilter: function(text) {
         return text.replace(/&quot;/g, "\"")
     }


### PR DESCRIPTION
Fies #3734 

Add `<h1>` and `<h2>` elements to sanitizer options.

I have a test structure setup for XSS/markdown in this branch: https://github.com/owenconti/swagger-ui/commits/test/3715-xss-unit-tests so I will add a test for these heading elements to those tests.

<img width="1163" alt="screen shot 2017-10-08 at 9 01 52 am" src="https://user-images.githubusercontent.com/791222/31318117-2461ceac-ac0a-11e7-8ad6-240a4990bbbf.png">
