### PR TITLE
Be more nodejs friendly

### DIFF
--- a/src/core/index.js
+++ b/src/core/index.js
@@ -3,11 +3,12 @@ import deepExtend from "deep-extend"
 import System from "core/system"
 import win from "core/window"
 import ApisPreset from "core/presets/apis"
+
 import * as AllPlugins from "core/plugins/all"
 import { parseSearch } from "core/utils"
 
-if (process.env.NODE_ENV !== "production") {
-  window.Perf = require("react-addons-perf")
+if (process.env.NODE_ENV !== "production" && typeof window !== "undefined") {
+  win.Perf = require("react-addons-perf")
 }
 
 // eslint-disable-next-line no-undef

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -607,7 +607,10 @@ export const getSampleSchema = (schema, contentType="", config={}) => {
 
 export const parseSearch = () => {
   let map = {}
-  let search = window.location.search
+  let search = win.location.search
+
+  if(!search)
+    return {}
 
   if ( search != "" ) {
     let params = search.substr(1).split("&")

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -1,6 +1,6 @@
 // Promise global, Used ( at least ) by 'whatwg-fetch'. And required by IE 11
 
-if(!window.Promise) {
+if(typeof Promise === "undefined") {
   require("core-js/fn/promise")
 }
 


### PR DESCRIPTION
Allow swagger-ui to be loaded into nodejs.
At this point for testing only ( no server side rendering magic yet )