### PR TITLE
OAS3 `TRACE` method operation display

### DIFF
--- a/src/core/components/operations.jsx
+++ b/src/core/components/operations.jsx
@@ -2,6 +2,13 @@ import React from "react"
 import PropTypes from "prop-types"
 import { createDeepLinkPath, sanitizeUrl } from "core/utils"
 
+const SWAGGER2_OPERATION_METHODS = [
+  "get", "put", "post", "delete", "options", "head", "patch"
+]
+
+const OAS3_OPERATION_METHODS = SWAGGER2_OPERATION_METHODS.concat(["trace"])
+
+
 export default class Operations extends React.Component {
 
   static propTypes = {
@@ -112,6 +119,13 @@ export default class Operations extends React.Component {
                       operations.map( op => {
                         const path = op.get("path")
                         const method = op.get("method")
+
+                        const validMethods = specSelectors.isOAS3() ?
+                          OAS3_OPERATION_METHODS : SWAGGER2_OPERATION_METHODS
+
+                        if(validMethods.indexOf(method) === -1) {
+                          return null
+                        }
 
                         return <OperationContainer
                           key={`${path}-${method}`}

--- a/src/core/components/operations.jsx
+++ b/src/core/components/operations.jsx
@@ -120,6 +120,11 @@ export default class Operations extends React.Component {
                         const path = op.get("path")
                         const method = op.get("method")
 
+                        // FIXME: (someday) this logic should probably be in a selector,
+                        // but doing so would require further opening up
+                        // selectors to the plugin system, to allow for dynamic
+                        // overriding of low-level selectors that other selectors
+                        // rely on. --KS, 12/17
                         const validMethods = specSelectors.isOAS3() ?
                           OAS3_OPERATION_METHODS : SWAGGER2_OPERATION_METHODS
 

--- a/src/core/plugins/spec/selectors.js
+++ b/src/core/plugins/spec/selectors.js
@@ -4,8 +4,6 @@ import { fromJS, Set, Map, OrderedMap, List } from "immutable"
 
 const DEFAULT_TAG = "default"
 
-const OPERATION_METHODS = ["get", "put", "post", "delete", "options", "head", "patch"]
-
 const state = state => {
   return state || Map()
 }
@@ -97,9 +95,6 @@ export const operations = createSelector(
         return {}
       }
       path.forEach((operation, method) => {
-        if(OPERATION_METHODS.indexOf(method) === -1) {
-          return
-        }
         list = list.push(fromJS({
           path: pathName,
           method,

--- a/test/components/operations.js
+++ b/test/components/operations.js
@@ -11,12 +11,14 @@ const components = {
   OperationContainer: ({ path, method }) => <span className="mocked-op" id={`${path}-${method}`} />
 }
 
-describe.only("<Operations/>", function(){
+describe("<Operations/>", function(){
   it("should render a Swagger2 `get` method, but not a `trace` or `foo` method", function(){
 
     let props = {
+      fn: {},
+      specActions: {},
+      layoutActions: {},
       getComponent: (name)=> {
-
         return components[name] || null
       },
       getConfigs: () => {
@@ -60,16 +62,17 @@ describe.only("<Operations/>", function(){
 
     let wrapper = render(<Operations {...props}/>)
 
-    expect(wrapper.find("span.mocked-op").length).toEqual(2)
+    expect(wrapper.find("span.mocked-op").length).toEqual(1)
     expect(wrapper.find("span.mocked-op").eq(0).attr("id")).toEqual("/pets/{id}-get")
-    expect(wrapper.find("span.mocked-op").eq(1).attr("id")).toEqual("/pets/{id}-trace")
   })
 
   it("should render an OAS3 `get` and `trace` method, but not a `foo` method", function(){
 
     let props = {
+      fn: {},
+      specActions: {},
+      layoutActions: {},
       getComponent: (name)=> {
-
         return components[name] || null
       },
       getConfigs: () => {

--- a/test/components/operations.js
+++ b/test/components/operations.js
@@ -1,0 +1,120 @@
+/* eslint-env mocha */
+import React from "react"
+import expect, { createSpy } from "expect"
+import { render } from "enzyme"
+import { fromJS } from "immutable"
+import Operations from "components/operations"
+import {Collapse} from "components/layout-utils"
+
+const components = {
+  Collapse,
+  OperationContainer: ({ path, method }) => <span className="mocked-op" id={`${path}-${method}`} />
+}
+
+describe.only("<Operations/>", function(){
+  it("should render a Swagger2 `get` method, but not a `trace` or `foo` method", function(){
+
+    let props = {
+      getComponent: (name)=> {
+
+        return components[name] || null
+      },
+      getConfigs: () => {
+        return {}
+      },
+      specSelectors: {
+        isOAS3() { return false },
+        taggedOperations() {
+          return fromJS({
+          "default": {
+            "operations": [
+              {
+                "path": "/pets/{id}",
+                "method": "get"
+              },
+              {
+                "path": "/pets/{id}",
+                "method": "trace"
+              },
+              {
+                "path": "/pets/{id}",
+                "method": "foo"
+              },
+            ]
+          }
+        })
+        },
+      },
+      layoutSelectors: {
+        currentFilter() {
+          return null
+        },
+        isShown() {
+          return true
+        },
+        show() {
+          return true
+        }
+      }
+    }
+
+    let wrapper = render(<Operations {...props}/>)
+
+    expect(wrapper.find("span.mocked-op").length).toEqual(2)
+    expect(wrapper.find("span.mocked-op").eq(0).attr("id")).toEqual("/pets/{id}-get")
+    expect(wrapper.find("span.mocked-op").eq(1).attr("id")).toEqual("/pets/{id}-trace")
+  })
+
+  it("should render an OAS3 `get` and `trace` method, but not a `foo` method", function(){
+
+    let props = {
+      getComponent: (name)=> {
+
+        return components[name] || null
+      },
+      getConfigs: () => {
+        return {}
+      },
+      specSelectors: {
+        isOAS3() { return true },
+        taggedOperations() {
+          return fromJS({
+          "default": {
+            "operations": [
+              {
+                "path": "/pets/{id}",
+                "method": "get"
+              },
+              {
+                "path": "/pets/{id}",
+                "method": "trace"
+              },
+              {
+                "path": "/pets/{id}",
+                "method": "foo"
+              },
+            ]
+          }
+        })
+        },
+      },
+      layoutSelectors: {
+        currentFilter() {
+          return null
+        },
+        isShown() {
+          return true
+        },
+        show() {
+          return true
+        }
+      }
+    }
+
+    let wrapper = render(<Operations {...props}/>)
+
+    expect(wrapper.find("span.mocked-op").length).toEqual(2)
+    expect(wrapper.find("span.mocked-op").eq(0).attr("id")).toEqual("/pets/{id}-get")
+    expect(wrapper.find("span.mocked-op").eq(1).attr("id")).toEqual("/pets/{id}-trace")
+  })
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

This PR allows OAS3 definitions to display operations defined as `TRACE` methods, which are legal in OAS3 but not Swagger 2.0.

##### Technical debt

Method filtering logic was moved from the spec selectors to the Operations component. This is _okay_, but the proper place for such logic is in a selector.

The problem was that it was that the Operations component was using the `operationsWithTags` selector, but the `operations` selector was doing the filtering. The data flow looked like this:

`operations => operationsWithRootInherited => operationsWithTags`

Because of the tight coupling of low-level selectors like `operations` within `/plugins/spec/selectors.js`, it was impossible to override the filtering logic from outside the file... so I compromised and moved the filtering logic to the component, which is able to get the necessary context to implement the Swagger2/OAS3 switching logic.

I made an attempt (two, actually) to quickly extend the selector system to accommodate, but didn't arrive at a solution I was happy with. I have some thoughts that I'll add to a forthcoming feature ticket for this.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes #3982.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- I added unit tests to `<Operations />` that cover the filtering logic.
- I manually tested the changes against Petstore 2.0, USPTO 3.0, and [this 3.0 definition](https://gist.githubusercontent.com/shockey/650c0402c64ada9ee925a5ec7b8aad28/raw/61640dc61d8b6d8e57d75288735be4c4e42ced0f/3986-trace-operation.openapi.yaml).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.