### PR TITLE
Bug/auth operation btn error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 .idea
 .deps_check
 .DS_Store
+.nyc_output
 npm-debug.log*
 .eslintcache
 package-lock.json

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "test-in-node": "npm run lint-errors && npm run just-test-in-node",
     "just-test": "karma start --config karma.conf.js",
     "just-test-in-node": "mocha --recursive --compilers js:babel-core/register test/core test/components test/bugs test/swagger-ui-dist-package test/xss",
+    "just-check-coverage": "nyc npm run just-test-in-node",
     "test-e2e": "sleep 3 && nightwatch test/e2e/scenarios/ --config test/e2e/nightwatch.json",
     "e2e-initial-render": "nightwatch test/e2e/scenarios/ --config test/e2e/nightwatch.json --group initial-render",
     "mock-api": "json-server --watch test/e2e/db.json --port 3204",
@@ -152,5 +153,9 @@
   ],
   "optionalDependencies": {
     "webpack-dev-server": "2.5.0"
+  },
+  "nyc": {
+    "all": true,
+    "include": ["**/src/core/plugins/**.js"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "node-sass": "^4.5.0",
     "npm-run-all": "4.0.2",
     "null-loader": "0.1.1",
+    "nyc": "^11.3.0",
     "open": "0.0.5",
     "postcss-loader": "2.0.6",
     "raw-loader": "0.5.1",
@@ -156,6 +157,8 @@
   },
   "nyc": {
     "all": true,
-    "include": ["**/src/core/plugins/**.js"]
+    "include": [
+      "**/src/core/plugins/**.js"
+    ]
   }
 }

--- a/src/core/components/auth/authorize-operation-btn.jsx
+++ b/src/core/components/auth/authorize-operation-btn.jsx
@@ -1,25 +1,23 @@
 import React from "react"
 import PropTypes from "prop-types"
