### PR TITLE
Callback expansion issues

### DIFF
--- a/src/core/components/content-type.jsx
+++ b/src/core/components/content-type.jsx
@@ -27,6 +27,16 @@ export default class ContentType extends React.Component {
     }
   }
 
+  componentWillReceiveProps(nextProps) {
+    if(!nextProps.contentTypes || !nextProps.contentTypes.size) {
+      return
+    }
+
+    if(!nextProps.contentTypes.includes(nextProps.value)) {
+      nextProps.onChange(nextProps.contentTypes.first())
+    }
+  }
+
   onChangeWrapper = e => this.props.onChange(e.target.value)
 
   render() {

--- a/src/core/containers/OperationContainer.jsx
+++ b/src/core/containers/OperationContainer.jsx
@@ -57,6 +57,8 @@ export default class OperationContainer extends PureComponent {
     const operationId = op.getIn(["operation", "operationId"]) || op.getIn(["operation", "__originalOperationId"]) || opId(op.get("operation"), props.path, props.method) || op.get("id")
     const isShownKey = ["operations", props.tag, operationId]
     const isDeepLinkingEnabled = deepLinking && deepLinking !== "false"
+    const allowTryItOut = typeof props.allowTryItOut === "undefined" ?
+      props.specSelectors.allowTryItOutFor(props.path, props.method) : props.allowTryItOut
 
     return {
       operationId,
@@ -64,9 +66,9 @@ export default class OperationContainer extends PureComponent {
       showSummary,
       displayOperationId,
       displayRequestDuration,
+      allowTryItOut,
       isShown: layoutSelectors.isShown(isShownKey, docExpansion === "full" ),
       jumpToKey: `paths.${props.path}.${props.method}`,
-      allowTryItOut: props.specSelectors.allowTryItOutFor(props.path, props.method),
       response: props.specSelectors.responseFor(props.path, props.method),
       request: props.specSelectors.requestFor(props.path, props.method)
     }

--- a/src/core/plugins/oas3/components/callbacks.jsx
+++ b/src/core/plugins/oas3/components/callbacks.jsx
@@ -4,7 +4,7 @@ import ImPropTypes from "react-immutable-proptypes"
 import { fromJS } from "immutable"
 
 const Callbacks = (props) => {
-  let { callbacks, getComponent, layoutSelectors } = props
+  let { callbacks, getComponent } = props
   // const Markdown = getComponent("Markdown")
   const OperationContainer = getComponent("OperationContainer", true)
 

--- a/src/core/plugins/oas3/components/callbacks.jsx
+++ b/src/core/plugins/oas3/components/callbacks.jsx
@@ -1,5 +1,6 @@
 import React from "react"
 import PropTypes from "prop-types"
+import ImPropTypes from "react-immutable-proptypes"
 import { fromJS } from "immutable"
 
 const Callbacks = (props) => {
@@ -24,6 +25,7 @@ const Callbacks = (props) => {
               {...props}
               op={op}
               key={method}
+              tag={""}
               method={method}
               path={pathItemName}
               allowTryItOut={false}
@@ -40,7 +42,7 @@ const Callbacks = (props) => {
 
 Callbacks.propTypes = {
   getComponent: PropTypes.func.isRequired,
-  callbacks: PropTypes.array.isRequired
+  callbacks: ImPropTypes.iterable.isRequired
 
 }
 

--- a/src/core/plugins/oas3/components/callbacks.jsx
+++ b/src/core/plugins/oas3/components/callbacks.jsx
@@ -1,10 +1,11 @@
 import React from "react"
 import PropTypes from "prop-types"
+import { fromJS } from "immutable"
 
 const Callbacks = (props) => {
-  let { callbacks, getComponent } = props
+  let { callbacks, getComponent, layoutSelectors } = props
   // const Markdown = getComponent("Markdown")
-  const Operation = getComponent("operation", true)
+  const OperationContainer = getComponent("OperationContainer", true)
 
   if(!callbacks) {
     return <span>No callbacks</span>
@@ -16,24 +17,21 @@ const Callbacks = (props) => {
       { callback.map((pathItem, pathItemName) => {
         return <div key={pathItemName}>
           { pathItem.map((operation, method) => {
-            return <Operation
-              operation={operation}
+            let op = fromJS({
+              operation
+            })
+            return <OperationContainer
+              {...props}
+              op={op}
               key={method}
               method={method}
-              isShownKey={["callbacks", operation.get("id"), callbackName]}
               path={pathItemName}
               allowTryItOut={false}
-              {...props}></Operation>
-            // return <pre>{JSON.stringify(operation)}</pre>
+              />
           }) }
         </div>
       }) }
     </div>
-    // return <div>
-    //   <h2>{name}</h2>
-    //   {callback.description && <Markdown source={callback.description}/>}
-    //   <pre>{JSON.stringify(callback)}</pre>
-    // </div>
   })
   return <div>
     {callbackElements}

--- a/src/core/plugins/oas3/components/request-body-editor.jsx
+++ b/src/core/plugins/oas3/components/request-body-editor.jsx
@@ -48,6 +48,13 @@ export default class RequestBodyEditor extends PureComponent {
     }
   }
 
+  componentDidUpdate(prevProps) {
+    if(this.props.requestBody !== prevProps.requestBody) {
+      // force recalc of value if the request body definition has changed
+      this.setValueToSample(this.props.mediaType)
+    }
+  }
+
   setValueToSample = (explicitMediaType) => {
     this.onChange(this.sample(explicitMediaType))
   }

--- a/src/core/plugins/oas3/components/request-body.jsx
+++ b/src/core/plugins/oas3/components/request-body.jsx
@@ -22,6 +22,10 @@ const RequestBody = ({
 
   const mediaTypeValue = requestBodyContent.get(contentType)
 
+  if(!mediaTypeValue) {
+    return null
+  }
+
   return <div>
     { requestBodyDescription &&
       <Markdown source={requestBodyDescription} />

--- a/src/core/plugins/view/root-injects.js
+++ b/src/core/plugins/view/root-injects.js
@@ -120,5 +120,5 @@ export const getComponent = (getSystem, getStore, getComponents, componentName, 
     return makeContainer(getSystem, component, getStore())
 
   // container == truthy
-  return makeContainer(getSystem, component)
+  return makeContainer(getSystem, wrapRender(component))
 }

--- a/test/core/system/system.js
+++ b/test/core/system/system.js
@@ -571,6 +571,116 @@ describe("bound system", function(){
       // Then
       expect(renderedComponent.text()).toEqual("This came from mapStateToProps and this came from the system and this came from my own props")
     })
+
+    it("should catch errors thrown inside of React Component Class render methods", function() {
+      // Given
+      // eslint-disable-next-line react/require-render-return
+      class BrokenComponent extends React.Component {
+        render() {
+          throw new Error("This component is broken")
+        }
+      }
+      const system = new System({
+        plugins: [
+          ViewPlugin,
+          {
+            components: {
+              BrokenComponent
+            }
+          }
+        ]
+      })
+
+      // When
+      var Component = system.getSystem().getComponent("BrokenComponent")
+      const renderedComponent = render(<Component />)
+
+      // Then
+      expect(renderedComponent.text()).toEqual("😱 Could not render BrokenComponent, see the console.")
+    })
+
+    it("should catch errors thrown inside of pure component render methods", function() {
+      // Given
+      // eslint-disable-next-line react/require-render-return
+      class BrokenComponent extends PureComponent {
+        render() {
+          throw new Error("This component is broken")
+        }
+      }
+
+      const system = new System({
+        plugins: [
+          ViewPlugin,
+          {
+            components: {
+              BrokenComponent
+            }
+          }
+        ]
+      })
+
+      // When
+      var Component = system.getSystem().getComponent("BrokenComponent")
+      const renderedComponent = render(<Component />)
+
+      // Then
+      expect(renderedComponent.text()).toEqual("😱 Could not render BrokenComponent, see the console.")
+    })
+
+    it("should catch errors thrown inside of stateless component functions", function() {
+      // Given
+      // eslint-disable-next-line react/require-render-return
+      let BrokenComponent = function BrokenComponent() { throw new Error("This component is broken") }
+      const system = new System({
+        plugins: [
+          ViewPlugin,
+          {
+            components: {
+              BrokenComponent
+            }
+          }
+        ]
+      })
+
+      // When
+      var Component = system.getSystem().getComponent("BrokenComponent")
+      const renderedComponent = render(<Component />)
+
+      // Then
+      expect(renderedComponent.text().startsWith("😱 Could not render")).toEqual(true)
+    })
+
+    it("should catch errors thrown inside of container components", function() {
+      // Given
+      // eslint-disable-next-line react/require-render-return
+      class BrokenComponent extends React.Component {
+        render() {
+          throw new Error("This component is broken")
+        }
+      }
+
+      const system = new System({
+        plugins: [
+          ViewPlugin,
+          {
+            components: {
+              BrokenComponent
+            }
+          }
+        ]
+      })
+
+      // When
+      var Component = system.getSystem().getComponent("BrokenComponent", true)
+      const renderedComponent = render(
+        <Provider store={system.getStore()}>
+          <Component />
+        </Provider>
+      )
+
+      // Then
+      expect(renderedComponent.text()).toEqual("😱 Could not render BrokenComponent, see the console.")
+    })
   })
 
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

**This PR restores the Callback display to its original glory.**

Freebies included:
- `ContentType` now uses its `onChange` callback to reset to the first available value if the value isn't in the next set of available content types.
  - This prevents the RequestBody component crashing when changing the name of a currently-selected content type.
- Container components now enjoy render try/catch protection.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes https://github.com/swagger-api/swagger-editor/issues/1565.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Manually tested with OAS3 callback example definition
- Manually tested integration with Editor - confirmed that all values update when changed

### Screenshots (if appropriate):

<img width="567" alt="messages image 3042805168" src="https://user-images.githubusercontent.com/680248/32976294-fef958dc-cbc7-11e7-96cd-83256c80934b.png">

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.