### PR TITLE
Add flow to make scope checkbox id unqiue

### DIFF
--- a/src/core/components/auth/oauth2.jsx
+++ b/src/core/components/auth/oauth2.jsx
@@ -200,11 +200,11 @@ export default class Oauth2 extends React.Component {
                 <Row key={ name }>
                   <div className="checkbox">
                     <Input data-value={ name }
-                          id={`${name}-checkbox-${this.state.name}`}
+                          id={`${name}-${flow}-checkbox-${this.state.name}`}
                            disabled={ isAuthorized }
                            type="checkbox"
                            onChange={ this.onScopeChange }/>
-                         <label htmlFor={`${name}-checkbox-${this.state.name}`}>
+                         <label htmlFor={`${name}-${flow}-checkbox-${this.state.name}`}>
                            <span className="item"></span>
                            <div className="text">
                              <p className="name">{name}</p>


### PR DESCRIPTION
This PR fixes issue #3925. In case we have two flows for the same security scheme and those flows define the same scopes, it is not possible to select a scope from the lower flow since both checkboxes have the same id.

This PR simply adds the flow name to the id so that the checkbox id is unqiue across all flows.


