### PR TITLE
Fix auth icon display regression

### DIFF
--- a/src/core/plugins/auth/selectors.js
+++ b/src/core/plugins/auth/selectors.js
@@ -10,7 +10,7 @@ export const shownDefinitions = createSelector(
 
 export const definitionsToAuthorize = createSelector(
     state,
-    () =>( { specSelectors } ) => {
+    () => ( { specSelectors } ) => {
       let definitions = specSelectors.securityDefinitions()
       let list = List()
 
@@ -27,7 +27,7 @@ export const definitionsToAuthorize = createSelector(
 )
 
 
-export const getDefinitionsByNames = ( state, securities ) =>( { specSelectors } ) => {
+export const getDefinitionsByNames = ( state, securities ) => ( { specSelectors } ) => {
   let securityDefinitions = specSelectors.securityDefinitions()
   let result = List()
 
@@ -64,7 +64,7 @@ export const authorized = createSelector(
 )
 
 
-export const isAuthorized = ( state, securities ) =>( { authSelectors } ) => {
+export const isAuthorized = ( state, securities ) => ( { authSelectors } ) => {
   let authorized = authSelectors.authorized()
 
   if(!List.isList(securities)) {

--- a/src/core/plugins/oas3/auth-extensions/wrap-selectors.js
+++ b/src/core/plugins/oas3/auth-extensions/wrap-selectors.js
@@ -20,7 +20,7 @@ const nullSelector =  createSelector(() => null)
 
 const OAS3NullSelector = onlyOAS3(nullSelector)
 
-// Hasta la vista, authentication!
+// Hasta la vista, authorization!
 export const shownDefinitions = OAS3NullSelector
 export const definitionsToAuthorize = OAS3NullSelector
 export const getDefinitionsByNames = OAS3NullSelector

--- a/src/core/plugins/oas3/auth-extensions/wrap-selectors.js
+++ b/src/core/plugins/oas3/auth-extensions/wrap-selectors.js
@@ -6,7 +6,7 @@ import { isOAS3 as isOAS3Helper } from "../helpers"
 // Helpers
 
 function onlyOAS3(selector) {
-  return (ori, system) => (...args) => {
+  return (ori, system) => (state, ...args) => {
     const spec = system.getSystem().specSelectors.specJson()
     if(isOAS3Helper(spec)) {
       return selector(...args)


### PR DESCRIPTION
CC @webron, we discussed this earlier today.

This PR fixes a problem with our authSelector wrapActions in the OAS3 plugin, which was causing bleed into Swagger2 usage.

This has to do with interaction between complex action creators (with the signature `(...args) => (system) => action`) and wrapActions. State is being provided to these original actions based on their signature, which creates an undocumented function signature in the wrapAction that sits atop it.

I've made a TODO for myself in #3754 to document the correct way to go about this before shipping our new docs.