### PR TITLE
Added extraction of quoted filename from content disposition header

### DIFF
--- a/src/main/javascript/view/OperationView.js
+++ b/src/main/javascript/view/OperationView.js
@@ -718,8 +718,11 @@ SwaggerUi.Views.OperationView = Backbone.View.extend({
 
         // Use filename from response header
         var disposition = headers['content-disposition'] || headers['Content-Disposition'];
-        if(typeof disposition !== 'undefined') {
-          var responseFilename = /filename=([^;]*);?/.exec(disposition);
+        if (typeof disposition !== 'undefined') {
+          var responseFilename = /filename=\\"([^;]*);?\\"/.exec(disposition);
+          if (responseFilename === null) {
+            responseFilename = /filename=([^;]*);?/.exec(disposition);
+          }
           if(responseFilename !== null && responseFilename.length > 1) {
             download = responseFilename[1];
             fileName = download;


### PR DESCRIPTION
Small bug fix, added ability to extract quoted file name from Content-Disposition header.

### Description
Extended fix for Issue #1991, added extraction of quoted file name that is present in case when file name contains special characters like " ".

### Motivation and Context
When header contains quoted file name, it is presented on UI quoted as well ("some file.ext"), when downloading file from UI on windows the " characters are replaced by "_" character and it does change file name and extension (first and last char in filename) after saving file.
