### PR TITLE
Fix regression with rendering links in Markdown.

### DIFF
--- a/src/core/components/providers/markdown.jsx
+++ b/src/core/components/providers/markdown.jsx
@@ -31,6 +31,7 @@ export default Markdown
 const sanitizeOptions = {
     allowedTags: sanitize.defaults.allowedTags.concat([ "h1", "h2", "img" ]),
     allowedAttributes: {
+        ...sanitize.defaults.allowedAttributes,
         "img": sanitize.defaults.allowedAttributes.img.concat(["title"])
     },
     textFilter: function(text) {

--- a/test/components/markdown.js
+++ b/test/components/markdown.js
@@ -24,6 +24,12 @@ describe("Markdown component", function() {
             const el = render(<Markdown source={str} />)
             expect(el.html()).toEqual(`<div class="markdown"><h1>h1</h1>\n<h2>h2</h2>\n<h3>h3</h3>\n<h4>h4</h4>\n<h5>h5</h5>\n<h6>h6</h6>\n</div>`)
         })
+
+        it("allows links", function() {
+            const str = `[Link](https://example.com/)`
+            const el = render(<Markdown source={str} />)
+            expect(el.html()).toEqual(`<div class="markdown"><p><a href="https://example.com/" target="_blank">Link</a></p>\n</div>`)
+        })
     })
 
     describe("OAS 3", function() {


### PR DESCRIPTION
Previously, sections of Markdown that included links would be rendered correctly in the generated API documentation. A recent change broke this as we aren't picking up the sanitise default allowed attributes. This puts the defaults back in place and also adds to the unit tests.