### PR TITLE
Add ESLint rule that catches `describe.only`, `it.only`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,7 +16,8 @@
   "extends": ["eslint:recommended", "plugin:react/recommended"],
 
   "plugins": [
-    "react"
+    "react",
+    "mocha"
   ],
 
   "rules": {
@@ -32,6 +33,7 @@
     "comma-dangle": 0,
     "no-console": ["error", { allow: ["warn", "error"] }],
     "react/jsx-no-bind": 1,
-    "react/display-name": 0
+    "react/display-name": 0,
+    "mocha/no-exclusive-tests": "error"
   }
 }

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "enzyme": "^2.7.1",
     "eslint": "^4.1.1",
     "eslint-plugin-import": "^2.6.0",
+    "eslint-plugin-mocha": "^4.11.0",
     "eslint-plugin-react": "^7.1.0",
     "extract-text-webpack-plugin": "^2.1.2",
     "file-loader": "0.11.2",

--- a/test/core/plugins/oas3/wrap-auth-selectors.js
+++ b/test/core/plugins/oas3/wrap-auth-selectors.js
@@ -5,7 +5,7 @@ import {
   definitionsToAuthorize
 } from "corePlugins/oas3/auth-extensions/wrap-selectors"
 
-describe.only("oas3 plugin - auth extensions - wrapSelectors", function(){
+describe("oas3 plugin - auth extensions - wrapSelectors", function(){
 
   describe("execute", function(){
 


### PR DESCRIPTION
CC: @heldersepu, @owenconti 

I'll make a note to add this rule to Swagger-Client and Swagger-Editor, but if anyone reading this wants to handle it, I wouldn't complain 😄 