### PR TITLE
initial perf, which gets stripped out in production

### DIFF
--- a/make-webpack-config.js
+++ b/make-webpack-config.js
@@ -37,7 +37,7 @@ var commonRules = [
   { test: /\.(woff|woff2)(\?.*)?$/,
     loader: "url-loader?limit=100000" },
   { test: /\.(ttf|eot)(\?.*)?$/,
-    loader: "file-loader" }
+    loader: "file-loader" },
 ]
 
 module.exports = function(rules, options) {

--- a/package.json
+++ b/package.json
@@ -145,7 +145,8 @@
     "style-loader": "0.18.2",
     "url-loader": "0.5.9",
     "webpack": "^2.6.1",
-    "webpack-bundle-size-analyzer": "^2.5.0"
+    "webpack-bundle-size-analyzer": "^2.5.0",
+    "webpack-strip-block": "^0.2.0"
   },
   "config": {
     "deps_check_dir": ".deps_check"

--- a/src/core/plugins/spec/actions.js
+++ b/src/core/plugins/spec/actions.js
@@ -93,6 +93,10 @@ export const resolveSpec = (json, url) => ({specActions, specSelectors, errActio
 
   let specStr = specSelectors.specStr()
 
+  /* develblock:start */
+  require("root/src/perf").start("resolve")
+  /* develblock:end */
+
   return resolve({
     fetch,
     spec: json,
@@ -120,6 +124,9 @@ export const resolveSpec = (json, url) => ({specActions, specSelectors, errActio
         errActions.newThrownErrBatch(preparedErrors)
       }
 
+    /* develblock:start */
+    require("root/src/perf").stop("resolve")
+    /* develblock:end */
       return specActions.updateResolved(spec)
     })
 }

--- a/src/core/plugins/spec/reducers.js
+++ b/src/core/plugins/spec/reducers.js
@@ -36,7 +36,15 @@ export default {
   },
 
   [UPDATE_RESOLVED]: (state, action) => {
-    return state.setIn(["resolved"], fromJSOrdered(action.payload))
+    /* develblock:start */
+    require("root/src/perf").start("UPDATE_RESOLVED")
+    /* develblock:end */
+    const resolved = fromJSOrdered(action.payload)
+
+    /* develblock:start */
+    require("root/src/perf").stop("UPDATE_RESOLVED")
+    /* develblock:end */
+    return state.setIn(["resolved"], resolved)
   },
 
   [UPDATE_PARAM]: ( state, {payload} ) => {

--- a/src/core/system.js
+++ b/src/core/system.js
@@ -15,9 +15,15 @@ const idFn = a => a
 function createStoreWithMiddleware(rootReducer, initialState, getSystem) {
 
   let middlwares = [
-    // createLogger( {
-    //   stateTransformer: state => state && state.toJS()
-    // } ),
+    /* develblock:start */
+    // Measure actions
+    () => next => action => {
+      require("root/src/perf").start("action:"+action.type)
+      const res = next(action)
+      require("root/src/perf").stop("action:"+action.type)
+      return res
+    },
+    /* develblock:end */
     systemThunkMiddleware( getSystem )
   ]
 

--- a/src/perf.js
+++ b/src/perf.js
@@ -1,0 +1,16 @@
+// This uses experimental console methods, to track performance
+
+module.exports = {
+  start(str) {
+    /* develblock:start */
+    // eslint-disable-next-line no-console
+    console.time(str)
+    /* develblock:end */
+  },
+  stop(str) {
+    /* develblock:start */
+    // eslint-disable-next-line no-console
+    console.timeEnd(str)
+    /* develblock:end */
+  }
+}

--- a/webpack-dist.config.js
+++ b/webpack-dist.config.js
@@ -15,7 +15,17 @@ let rules = [
       },
       { loader: "babel-loader?retainLines=true" }
     ]
-  }
+  },
+  // This will strip out blocks of code that start with:
+  /* develblock:start */
+  // And end with
+  /* develblock:end */
+  {
+    test: /\.jsx?$/,
+    enforce: "pre",
+    exclude: /(node_modules|\.spec\.js)/,
+    loader: "webpack-strip-block"
+  },
 ]
 rules = rules.concat(styleRules)
 

--- a/webpack-hot-dev-server.config.js
+++ b/webpack-hot-dev-server.config.js
@@ -35,7 +35,7 @@ const rules = [
         }
       }
     ]
-  }
+  },
 ]
 
 module.exports = require("./make-webpack-config")(rules, {

--- a/webpack-watch.config.js
+++ b/webpack-watch.config.js
@@ -5,4 +5,9 @@ config.plugins = config.plugins.filter(plugin => {
   return plugin.constructor.name !== "UglifyJsPlugin"
 })
 
+config.module.rules = config.module.rules.filter(rule => {
+  // Disable minification
+  return rule.loader != "webpack-strip-block"
+})
+
 module.exports = config


### PR DESCRIPTION
Measures the time for each action, and can be used for other performance metrics that we don't want in production builds.