### PR TITLE
Fix accessing bundled swagger json behind reverse proxy

### DIFF
--- a/docker-run.sh
+++ b/docker-run.sh
@@ -32,7 +32,7 @@ fi
 
 if [[ -f $SWAGGER_JSON ]]; then
   cp $SWAGGER_JSON $NGINX_ROOT
-  REL_PATH="/$(basename $SWAGGER_JSON)"
+  REL_PATH="./$(basename $SWAGGER_JSON)"
   sed -i "s|http://petstore.swagger.io/v2/swagger.json|$REL_PATH|g" $INDEX_FILE
   sed -i "s|http://example.com/api|$REL_PATH|g" $INDEX_FILE
 else


### PR DESCRIPTION
If swagger-ui is run behind reverse proxy in path other than /, accessing
bundled swagger json configured in SWAGGER_JSON env variable will fail.

Fix that by changing REL_PATH prefix from `/` to `./`