### PR TITLE
Display `name` security scheme property for apiKey type

### DIFF
--- a/src/core/components/auth/api-key-auth.jsx
+++ b/src/core/components/auth/api-key-auth.jsx
@@ -61,6 +61,9 @@ export default class ApiKeyAuth extends React.Component {
           <Markdown source={ schema.get("description") } />
         </Row>
         <Row>
+          <p>Name: <code>{ schema.get("name") }</code></p>
+        </Row>
+        <Row>
           <p>In: <code>{ schema.get("in") }</code></p>
         </Row>
         <Row>


### PR DESCRIPTION
EZ

Fixes https://github.com/swagger-api/swagger-ui/issues/3907