### PR TITLE
Fixes Execution error in IE11

### DIFF
--- a/src/core/plugins/auth/reducers.js
+++ b/src/core/plugins/auth/reducers.js
@@ -44,7 +44,7 @@ export default {
     let { auth, token } = payload
     let parsedAuth
 
-    auth.token = token
+    auth.token = Object.assign({}, token)
     parsedAuth = fromJS(auth)
 
     return state.setIn( [ "authorized", parsedAuth.get("name") ], parsedAuth )


### PR DESCRIPTION
### Description
Fixes a weird IE11 edge case, potentially related to IE11 handling of object references that traverse frames.

### Motivation and Context
In IE11 we were unable to execute requests after authenticating. After authenticating and attempting to execute a request in IE, the below error was logged to the console and the "Loading" indicator stayed present in the UI. The HTTP request also never executed. I believe the error number indicates a NullPointerException in IE, but not sure.
![image](https://user-images.githubusercontent.com/1234523/35071422-3e0fb828-fba6-11e7-9d1b-a848911309ff.png)

I tracked the exception source down in swagger-js to: 

```js
export function applySecurities({ request, securities = {}, operation = {}, spec }) {
      ...
      const accessToken = token && token.access_token
```

At this point `token` was defined but `token.access_token` access threw an error. The debugger value was hidden (not able to view the properties of the object) and logging `token` displayed 'Permission Denied'. 

This only occurred in IE, while chrome and others worked just fine. I'm still unsure the exact cause, but my hunch is that because the `token` object is originally generated in the oauth2 frame, there is some weird permission interaction with the parent frame. So, I attempted to break the reference and it seems to resolve the issue. This change would probably work in other places, specifically within the auth callbacks themselves, so we can move it if needed.

### How Has This Been Tested?
Fixes the issue and IE and I see no regression in Chrome.

All existing tests pass in my fork: 
![image](https://user-images.githubusercontent.com/1234523/35071966-57ed2da0-fba8-11e7-84b9-8d876c032bfe.png)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
