### PR TITLE
Pass `false` webpack devtool option instead of `null`

### DIFF
--- a/make-webpack-config.js
+++ b/make-webpack-config.js
@@ -137,7 +137,7 @@ module.exports = function(rules, options) {
       }
     },
 
-  devtool: specialOptions.sourcemaps ? "nosource-source-map" : null,
+  devtool: specialOptions.sourcemaps ? "nosource-source-map" : false,
 
     plugins,
 


### PR DESCRIPTION
devtool is accept `string | false` but passed `null`

### How Has This Been Tested?

Specify `false` as `sourcemaps` in webpack-dist.config.js, and do `npm run build`.
It will be failed before this modifications.