-import ImPropTypes from "react-immutable-proptypes"
 
 export default class AuthorizeOperationBtn extends React.Component {
+    static propTypes = {
+      isAuthorized: PropTypes.bool.isRequired,
+      onClick: PropTypes.func
+    }
+
   onClick =(e) => {
     e.stopPropagation()
+    let { onClick } = this.props
 
-    let { security, authActions, authSelectors } = this.props
-    let definitions = authSelectors.getDefinitionsByNames(security)
-
-    authActions.showDefinitions(definitions)
+    if(onClick) {
+      onClick()
+    }
   }
 
   render() {
-    let { security, authSelectors } = this.props
-
-    let isAuthorized = authSelectors.isAuthorized(security)
-
-    if(isAuthorized === null) {
-      return null
-    }
+    let { isAuthorized } = this.props
 
     return (
       <button className={isAuthorized ? "authorization__btn locked" : "authorization__btn unlocked"} onClick={ this.onClick }>
@@ -29,11 +27,5 @@ export default class AuthorizeOperationBtn extends React.Component {
       </button>
 
     )
-  }
-
-  static propTypes = {
-    authSelectors: PropTypes.object.isRequired,
-    authActions: PropTypes.object.isRequired,
-    security: ImPropTypes.iterable.isRequired
   }
 }

--- a/src/core/components/operation.jsx
+++ b/src/core/components/operation.jsx
@@ -1,4 +1,5 @@
 import React, { PureComponent } from "react"
+import { List } from "immutable"
 import PropTypes from "prop-types"
 import { getList } from "core/utils"
 import * as CustomPropTypes from "core/proptypes"
@@ -183,9 +184,13 @@ export default class Operation extends PureComponent {
 
             {
               (!security || !security.count()) ? null :
-                <AuthorizeOperationBtn authActions={ authActions }
-                  security={ security }
-                  authSelectors={ authSelectors }/>
+                <AuthorizeOperationBtn
+                  isAuthorized={ authSelectors.isAuthorized(security) }
+                  onClick={() => {
+                    const applicableDefinitions = authSelectors.definitionsForRequirements(security)
+                    authActions.showDefinitions(applicableDefinitions)
+                  }}
+                />
             }
           </div>
 

--- a/src/core/components/operation.jsx
+++ b/src/core/components/operation.jsx
@@ -1,5 +1,4 @@
 import React, { PureComponent } from "react"
-import { List } from "immutable"
 import PropTypes from "prop-types"
 import { getList } from "core/utils"
 import * as CustomPropTypes from "core/proptypes"

--- a/src/core/plugins/auth/selectors.js
+++ b/src/core/plugins/auth/selectors.js
@@ -58,10 +58,10 @@ export const getDefinitionsByNames = ( state, securities ) => ( { specSelectors 
   return result
 }
 
-export const definitionsForRequirements = (state, securities) => ({ authSelectors }) => {
-  const allDefinitions = authSelectors.definitionsToAuthorize()
-  return allDefinitions.filter((def, name) => {
-    return securities.has(name)
+export const definitionsForRequirements = (state, securities = List()) => ({ authSelectors }) => {
+  const allDefinitions = authSelectors.definitionsToAuthorize() || List()
+  return allDefinitions.filter((def) => {
+    return securities.some(sec => sec.get(def.keySeq().first()))
   })
 }
 

--- a/src/core/plugins/auth/selectors.js
+++ b/src/core/plugins/auth/selectors.js
@@ -58,6 +58,13 @@ export const getDefinitionsByNames = ( state, securities ) => ( { specSelectors 
   return result
 }
 
+export const definitionsForRequirements = (state, securities) => ({ authSelectors }) => {
+  const allDefinitions = authSelectors.definitionsToAuthorize()
+  return allDefinitions.filter((def, name) => {
+    return securities.has(name)
+  })
+}
+
 export const authorized = createSelector(
     state,
     auth => auth.get("authorized") || Map()

--- a/src/core/plugins/auth/selectors.js
+++ b/src/core/plugins/auth/selectors.js
@@ -28,6 +28,7 @@ export const definitionsToAuthorize = createSelector(
 
 
 export const getDefinitionsByNames = ( state, securities ) => ( { specSelectors } ) => {
+  console.warn("WARNING: getDefinitionsByNames is deprecated and will be removed in the next major version.")
   let securityDefinitions = specSelectors.securityDefinitions()
   let result = List()
 

--- a/src/core/plugins/auth/selectors.js
+++ b/src/core/plugins/auth/selectors.js
@@ -11,7 +11,7 @@ export const shownDefinitions = createSelector(
 export const definitionsToAuthorize = createSelector(
     state,
     () => ( { specSelectors } ) => {
-      let definitions = specSelectors.securityDefinitions()
+      let definitions = specSelectors.securityDefinitions() || Map({})
       let list = List()
 
       //todo refactor

--- a/test/core/plugins/auth/selectors.js
+++ b/test/core/plugins/auth/selectors.js
@@ -3,7 +3,7 @@ import expect from "expect"
 import { fromJS } from "immutable"
 import { definitionsToAuthorize, definitionsForRequirements } from "corePlugins/auth/selectors"
 
-describe.only("auth plugin - selectors", () => {
+describe("auth plugin - selectors", () => {
   describe("definitionsToAuthorize", () => {
     it("should return securityDefinitions as a List", () => {
       const securityDefinitions = {

--- a/test/core/plugins/auth/selectors.js
+++ b/test/core/plugins/auth/selectors.js
@@ -1,0 +1,133 @@
+/* eslint-env mocha */
+import expect from "expect"
+import { fromJS } from "immutable"
+import { definitionsToAuthorize, definitionsForRequirements } from "corePlugins/auth/selectors"
+
+describe.only("auth plugin - selectors", () => {
+  describe("definitionsToAuthorize", () => {
+    it("should return securityDefinitions as a List", () => {
+      const securityDefinitions = {
+        "petstore_auth": {
+          "type": "oauth2",
+          "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+          "flow": "implicit",
+          "scopes": {
+            "write:pets": "modify pets in your account",
+            "read:pets": "read your pets"
+          }
+        },
+        "api_key": {
+          "type": "apiKey",
+          "name": "api_key",
+          "in": "header"
+        }
+      }
+
+      const system = {
+        specSelectors: {
+          securityDefinitions() {
+            return fromJS(securityDefinitions)
+          }
+        }
+      }
+
+      const res = definitionsToAuthorize({})(system)
+
+      expect(res.toJS()).toEqual([
+        {
+          "petstore_auth": securityDefinitions["petstore_auth"]
+        },
+        {
+          "api_key": securityDefinitions["api_key"]
+        },
+      ])
+    })
+
+    it("should fail gracefully with bad data", () => {
+      const securityDefinitions = null
+
+      const system = {
+        specSelectors: {
+          securityDefinitions() {
+            return fromJS(securityDefinitions)
+          }
+        }
+      }
+
+      const res = definitionsToAuthorize({})(system)
+
+      expect(res.toJS()).toEqual([])
+    })
+  })
+
+  describe("definitionsForRequirements", () => {
+    it("should return applicable securityDefinitions as a List", () => {
+      const securityDefinitions = {
+        "petstore_auth": {
+          "type": "oauth2",
+          "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+          "flow": "implicit",
+          "scopes": {
+            "write:pets": "modify pets in your account",
+            "read:pets": "read your pets"
+          }
+        },
+        "api_key": {
+          "type": "apiKey",
+          "name": "api_key",
+          "in": "header"
+        }
+      }
+
+      const system = {
+        authSelectors: {
+          definitionsToAuthorize() {
+            return fromJS([
+              {
+                "petstore_auth": securityDefinitions["petstore_auth"]
+              },
+              {
+                "api_key": securityDefinitions["api_key"]
+              },
+            ])
+          }
+        }
+      }
+
+      const securities = fromJS([
+        {
+          "petstore_auth": [
+            "write:pets",
+            "read:pets"
+          ]
+        }
+      ])
+
+      const res = definitionsForRequirements({}, securities)(system)
+
+      expect(res.toJS()).toEqual([
+        {
+          "petstore_auth": securityDefinitions["petstore_auth"]
+        }
+      ])
+    })
+
+    it("should fail gracefully with bad data", () => {
+      const securityDefinitions = null
+
+      const system = {
+        authSelectors: {
+          definitionsToAuthorize() {
+            return null
+          }
+        }
+      }
+
+      const securities = null
+
+      const res = definitionsForRequirements({}, securities)(system)
+
+      expect(res.toJS()).toEqual([])
+    })
+  })
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

- Makes the `AuthorizeOperationBtn` component dumber
- Creates `definitionsForRequirements` auth selector
- Adds `NYC` test coverage reporter (free bonus)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes an issue identified by @webron today - no ticket for the problem.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
##### Manual
- I tested the changes with the Swagger 2.0 Petstore.
- I tested the changes with the OpenAPI 3.0 Petstore.
- I tested the changes with an OpenAPI 3.0 document with a multiflow OAuth2 security scheme.

##### Project tests
- I added Swagger 2.0 tests for the selectors I changed.
- OAS 3.0 is already covered by existing tests.

### Screenshots (if appropriate):



### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.