### PR TITLE
improve(npm-module): include standalone preset in `swagger-ui`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,6 +4,8 @@
 !package.json
 !dist/swagger-ui.js
 !dist/swagger-ui.js.map
+!dist/swagger-ui-standalone-preset.js
+!dist/swagger-ui-standalone-preset.js.map
 !dist/swagger-ui.css
 !dist/swagger-ui.css.map
 !dist/oauth2-redirect.html


### PR DESCRIPTION
Fixes swagger-api/swagger-ui#3978.

Usage:

```js
import StandalonePreset from 'swagger-ui/dist/swagger-ui-standalone-preset'

SwaggerUI({
  dom_id: '#swagger',
  url:'http://petstore.swagger.io/v2/swagger.json',
  plugins: [StandalonePreset],
  layout: 'StandaloneLayout'
});
```