### PR TITLE
Don't parse non-method path keys as operations

### DIFF
--- a/src/core/plugins/spec/selectors.js
+++ b/src/core/plugins/spec/selectors.js
@@ -4,6 +4,10 @@ import { fromJS, Set, Map, OrderedMap, List } from "immutable"
 
 const DEFAULT_TAG = "default"
 
+const OPERATION_METHODS = [
+  "get", "put", "post", "delete", "options", "head", "patch", "trace"
+]
+
 const state = state => {
   return state || Map()
 }
@@ -95,6 +99,9 @@ export const operations = createSelector(
         return {}
       }
       path.forEach((operation, method) => {
+        if(OPERATION_METHODS.indexOf(method) < 0) {
+          return
+        }
         list = list.push(fromJS({
           path: pathName,
           method,


### PR DESCRIPTION
Fixes https://github.com/swagger-api/swagger-ui/issues/4040 🎉 