### PR TITLE
Pass configuration interceptors to spec download fetch

### DIFF
--- a/src/core/plugins/download-url.js
+++ b/src/core/plugins/download-url.js
@@ -7,13 +7,16 @@ export default function downloadUrlPlugin (toolbox) {
   let { fn } = toolbox
 
   const actions = {
-    download: (url)=> ({ errActions, specSelectors, specActions }) => {
+    download: (url)=> ({ errActions, specSelectors, specActions, getConfigs }) => {
       let { fetch } = fn
+      const config = getConfigs()
       url = url || specSelectors.url()
       specActions.updateLoadingStatus("loading")
       fetch({
         url,
         loadSpec: true,
+        requestInterceptor: config.requestInterceptor || (a => a),
+        responseInterceptor: config.responseInterceptor || (a => a),
         credentials: "same-origin",
         headers: {
           "Accept": "application/json,*/*"


### PR DESCRIPTION
CC: #2793.

This PR modifies the DownloadURL plugin to use the `requestInterceptor` and `responseInterceptor` configuration options for spec fetches, which will allow users to handle access of API definitions protected by HTTP Basic authentication.