### PR TITLE
Update _table.scss to fix varying column widths

### DIFF
--- a/src/style/_table.scss
+++ b/src/style/_table.scss
@@ -52,8 +52,7 @@ table
 
                 &:first-of-type
                 {
-                    max-width: 20%;
-                    min-width: 6em;
+                    width: 20%;
                     padding: 10px 0;
                 }
             }


### PR DESCRIPTION
### Description
This fixes an issue where the width of the Description column (parameters-col_description) changes when switching between Example Value and Model view.

### Motivation and Context
We noticed this while making some changes to our company's swagger doc. It can also be seen in the [Swagger Petstore](http://petstore.swagger.io/) example. 

### How Has This Been Tested?
I made the changes locally and it fixed the issue. This shouldn't require any further testing as it's a minor CSS change.

### Screenshots (if appropriate):
Toggling between Example Value and Model for a given method causes the width of the column to change. See examples below for [updatePet](http://petstore.swagger.io/#/pet/updatePet):

- Example Value (1044 px wide):
![image](https://user-images.githubusercontent.com/35153209/34631987-f2b0593c-f227-11e7-898a-297649e831ef.png)
- Model (1081px wide):
![image](https://user-images.githubusercontent.com/35153209/34631993-f7b8fa60-f227-11e7-8e91-1c932682072e.png)


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
