### PR TITLE
`Good first contribution` -> `Good first issue`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **This is the new version of swagger-ui, 3.x. Want to learn more? Check out our [FAQ](http://swagger.io/new-ui-faq/).**
 
-**👉🏼 Want to score an easy open-source contribution?** Check out our [Good first contribution](https://github.com/swagger-api/swagger-ui/issues?q=is%3Aissue+is%3Aopen+label%3A%22Good+first+contribution%22) label.
+**👉🏼 Want to score an easy open-source contribution?** Check out our [Good first issue](https://github.com/swagger-api/swagger-ui/issues?q=is%3Aissue+is%3Aopen+label%3A%22Good+first+issue%22) label.
 
 As a brand new version, written from the ground up, there are some known issues and unimplemented features. Check out the [Known Issues](#known-issues) section for more details.
 


### PR DESCRIPTION
GitHub suggested that `Good first issue` is now a blessed label name:

<img width="856" alt="messages image 1075800677" src="https://user-images.githubusercontent.com/680248/31518223-6b2ed194-af53-11e7-83f9-4ec078d2bee3.png">

I've renamed the label itself as well.