### PR TITLE
Do not display undocumenetd when there is a default response

### DIFF
--- a/src/core/components/operation.jsx
+++ b/src/core/components/operation.jsx
@@ -107,7 +107,7 @@ export default class Operation extends PureComponent {
 
     // Merge in Live Response
     if(responses && response && response.size > 0) {
-      let notDocumented = !responses.get(String(response.get("status")))
+      let notDocumented = !responses.get(String(response.get("status"))) && !responses.get("default")
       response = response.set("notDocumented", notDocumented)
     }
 


### PR DESCRIPTION
From the documentation about Default response:

> Sometimes, an operation can return multiple errors with different HTTP status codes, but all of them have the same response structure. You can use the default response to describe these errors collectively, not individually. “default” means this response is used for all HTTP codes that are not covered individually for this operation.

However, when default is used and a status is returned which is not specifically defined - the "undocumented" warning appears - although it is defined with the default.
When default exists no such warning should appear.

