### PR TITLE
Sourcemaps

### DIFF
--- a/make-webpack-config.js
+++ b/make-webpack-config.js
@@ -137,7 +137,7 @@ module.exports = function(rules, options) {
       }
     },
 
-    devtool: specialOptions.sourcemaps ? "cheap-module-source-map" : null,
+  devtool: specialOptions.sourcemaps ? "nosource-source-map" : null,
 
     plugins,
 

--- a/webpack-dist-bundle.config.js
+++ b/webpack-dist-bundle.config.js
@@ -11,7 +11,7 @@ let rules = [
           name: "[name].js"
         }
       },
-      { loader: "babel-loader" }
+      { loader: "babel-loader?retainLines=true" }
     ]
   }
 ]

--- a/webpack-dist-standalone.config.js
+++ b/webpack-dist-standalone.config.js
@@ -11,7 +11,7 @@ let rules = [
           name: "[name].js"
         }
       },
-      { loader: "babel-loader" }
+      { loader: "babel-loader?retainLines=true" }
     ]
   }
 ]

--- a/webpack-dist.config.js
+++ b/webpack-dist.config.js
@@ -13,7 +13,7 @@ let rules = [
           name: "[name].js"
         }
       },
-      { loader: "babel-loader" }
+      { loader: "babel-loader?retainLines=true" }
     ]
   }
 ]

--- a/webpack-hot-dev-server.config.js
+++ b/webpack-hot-dev-server.config.js
@@ -9,13 +9,7 @@ const rules = [
           inline: true
         }
       },
-      { loader: "babel-loader" }
-    ]
-  },
-  { test: /\.(jsx)(\?.*)?$/,
-    use: [
-      { loader: "react-hot-loader" }, 
-      { loader: "babel-loader" }
+      { loader: "babel-loader?retainLines=true" }
     ]
   },
   { test: /\.(css)(\?.*)?$/,
@@ -48,7 +42,7 @@ module.exports = require("./make-webpack-config")(rules, {
   _special: {
     separateStylesheets: false,
   },
-	devtool: "eval",
+	devtool: "eval-source-map",
   entry: {
     "swagger-ui-bundle": [
       "./src/polyfills",


### PR DESCRIPTION
Fixes #3263.
Prior art: #3296.
CC: #3592.
CC: @scottohara (you were working on this a couple months back), @heldersepu (we chatted about this last month), & @webron (you pointed out the Docker source map issue this week).

This PR:
- Switches static builds to `nosource-source-map`, a lightweight source map that does not include code visibility, but provides line-accurate stack traces.
- Switches dev server to `eval-source-map`, a heavy but high-accuracy source map.

I built the Docker image locally, and the new source map settings are working as expected.

---

I tested every [devtool option that Webpack has](https://webpack.js.org/configuration/devtool/). Here are my findings:
![img_9127](https://user-images.githubusercontent.com/680248/31807034-86e35d4c-b520-11e7-9aa2-95249c4a4c7f.JPG)
