### PR TITLE
Pass `parameter.schema` as schema in OAS 3.0

### DIFF
--- a/src/core/components/parameter-row.jsx
+++ b/src/core/components/parameter-row.jsx
@@ -115,7 +115,7 @@ export default class ParameterRow extends Component {
                               required={ required }
                               description={param.get("description") ? `${param.get("name")} - ${param.get("description")}` : `${param.get("name")}`}
                               onChange={ this.onChangeWrapper }
-                              schema={ param }/>
+                              schema={ isOAS3 && isOAS3() ? param.get("schema") : param }/>
           }
 
 


### PR DESCRIPTION
Fixes https://github.com/swagger-api/swagger-editor/issues/1530.

Parameters were restructured in OAS 3.0; schemas are no longer at the top level of parameters. Adjusting to account for the change. EZ.