### PR TITLE
Change nginx configuration in Docker container based on BASE_URL, instead of moving actual files

### DIFF
--- a/docker-run.sh
+++ b/docker-run.sh
@@ -2,6 +2,7 @@
 
 set -e
 
+BASE_URL=${BASE_URL:-/}
 NGINX_ROOT=/usr/share/nginx/html
 INDEX_FILE=$NGINX_ROOT/index.html
 
@@ -22,13 +23,7 @@ replace_or_delete_in_index () {
 }
 
 if [ "${BASE_URL}" ]; then
-  NGINX_WITH_BASE_URL="${NGINX_ROOT}${BASE_URL}"
-
-  mkdir -p ${NGINX_WITH_BASE_URL}
-  mv ${NGINX_ROOT}/*.* ${NGINX_WITH_BASE_URL}/
-
-  INDEX_FILE=$NGINX_WITH_BASE_URL/index.html
-  NGINX_ROOT=$NGINX_WITH_BASE_URL
+  sed -i "s|location .* {|location $BASE_URL {|g" /etc/nginx/nginx.conf
 fi
 
 replace_in_index myApiKeyXXXX123456789 $API_KEY

--- a/nginx.conf
+++ b/nginx.conf
@@ -15,10 +15,11 @@ http {
   server {
     listen            8080;
     server_name       localhost;
+    index             index.html index.htm;
 
     location / {
-      root            /usr/share/nginx/html;
-      index           index.html index.htm;
+      alias            /usr/share/nginx/html/;
+
       if ($request_method = 'OPTIONS') {
           add_header 'Access-Control-Allow-Origin' '*';
           add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';


### PR DESCRIPTION
### Description
Change nginx configuration based on BASE_URL, instead of moving actual files.

### Motivation and Context
Following to #4072 

Since moving static files around is too complex (because the files may be moved before), so in this change, will changing `location` directive in nginx.conf. To make it works, `alias` directive is required instead of `root`.

### How Has This Been Tested?
```bash
docker build -t swagger-ui .
docker run -p 8080:8080 -e "BASE_URL=/api/docs" swagger-ui
# Should be able to access http://localhost:8080/api/docs
docker run -p 8080:8080 -e "BASE_URL=/api/docs" swagger-ui
# Even running it again, should still be able to access http://localhost:8080/api/docs
docker run -p 8080:8080 swagger-ui
# Even changing BASE_URL later, Should be able to access http://localhost:8080
```

### Screenshots (if appropriate):
None

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

  