### PR TITLE
Ft/deprecated schema

### DIFF
--- a/src/core/components/object-model.jsx
+++ b/src/core/components/object-model.jsx
@@ -76,13 +76,14 @@ export default class ObjectModel extends Component {
               {
                 !(properties && properties.size) ? null : properties.entrySeq().map(
                     ([key, value]) => {
+                      let isDeprecated = isOAS3() && value.get("deprecated")
                       let isRequired = List.isList(requiredProperties) && requiredProperties.contains(key)
                       let propertyStyle = { verticalAlign: "top", paddingRight: "0.2em" }
                       if ( isRequired ) {
                         propertyStyle.fontWeight = "bold"
                       }
 
-                      return (<tr key={key}>
+                      return (<tr key={key} className={isDeprecated && "deprecated"}>
                         <td style={ propertyStyle }>
                           { key }{ isRequired && <span style={{ color: "red" }}>*</span> }
                         </td>

--- a/src/style/_models.scss
+++ b/src/style/_models.scss
@@ -12,6 +12,10 @@
         {
             color: $model-deprecated-font-color !important;
         }
+
+        > td:first-of-type {
+            text-decoration: line-through;
+        }
     }
     &-toggle
     {


### PR DESCRIPTION
Adds more visual distinction to deprecated model properties

* Adds `deprecated` class to `tr` of deprecated model property
* Use class to add strike-through via CSS (similar to how deprecated is handled visually elsewhere)

Visual change:
![screen shot 2017-11-16 at 1 29 06 pm](https://user-images.githubusercontent.com/2728212/32911584-2a6e0446-cad2-11e7-954c-d2485b7377fc.png)
