### PR TITLE
Allow Custom Nginx Port in Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+/.git
+/.github
+/dev-helpers
+/docs
+/src
+/swagger-ui-dist-package
+/test

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV OAUTH_REALM "**None**"
 ENV OAUTH_APP_NAME "**None**"
 ENV OAUTH_ADDITIONAL_PARAMS "**None**"
 ENV SWAGGER_JSON "/app/swagger.json"
-ENV PORT 80
+ENV PORT 8080
 ENV BASE_URL ""
 
 RUN apk add --update nginx

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -53,4 +53,7 @@ if [[ -n "$VALIDATOR_URL" ]]; then
   unset TMP_VU
 fi
 
+# replace the PORT that nginx listens on if supplied
+if [[ -n "${PORT}" ]]; then sed -i "s|8080|${PORT}|g" /etc/nginx/nginx.conf; fi
+
 exec nginx -g 'daemon off;'


### PR DESCRIPTION
@shockey 

### Description

Adding the ability to use a custom port for Nginx within the docker container.

### Motivation and Context

In some environments, it can be desirable to specify a custom port to use within the container. Specifically, I'm referring to Kubernetes, where all pods within a deployment are addressable (to each other) via `localhost`. This means that within a deployment, we can't have multiple side car pods/containers listening on the same port.

Normally, this isn't an issue. But when there are multiple hardcoded ports it can be difficult to get things working without having to create services to map ports and separate deployments.

### How Has This Been Tested?

* `docker build -t swaggertest .`
* `docker run --rm -it -p 8900:8709 -e PORT=8709 swaggertest`
* `open http://localhost:8900`
* 🎆  🍾 

I also added a _.dockerignore_ file to decrease the build context size (faster docker builds). It went from ~195MB to ~18MB.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality) 
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
