### PR TITLE
Make parameter description styles consistent

### DIFF
--- a/src/style/_table.scss
+++ b/src/style/_table.scss
@@ -84,15 +84,6 @@ table
 
 .parameters-col_description
 {
-    p
-    {
-        font-size: 14px;
-
-        margin: 0;
-
-        @include text_body();
-    }
-
     input[type=text]
     {
         width: 100%;


### PR DESCRIPTION
Remove ".swagger-ui .parameters-col_description p" formatting from _table.scss.

<!--- Provide a general summary of your changes in the Title above -->

### Description
Descriptions for request parameters are bold and a larger font (14px) than they are for response descriptions (12px, normal weight). This proposed change makes the font display consistent.

### Motivation and Context
We noticed this while making some updates to our company's swagger doc and wanted to share. It can also be seen in the [Swagger Petstore](http://petstore.swagger.io/) example (screenshots below).

### How Has This Been Tested?
We made the changes locally and it fixed the issue.

### Screenshots (if appropriate):
See the request parameter description ([POST /pet](http://petstore.swagger.io/#/pet/addPet)):
![image](https://user-images.githubusercontent.com/35153209/34632819-92f27f84-f22c-11e7-89f7-b9200451f9e1.png)
The font for a response property description is different ([GET /pet/{petId}](http://petstore.swagger.io/#/pet/getPetById)):
![image](https://user-images.githubusercontent.com/35153209/34632860-cc6ed546-f22c-11e7-9430-320dc8ff4b62.png)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
