### PR TITLE
Custom Header support for OAuth2 Authorization flows

### DIFF
--- a/dev-helpers/index.html
+++ b/dev-helpers/index.html
@@ -95,7 +95,8 @@
       realm: "your-realms",
       appName: "your-app-name",
       scopeSeparator: " ",
-      additionalQueryStringParams: {}
+      additionalQueryStringParams: {},
+      additionalHeaders: {}
     })
   }
 </script>

--- a/src/core/plugins/auth/actions.js
+++ b/src/core/plugins/auth/actions.js
@@ -141,7 +141,7 @@ export const authorizeAccessCodeWithBasicAuthentication = ( { auth, redirectUrl 
 
 export const authorizeRequest = ( data ) => ( { fn, authActions, errActions, authSelectors } ) => {
   let { body, query={}, headers={}, name, url, auth } = data
-  let { additionalQueryStringParams } = authSelectors.getConfigs() || {}
+  let { additionalQueryStringParams, additionalHeaders } = authSelectors.getConfigs() || {}
   let fetchUrl = url
 
   for (let key in additionalQueryStringParams) {
@@ -151,7 +151,7 @@ export const authorizeRequest = ( data ) => ( { fn, authActions, errActions, aut
   let _headers = Object.assign({
     "Accept":"application/json, text/plain, */*",
     "Content-Type": "application/x-www-form-urlencoded"
-  }, headers)
+  }, additionalHeaders, headers)
 
   fn.fetch({
     url: fetchUrl,


### PR DESCRIPTION
### Description

While the regular Swagger UI configuration permits intercepting and
decorating requests using the `requestInterceptor` option, the same
is not available for the OAuth2 Authorization requests. Thus it
is not possible to add common CSRF protection headers required by
some API's.

As the OAuth2 configuration seems to have a slightly different signature
than the usual swagger UI config, this patch adds an `additionalHeaders`
field (similar to `additionalQueryStringParams`) on the initOAuth2 configuration
input, which is attached to all OAuth2 based API requests.

### Motivation and Context
My API requires the existence of the `X-Requested-With` HTTP Header for CSRF protection
in accordance to the OWASP guidelines. I can easily add this to actual API requests, but not
to the original OAuth2 authorization request.

### How Has This Been Tested?

Manual checks against a private API.

### Types of changes
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
