### PR TITLE
Don't treat `not` as an array (in contrast to `allOf`, `anyOf`, `oneOf`)

### DIFF
--- a/src/core/components/model.jsx
+++ b/src/core/components/model.jsx
@@ -1,9 +1,10 @@
 import React, { PureComponent } from "react"
+import ImPropTypes from "react-immutable-proptypes"
 import PropTypes from "prop-types"
 
 export default class Model extends PureComponent {
   static propTypes = {
-    schema: PropTypes.object.isRequired,
+    schema: ImPropTypes.orderedMap.isRequired,
     getComponent: PropTypes.func.isRequired,
     specSelectors: PropTypes.object.isRequired,
     name: PropTypes.string,

--- a/src/core/components/object-model.jsx
+++ b/src/core/components/object-model.jsx
@@ -142,12 +142,13 @@ export default class ObjectModel extends Component {
                   : <tr>
                     <td>{ "not ->" }</td>
                     <td>
-                      {not.map((schema, k) => {
-                        return <div key={k}><Model { ...otherProps } required={ false }
-                                 getComponent={ getComponent }
-                                 schema={ schema }
-                                 depth={ depth + 1 } /></div>
-                      })}
+                      <div>
+                        <Model { ...otherProps }
+                               required={ false }
+                               getComponent={ getComponent }
+                               schema={ not }
+                               depth={ depth + 1 } />
+                        </div>
                     </td>
                   </tr>
               }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

This fixes Swagger-UI's incorrect parsing of Schema object `not `values. It looks like I introduced this problem - looking back at the RC1 definitions I wrote to implement against, the Schema Object definition had an invalid array under the `not `key (presumably a result of copy-pasting `anyOf`/`oneOf`). Mea culpa!

Per JSON Schema (emphasis mine):

#### allOf

> The value of this keyword MUST be an array. This array MUST have at least one element.
> 
> Each element of this array MUST be an object, and each object MUST be a valid JSON Schema.

#### anyOf

> The value of this keyword MUST be an array. This array MUST have at least one element.
> 
> Each element of this array MUST be an object, and each object MUST be a valid JSON Schema.

#### oneOf

> The value of this keyword MUST be an array. This array MUST have at least one element.
> 
> Each element of this array MUST be an object, and each object MUST be a valid JSON Schema.


#### not 

> **The value of this keyword MUST be an object**. This object MUST be a valid JSON Schema.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes swagger-api/swagger-ui#3932.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Manually tested (screenshot below).

### Screenshots (if appropriate):

<img width="1792" alt="messages image 3494563957" src="https://user-images.githubusercontent.com/680248/33099854-32db365a-cec7-11e7-9a1e-edcb54ac149d.png">


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.