### PR TITLE
Fix example

### DIFF
--- a/docs/usage/installation.md
+++ b/docs/usage/installation.md
@@ -27,7 +27,7 @@ The module's contents mirrors the `dist` folder you see in the Git repository. T
 
 ```javascript
 const express = require('express')
-const pathToSwaggerUi = require('swagger-ui').absolutePath()
+const pathToSwaggerUi = require('swagger-ui-dist').absolutePath()
 
 const app = express()
 


### PR DESCRIPTION
Fix readme example
### Description
installation.md provides an example with 'swagger-ui' but the example fails whereas 'swagger-ui-dist' works


### Motivation and Context
Helps people following examples from documentation

### How Has This Been Tested?
Manually created a new project and tried the example

### Types of changes
- [x] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
