### PR TITLE
Return null instead of empty ImmutableMap in OAS3 securityDefinitions selector

### DIFF
--- a/src/core/plugins/oas3/spec-extensions/wrap-selectors.js
+++ b/src/core/plugins/oas3/spec-extensions/wrap-selectors.js
@@ -50,7 +50,7 @@ export const definitions = onlyOAS3(createSelector(
 
 export const securityDefinitions = onlyOAS3(createSelector(
   spec,
-  spec => spec.getIn(["components", "securitySchemes"]) || Map()
+  spec => spec.getIn(["components", "securitySchemes"]) || null
 ))
 
 export const host = OAS3NullSelector


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

This PR changes the `specSelectors.securityDefinitions` selector in OAS3 to return `null` instead of `Immutable.Map()`.

Returning a falsy value allows existing logic that uses the selector to work correctly - for example, the AuthorizeBtn show/hide logic:

https://github.com/swagger-api/swagger-ui/blob/3f9b999e902dcd2cf3e2873e35f7f0dad075925d/src/core/components/layouts/base.jsx#L89-L91

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes #3816.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

See the screenshots below - I tested this with two OpenAPI definitions, one with authorizations and one without.

### Screenshots (if appropriate):

No authorization:

<img width="1297" alt="messages image 195195724" src="https://user-images.githubusercontent.com/680248/32080241-74e87990-ba63-11e7-9e56-a8bc1757b376.png">

Yes authorization:

<img width="1297" alt="messages image 3774973505" src="https://user-images.githubusercontent.com/680248/32080344-f0a0c6fa-ba63-11e7-9742-330a4e96d4a3.png">

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] ~~I have added tests to cover my changes.~~ (This is a small change)
- [x] All new and existing tests passed.