### PR TITLE
Correctly validate OAS3 parameters that lack a `schema`

### DIFF
--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -473,6 +473,9 @@ export const validateParam = (param, isXml, isOAS3 = false) => {
   let required = param.get("required")
 
   let paramDetails = isOAS3 ? param.get("schema") : param
+
+  if(!paramDetails) return errors
+
   let maximum = paramDetails.get("maximum")
   let minimum = paramDetails.get("minimum")
   let type = paramDetails.get("type")
@@ -480,7 +483,7 @@ export const validateParam = (param, isXml, isOAS3 = false) => {
   let maxLength = paramDetails.get("maxLength")
   let minLength = paramDetails.get("minLength")
   let pattern = paramDetails.get("pattern")
-  
+
 
   /*
     If the parameter is required OR the parameter has a value (meaning optional, but filled in)
@@ -506,7 +509,7 @@ export const validateParam = (param, isXml, isOAS3 = false) => {
       let err = validatePattern(value, pattern)
       if (err) errors.push(err)
     }
-    
+
     if (maxLength || maxLength === 0) {
       let err = validateMaxLength(value, maxLength)
       if (err) errors.push(err)

--- a/test/core/utils.js
+++ b/test/core/utils.js
@@ -321,14 +321,11 @@ describe("utils", function() {
     }
 
     it("should check the isOAS3 flag when validating parameters", function() {
-      // This should "skip" validation because there is no `schema.type` property
+      // This should "skip" validation because there is no `schema` property
       // and we are telling `validateParam` this is an OAS3 spec
       param = fromJS({
         value: "",
-        required: true,
-        schema: {
-          notTheTypeProperty: "string"
-        }
+        required: true
       })
       result = validateParam( param, false, true )
       expect( result ).toEqual( [] )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

This PR changes `validateParam` to tolerate OAS3 parameters that lack a `schema` property entirely.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

I bumped into this while fixing a different bug 😄

The OpenAPI 3.0.0 specification [indicates that `schema` is not required](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#parameter-object), therefore we should not rely on it being present.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I modified an existing unit test in order to create a failing test, then made source changes.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.