### PR TITLE
Fixes #3747 OAS3 validate param

### DIFF
--- a/src/core/plugins/spec/actions.js
+++ b/src/core/plugins/spec/actions.js
@@ -137,10 +137,13 @@ export function changeParam( path, paramName, paramIn, value, isXml ){
   }
 }
 
-export function validateParams( payload ){
+export const validateParams = ( payload, isOAS3 ) =>{
   return {
     type: VALIDATE_PARAMS,
-    payload:{ pathMethod: payload }
+    payload:{ 
+      pathMethod: payload,
+      isOAS3
+    }
   }
 }
 

--- a/src/core/plugins/spec/reducers.js
+++ b/src/core/plugins/spec/reducers.js
@@ -51,14 +51,14 @@ export default {
     })
   },
 
-  [VALIDATE_PARAMS]: ( state, { payload:  { pathMethod } } ) => {
+  [VALIDATE_PARAMS]: ( state, { payload: { pathMethod, isOAS3 } } ) => {
     let operation = state.getIn( [ "resolved", "paths", ...pathMethod ] )
     let isXml = /xml/i.test(operation.get("consumes_value"))
 
     return state.updateIn( [ "resolved", "paths", ...pathMethod, "parameters" ], fromJS([]), parameters => {
       return parameters.withMutations( parameters => {
         for ( let i = 0, len = parameters.count(); i < len; i++ ) {
-          let errors = validateParam(parameters.get(i), isXml)
+          let errors = validateParam(parameters.get(i), isXml, isOAS3)
           parameters.setIn([i, "errors"], fromJS(errors))
         }
       })

--- a/src/core/plugins/spec/wrap-actions.js
+++ b/src/core/plugins/spec/wrap-actions.js
@@ -13,3 +13,7 @@ export const executeRequest = (ori, { specActions }) => (req) => {
   specActions.logRequest(req)
   return ori(req)
 }
+
+export const validateParams = (ori, { specSelectors }) => (req) => {
+  return ori(req, specSelectors.isOAS3())
+}

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -541,12 +541,14 @@ export const validateParam = (param, isXml) => {
   let errors = []
   let value = isXml && param.get("in") === "body" ? param.get("value_xml") : param.get("value")
   let required = param.get("required")
-  let maximum = param.get("maximum")
-  let minimum = param.get("minimum")
-  let type = param.get("type")
-  let format = param.get("format")
-  let maxLength = param.get("maxLength")
-  let minLength = param.get("minLength")
+
+  let paramDetails = param.get("schema") || param
+  let maximum = paramDetails.get("maximum")
+  let minimum = paramDetails.get("minimum")
+  let type = paramDetails.get("type")
+  let format = paramDetails.get("format")
+  let maxLength = paramDetails.get("maxLength")
+  let minLength = paramDetails.get("minLength")
 
   /*
     If the parameter is required OR the parameter has a value (meaning optional, but filled in)

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -537,12 +537,12 @@ export const validateMinLength = (val, min) => {
 }
 
 // validation of parameters before execute
-export const validateParam = (param, isXml) => {
+export const validateParam = (param, isXml, isOAS3 = false) => {
   let errors = []
   let value = isXml && param.get("in") === "body" ? param.get("value_xml") : param.get("value")
   let required = param.get("required")
 
-  let paramDetails = param.get("schema") || param
+  let paramDetails = isOAS3 ? param.get("schema") : param
   let maximum = paramDetails.get("maximum")
   let minimum = paramDetails.get("minimum")
   let type = paramDetails.get("type")
@@ -618,7 +618,7 @@ export const validateParam = (param, isXml) => {
 
       if ( !value.count() ) { return errors }
 
-      itemType = param.getIn(["items", "type"])
+      itemType = paramDetails.getIn(["items", "type"])
 
       value.forEach((item, index) => {
         let err

--- a/test/core/utils.js
+++ b/test/core/utils.js
@@ -274,464 +274,518 @@ describe("utils", function() {
    })
 
   describe("validateParam", function() {
-    let param = null
-    let result = null
 
-    it("skips validation when `type` is not specified", function() {
-      // invalid type
-      param = fromJS({
-        required: false,
-        type: undefined,
-        value: ""
+    describe("OAS3 specs", function() {
+      let param = null
+      let result = null
+
+      it("should check the isOAS3 flag when validating parameters", function() {
+        // This should "skip" validation because there is no `schema.type` property
+        // and we are telling `validateParam` this is an OAS3 spec
+        param = fromJS({
+          value: "",
+          required: true,
+          schema: {
+            notTheTypeProperty: "string"
+          }
+        })
+        result = validateParam( param, false, true )
+        expect( result ).toEqual( [] )
       })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
+
+      // Test a couple examples of validateParam()
+      it("validates required strings", function() {
+        // invalid string
+        param = fromJS({
+          value: "",
+          required: true,
+          schema: {
+            type: "string"
+          }
+        })
+        result = validateParam( param, false, true )
+        expect( result ).toEqual( ["Required field is not provided"] )
+      })
+
+      it("validates required arrays", function() {
+        // invalid array, items do not match correct type
+        param = fromJS({
+          required: true,
+          value: [1],
+          schema: {
+            type: "array",
+            items: {
+              type: "string"
+            }
+          }
+        })
+        result = validateParam( param, false, true )
+        expect( result ).toEqual( [{index: 0, error: "Value must be a string"}] )
+      })
+
+      it("validates required numbers", function() {
+        // invalid number, string instead of a number
+        param = fromJS({
+          required: true,
+          value: "test",
+          schema: {
+            type: "number"
+          }
+        })
+        result = validateParam( param, false, true )
+        expect( result ).toEqual( ["Required field is not provided"] )
+      })
     })
 
-    it("validates required strings", function() {
-      // invalid string
-      param = fromJS({
-        required: true,
-        type: "string",
-        value: ""
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( ["Required field is not provided"] )
+    describe("Swagger 2.0 specs", function() {
+      let param = null
+      let result = null
 
-      // valid string
-      param = fromJS({
-        required: true,
-        type: "string",
-        value: "test string"
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
+      it("validates required strings", function() {
+        // invalid string
+        param = fromJS({
+          required: true,
+          type: "string",
+          value: ""
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( ["Required field is not provided"] )
 
-      // valid string with min and max length
-      param = fromJS({
-        required: true,
-        type: "string",
-        value: "test string",
-        maxLength: 50,
-        minLength: 1
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
-    })
+        // valid string
+        param = fromJS({
+          required: true,
+          type: "string",
+          value: "test string"
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( [] )
 
-    it("validates required strings with min and max length", function() {
-      // invalid string with max length
-      param = fromJS({
-        required: true,
-        type: "string",
-        value: "test string",
-        maxLength: 5
+        // valid string with min and max length
+        param = fromJS({
+          required: true,
+          type: "string",
+          value: "test string",
+          maxLength: 50,
+          minLength: 1
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( [] )
       })
-      result = validateParam( param, false )
-      expect( result ).toEqual( ["Value must be less than MaxLength"] )
 
-      // invalid string with max length 0
-      param = fromJS({
-        required: true,
-        type: "string",
-        value: "test string",
-        maxLength: 0
+      it("validates required strings with min and max length", function() {
+        // invalid string with max length
+        param = fromJS({
+          required: true,
+          type: "string",
+          value: "test string",
+          maxLength: 5
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( ["Value must be less than MaxLength"] )
+
+        // invalid string with max length 0
+        param = fromJS({
+          required: true,
+          type: "string",
+          value: "test string",
+          maxLength: 0
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( ["Value must be less than MaxLength"] )
+
+
+        // invalid string with min length
+        param = fromJS({
+          required: true,
+          type: "string",
+          value: "test string",
+          minLength: 50
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( ["Value must be greater than MinLength"] )
       })
-      result = validateParam( param, false )
-      expect( result ).toEqual( ["Value must be less than MaxLength"] )
 
+      it("validates optional strings", function() {
+        // valid (empty) string
+        param = fromJS({
+          required: false,
+          type: "string",
+          value: ""
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( [] )
 
-      // invalid string with min length
-      param = fromJS({
-        required: true,
-        type: "string",
-        value: "test string",
-        minLength: 50
+        // valid string
+        param = fromJS({
+          required: false,
+          type: "string",
+          value: "test"
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( [] )
       })
-      result = validateParam( param, false )
-      expect( result ).toEqual( ["Value must be greater than MinLength"] )
-    })
 
-    it("validates optional strings", function() {
-      // valid (empty) string
-      param = fromJS({
-        required: false,
-        type: "string",
-        value: ""
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
+      it("validates required files", function() {
+        // invalid file
+        param = fromJS({
+          required: true,
+          type: "file",
+          value: undefined
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( ["Required field is not provided"] )
 
-      // valid string
-      param = fromJS({
-        required: false,
-        type: "string",
-        value: "test"
+        // valid file
+        param = fromJS({
+          required: true,
+          type: "file",
+          value: new win.File()
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( [] )
       })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
-    })
 
-    it("validates required files", function() {
-      // invalid file
-      param = fromJS({
-        required: true,
-        type: "file",
-        value: undefined
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( ["Required field is not provided"] )
+      it("validates optional files", function() {
+        // invalid file
+        param = fromJS({
+          required: false,
+          type: "file",
+          value: "not a file"
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( ["Value must be a file"] )
 
-      // valid file
-      param = fromJS({
-        required: true,
-        type: "file",
-        value: new win.File()
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
-    })
+        // valid (empty) file
+        param = fromJS({
+          required: false,
+          type: "file",
+          value: undefined
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( [] )
 
-    it("validates optional files", function() {
-      // invalid file
-      param = fromJS({
-        required: false,
-        type: "file",
-        value: "not a file"
+        // valid file
+        param = fromJS({
+          required: false,
+          type: "file",
+          value: new win.File()
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( [] )
       })
-      result = validateParam( param, false )
-      expect( result ).toEqual( ["Value must be a file"] )
 
-      // valid (empty) file
-      param = fromJS({
-        required: false,
-        type: "file",
-        value: undefined
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
+      it("validates required arrays", function() {
+        // invalid (empty) array
+        param = fromJS({
+          required: true,
+          type: "array",
+          value: []
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( ["Required field is not provided"] )
 
-      // valid file
-      param = fromJS({
-        required: false,
-        type: "file",
-        value: new win.File()
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
-    })
+        // invalid (not an array)
+        param = fromJS({
+          required: true,
+          type: "array",
+          value: undefined
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( ["Required field is not provided"] )
 
-    it("validates required arrays", function() {
-      // invalid (empty) array
-      param = fromJS({
-        required: true,
-        type: "array",
-        value: []
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( ["Required field is not provided"] )
+        // invalid array, items do not match correct type
+        param = fromJS({
+          required: true,
+          type: "array",
+          value: [1],
+          items: {
+            type: "string"
+          }
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( [{index: 0, error: "Value must be a string"}] )
 
-      // invalid (not an array)
-      param = fromJS({
-        required: true,
-        type: "array",
-        value: undefined
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( ["Required field is not provided"] )
+        // valid array, with no 'type' for items
+        param = fromJS({
+          required: true,
+          type: "array",
+          value: ["1"]
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( [] )
 
-      // invalid array, items do not match correct type
-      param = fromJS({
-        required: true,
-        type: "array",
-        value: [1],
-        items: {
-          type: "string"
-        }
+        // valid array, items match type
+        param = fromJS({
+          required: true,
+          type: "array",
+          value: ["1"],
+          items: {
+            type: "string"
+          }
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( [] )
       })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [{index: 0, error: "Value must be a string"}] )
 
-      // valid array, with no 'type' for items
-      param = fromJS({
-        required: true,
-        type: "array",
-        value: ["1"]
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
+      it("validates optional arrays", function() {
+        // valid, empty array
+        param = fromJS({
+          required: false,
+          type: "array",
+          value: []
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( [] )
 
-      // valid array, items match type
-      param = fromJS({
-        required: true,
-        type: "array",
-        value: ["1"],
-        items: {
-          type: "string"
-        }
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
-    })
+        // invalid, items do not match correct type
+        param = fromJS({
+          required: false,
+          type: "array",
+          value: ["number"],
+          items: {
+            type: "number"
+          }
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( [{index: 0, error: "Value must be a number"}] )
 
-    it("validates optional arrays", function() {
-      // valid, empty array
-      param = fromJS({
-        required: false,
-        type: "array",
-        value: []
+        // valid
+        param = fromJS({
+          required: false,
+          type: "array",
+          value: ["test"],
+          items: {
+            type: "string"
+          }
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( [] )
       })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
 
-      // invalid, items do not match correct type
-      param = fromJS({
-        required: false,
-        type: "array",
-        value: ["number"],
-        items: {
-          type: "number"
-        }
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [{index: 0, error: "Value must be a number"}] )
+      it("validates required booleans", function() {
+        // invalid boolean value
+        param = fromJS({
+          required: true,
+          type: "boolean",
+          value: undefined
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( ["Required field is not provided"] )
 
-      // valid
-      param = fromJS({
-        required: false,
-        type: "array",
-        value: ["test"],
-        items: {
-          type: "string"
-        }
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
-    })
+        // invalid boolean value (not a boolean)
+        param = fromJS({
+          required: true,
+          type: "boolean",
+          value: "test string"
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( ["Required field is not provided"] )
 
-    it("validates required booleans", function() {
-      // invalid boolean value
-      param = fromJS({
-        required: true,
-        type: "boolean",
-        value: undefined
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( ["Required field is not provided"] )
+        // valid boolean value
+        param = fromJS({
+          required: true,
+          type: "boolean",
+          value: "true"
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( [] )
 
-      // invalid boolean value (not a boolean)
-      param = fromJS({
-        required: true,
-        type: "boolean",
-        value: "test string"
+        // valid boolean value
+        param = fromJS({
+          required: true,
+          type: "boolean",
+          value: false
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( [] )
       })
-      result = validateParam( param, false )
-      expect( result ).toEqual( ["Required field is not provided"] )
 
-      // valid boolean value
-      param = fromJS({
-        required: true,
-        type: "boolean",
-        value: "true"
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
+      it("validates optional booleans", function() {
+        // valid (empty) boolean value
+        param = fromJS({
+          required: false,
+          type: "boolean",
+          value: undefined
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( [] )
 
-      // valid boolean value
-      param = fromJS({
-        required: true,
-        type: "boolean",
-        value: false
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
-    })
+        // invalid boolean value (not a boolean)
+        param = fromJS({
+          required: false,
+          type: "boolean",
+          value: "test string"
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( ["Value must be a boolean"] )
 
-    it("validates optional booleans", function() {
-      // valid (empty) boolean value
-      param = fromJS({
-        required: false,
-        type: "boolean",
-        value: undefined
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
+        // valid boolean value
+        param = fromJS({
+          required: false,
+          type: "boolean",
+          value: "true"
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( [] )
 
-      // invalid boolean value (not a boolean)
-      param = fromJS({
-        required: false,
-        type: "boolean",
-        value: "test string"
+        // valid boolean value
+        param = fromJS({
+          required: false,
+          type: "boolean",
+          value: false
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( [] )
       })
-      result = validateParam( param, false )
-      expect( result ).toEqual( ["Value must be a boolean"] )
 
-      // valid boolean value
-      param = fromJS({
-        required: false,
-        type: "boolean",
-        value: "true"
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
+      it("validates required numbers", function() {
+        // invalid number, string instead of a number
+        param = fromJS({
+          required: true,
+          type: "number",
+          value: "test"
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( ["Required field is not provided"] )
 
-      // valid boolean value
-      param = fromJS({
-        required: false,
-        type: "boolean",
-        value: false
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
-    })
+        // invalid number, undefined value
+        param = fromJS({
+          required: true,
+          type: "number",
+          value: undefined
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( ["Required field is not provided"] )
 
-    it("validates required numbers", function() {
-      // invalid number, string instead of a number
-      param = fromJS({
-        required: true,
-        type: "number",
-        value: "test"
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( ["Required field is not provided"] )
+        // valid number with min and max
+        param = fromJS({
+          required: true,
+          type: "number",
+          value: 10,
+          minimum: 5,
+          maximum: 99
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( [] )
 
-      // invalid number, undefined value
-      param = fromJS({
-        required: true,
-        type: "number",
-        value: undefined
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( ["Required field is not provided"] )
+        // valid negative number with min and max
+        param = fromJS({
+          required: true,
+          type: "number",
+          value: -10,
+          minimum: -50,
+          maximum: -5
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( [] )
 
-      // valid number with min and max
-      param = fromJS({
-        required: true,
-        type: "number",
-        value: 10,
-        minimum: 5,
-        maximum: 99
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
+        // invalid number with maximum:0
+        param = fromJS({
+          required: true,
+          type: "number",
+          value: 1,
+          maximum: 0
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( ["Value must be less than Maximum"] )
 
-      // valid negative number with min and max
-      param = fromJS({
-        required: true,
-        type: "number",
-        value: -10,
-        minimum: -50,
-        maximum: -5
+        // invalid number with minimum:0
+        param = fromJS({
+          required: true,
+          type: "number",
+          value: -10,
+          minimum: 0
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( ["Value must be greater than Minimum"] )
       })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
 
-      // invalid number with maximum:0
-      param = fromJS({
-        required: true,
-        type: "number",
-        value: 1,
-        maximum: 0
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( ["Value must be less than Maximum"] )
+      it("validates optional numbers", function() {
+        // invalid number, string instead of a number
+        param = fromJS({
+          required: false,
+          type: "number",
+          value: "test"
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( ["Value must be a number"] )
 
-      // invalid number with minimum:0
-      param = fromJS({
-        required: true,
-        type: "number",
-        value: -10,
-        minimum: 0
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( ["Value must be greater than Minimum"] )
-    })
+        // valid (empty) number
+        param = fromJS({
+          required: false,
+          type: "number",
+          value: undefined
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( [] )
 
-    it("validates optional numbers", function() {
-      // invalid number, string instead of a number
-      param = fromJS({
-        required: false,
-        type: "number",
-        value: "test"
+        // valid number
+        param = fromJS({
+          required: false,
+          type: "number",
+          value: 10
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( [] )
       })
-      result = validateParam( param, false )
-      expect( result ).toEqual( ["Value must be a number"] )
 
-      // valid (empty) number
-      param = fromJS({
-        required: false,
-        type: "number",
-        value: undefined
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
+      it("validates required integers", function() {
+        // invalid integer, string instead of an integer
+        param = fromJS({
+          required: true,
+          type: "integer",
+          value: "test"
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( ["Required field is not provided"] )
 
-      // valid number
-      param = fromJS({
-        required: false,
-        type: "number",
-        value: 10
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
-    })
+        // invalid integer, undefined value
+        param = fromJS({
+          required: true,
+          type: "integer",
+          value: undefined
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( ["Required field is not provided"] )
 
-    it("validates required integers", function() {
-      // invalid integer, string instead of an integer
-      param = fromJS({
-        required: true,
-        type: "integer",
-        value: "test"
+        // valid integer
+        param = fromJS({
+          required: true,
+          type: "integer",
+          value: 10
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( [] )
       })
-      result = validateParam( param, false )
-      expect( result ).toEqual( ["Required field is not provided"] )
 
-      // invalid integer, undefined value
-      param = fromJS({
-        required: true,
-        type: "integer",
-        value: undefined
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( ["Required field is not provided"] )
+      it("validates optional integers", function() {
+        // invalid integer, string instead of an integer
+        param = fromJS({
+          required: false,
+          type: "integer",
+          value: "test"
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( ["Value must be an integer"] )
 
-      // valid integer
-      param = fromJS({
-        required: true,
-        type: "integer",
-        value: 10
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
-    })
+        // valid (empty) integer
+        param = fromJS({
+          required: false,
+          type: "integer",
+          value: undefined
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( [] )
 
-    it("validates optional integers", function() {
-      // invalid integer, string instead of an integer
-      param = fromJS({
-        required: false,
-        type: "integer",
-        value: "test"
+        // integers
+        param = fromJS({
+          required: false,
+          type: "integer",
+          value: 10
+        })
+        result = validateParam( param, false )
+        expect( result ).toEqual( [] )
       })
-      result = validateParam( param, false )
-      expect( result ).toEqual( ["Value must be an integer"] )
-
-      // valid (empty) integer
-      param = fromJS({
-        required: false,
-        type: "integer",
-        value: undefined
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
-
-      // integers
-      param = fromJS({
-        required: false,
-        type: "integer",
-        value: 10
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
     })
   })
 

--- a/test/core/utils.js
+++ b/test/core/utils.js
@@ -284,8 +284,8 @@ describe("utils", function() {
 
       // OAS3 version, using `schema` sub-object
       let oas3Param = {
-        value: param.value || null,
-        required: param.required || null,
+        value: param.value,
+        required: param.required,
         schema: {
           ...param,
           value: undefined,
@@ -377,375 +377,338 @@ describe("utils", function() {
       assertValidateParam(param, [])
 
       // valid string
-      param = fromJS({
+      param = {
         required: false,
         type: "string",
         value: "test"
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
+      }
+      assertValidateParam(param, [])
     })
 
     it("validates required files", function() {
       // invalid file
-      param = fromJS({
+      param = {
         required: true,
         type: "file",
         value: undefined
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( ["Required field is not provided"] )
+      }
+      assertValidateParam(param, ["Required field is not provided"])
 
       // valid file
-      param = fromJS({
+      param = {
         required: true,
         type: "file",
         value: new win.File()
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
+      }
+      assertValidateParam(param, [])
     })
 
     it("validates optional files", function() {
       // invalid file
-      param = fromJS({
+      param = {
         required: false,
         type: "file",
         value: "not a file"
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( ["Value must be a file"] )
+      }
+      assertValidateParam(param, ["Value must be a file"])
 
       // valid (empty) file
-      param = fromJS({
+      param = {
         required: false,
         type: "file",
         value: undefined
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
+      }
+      assertValidateParam(param, [])
 
       // valid file
-      param = fromJS({
+      param = {
         required: false,
         type: "file",
         value: new win.File()
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
+      }
+      assertValidateParam(param, [])
     })
 
     it("validates required arrays", function() {
       // invalid (empty) array
-      param = fromJS({
+      param = {
         required: true,
         type: "array",
         value: []
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( ["Required field is not provided"] )
+      }
+      assertValidateParam(param, ["Required field is not provided"])
 
       // invalid (not an array)
-      param = fromJS({
+      param = {
         required: true,
         type: "array",
         value: undefined
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( ["Required field is not provided"] )
+      }
+      assertValidateParam(param, ["Required field is not provided"])
 
       // invalid array, items do not match correct type
-      param = fromJS({
+      param = {
         required: true,
         type: "array",
         value: [1],
         items: {
           type: "string"
         }
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [{index: 0, error: "Value must be a string"}] )
+      }
+      assertValidateParam(param, [{index: 0, error: "Value must be a string"}])
 
       // valid array, with no 'type' for items
-      param = fromJS({
+      param = {
         required: true,
         type: "array",
         value: ["1"]
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
+      }
+      assertValidateParam(param, [])
 
       // valid array, items match type
-      param = fromJS({
+      param = {
         required: true,
         type: "array",
         value: ["1"],
         items: {
           type: "string"
         }
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
+      }
+      assertValidateParam(param, [])
     })
 
     it("validates optional arrays", function() {
       // valid, empty array
-      param = fromJS({
+      param = {
         required: false,
         type: "array",
         value: []
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
+      }
+      assertValidateParam(param, [])
 
       // invalid, items do not match correct type
-      param = fromJS({
+      param = {
         required: false,
         type: "array",
         value: ["number"],
         items: {
           type: "number"
         }
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [{index: 0, error: "Value must be a number"}] )
+      }
+      assertValidateParam(param, [{index: 0, error: "Value must be a number"}])
 
       // valid
-      param = fromJS({
+      param = {
         required: false,
         type: "array",
         value: ["test"],
         items: {
           type: "string"
         }
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
+      }
+      assertValidateParam(param, [])
     })
 
     it("validates required booleans", function() {
       // invalid boolean value
-      param = fromJS({
+      param = {
         required: true,
         type: "boolean",
         value: undefined
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( ["Required field is not provided"] )
+      }
+      assertValidateParam(param, ["Required field is not provided"])
 
       // invalid boolean value (not a boolean)
-      param = fromJS({
+      param = {
         required: true,
         type: "boolean",
         value: "test string"
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( ["Required field is not provided"] )
+      }
+      assertValidateParam(param, ["Required field is not provided"])
 
       // valid boolean value
-      param = fromJS({
+      param = {
         required: true,
         type: "boolean",
         value: "true"
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
+      }
+      assertValidateParam(param, [])
 
       // valid boolean value
-      param = fromJS({
+      param = {
         required: true,
         type: "boolean",
         value: false
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
+      }
+      assertValidateParam(param, [])
     })
 
     it("validates optional booleans", function() {
       // valid (empty) boolean value
-      param = fromJS({
+      param = {
         required: false,
         type: "boolean",
         value: undefined
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
+      }
+      assertValidateParam(param, [])
 
       // invalid boolean value (not a boolean)
-      param = fromJS({
+      param = {
         required: false,
         type: "boolean",
         value: "test string"
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( ["Value must be a boolean"] )
+      }
+      assertValidateParam(param, ["Value must be a boolean"])
 
       // valid boolean value
-      param = fromJS({
+      param = {
         required: false,
         type: "boolean",
         value: "true"
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
+      }
+      assertValidateParam(param, [])
 
       // valid boolean value
-      param = fromJS({
+      param = {
         required: false,
         type: "boolean",
         value: false
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
+      }
+      assertValidateParam(param, [])
     })
 
     it("validates required numbers", function() {
       // invalid number, string instead of a number
-      param = fromJS({
+      param = {
         required: true,
         type: "number",
         value: "test"
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( ["Required field is not provided"] )
+      }
+      assertValidateParam(param, ["Required field is not provided"])
 
       // invalid number, undefined value
-      param = fromJS({
+      param = {
         required: true,
         type: "number",
         value: undefined
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( ["Required field is not provided"] )
+      }
+      assertValidateParam(param, ["Required field is not provided"])
 
       // valid number with min and max
-      param = fromJS({
+      param = {
         required: true,
         type: "number",
         value: 10,
         minimum: 5,
         maximum: 99
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
+      }
+      assertValidateParam(param, [])
 
       // valid negative number with min and max
-      param = fromJS({
+      param = {
         required: true,
         type: "number",
         value: -10,
         minimum: -50,
         maximum: -5
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
+      }
+      assertValidateParam(param, [])
 
       // invalid number with maximum:0
-      param = fromJS({
+      param = {
         required: true,
         type: "number",
         value: 1,
         maximum: 0
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( ["Value must be less than Maximum"] )
+      }
+      assertValidateParam(param, ["Value must be less than Maximum"])
 
       // invalid number with minimum:0
-      param = fromJS({
+      param = {
         required: true,
         type: "number",
         value: -10,
         minimum: 0
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( ["Value must be greater than Minimum"] )
+      }
+      assertValidateParam(param, ["Value must be greater than Minimum"])
     })
 
     it("validates optional numbers", function() {
       // invalid number, string instead of a number
-      param = fromJS({
+      param = {
         required: false,
         type: "number",
         value: "test"
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( ["Value must be a number"] )
+      }
+      assertValidateParam(param, ["Value must be a number"])
 
       // valid (empty) number
-      param = fromJS({
+      param = {
         required: false,
         type: "number",
         value: undefined
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
+      }
+      assertValidateParam(param, [])
 
       // valid number
-      param = fromJS({
+      param = {
         required: false,
         type: "number",
         value: 10
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
+      }
+      assertValidateParam(param, [])
     })
 
     it("validates required integers", function() {
       // invalid integer, string instead of an integer
-      param = fromJS({
+      param = {
         required: true,
         type: "integer",
         value: "test"
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( ["Required field is not provided"] )
+      }
+      assertValidateParam(param, ["Required field is not provided"])
 
       // invalid integer, undefined value
-      param = fromJS({
+      param = {
         required: true,
         type: "integer",
         value: undefined
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( ["Required field is not provided"] )
+      }
+      assertValidateParam(param, ["Required field is not provided"])
 
       // valid integer
-      param = fromJS({
+      param = {
         required: true,
         type: "integer",
         value: 10
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
+      }
+      assertValidateParam(param, [])
     })
 
     it("validates optional integers", function() {
       // invalid integer, string instead of an integer
-      param = fromJS({
+      param = {
         required: false,
         type: "integer",
         value: "test"
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( ["Value must be an integer"] )
+      }
+      assertValidateParam(param, ["Value must be an integer"])
 
       // valid (empty) integer
-      param = fromJS({
+      param = {
         required: false,
         type: "integer",
         value: undefined
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
+      }
+      assertValidateParam(param, [])
 
       // integers
-      param = fromJS({
+      param = {
         required: false,
         type: "integer",
         value: 10
-      })
-      result = validateParam( param, false )
-      expect( result ).toEqual( [] )
+      }
+      assertValidateParam(param, [])
     })
   })
 


### PR DESCRIPTION
Fixes #3747 

Add flag for `isOAS3` on `validateParam` function. Access parameter details from OAS3's `schema` object.

Add a couple tests for new `isOAS3` flag. 