### PR TITLE
Streamline management of user-selected `produces` and `consumes` values (WIP)

### DIFF
--- a/src/core/components/operation.jsx
+++ b/src/core/components/operation.jsx
@@ -248,7 +248,7 @@ export default class Operation extends PureComponent {
                     oas3Actions={oas3Actions}
                     specActions={ specActions }
                     produces={ produces }
-                    producesValue={ operation.get("produces_value") }
+                    producesValue={ specSelectors.currentProducesFor([path, method]) }
                     specPath={specPath.push("responses")}
                     path={ path }
                     method={ method }

--- a/src/core/containers/OperationContainer.jsx
+++ b/src/core/containers/OperationContainer.jsx
@@ -82,26 +82,8 @@ export default class OperationContainer extends PureComponent {
   }
 
   componentWillReceiveProps(nextProps) {
-    const defaultContentType = "application/json"
-    let { specActions, path, method, op } = nextProps
-    let operation = op.get("operation")
-    let producesValue = operation.get("produces_value")
-    let produces = operation.get("produces")
-    let consumes = operation.get("consumes")
-    let consumesValue = operation.get("consumes_value")
-
     if(nextProps.response !== this.props.response) {
       this.setState({ executeInProgress: false })
-    }
-
-    if (producesValue === undefined) {
-      producesValue = produces && produces.size ? produces.first() : defaultContentType
-      specActions.changeProducesValue([path, method], producesValue)
-    }
-
-    if (consumesValue === undefined) {
-      consumesValue = consumes && consumes.size ? consumes.first() : defaultContentType
-      specActions.changeConsumesValue([path, method], consumesValue)
     }
   }
 

--- a/src/core/plugins/spec/actions.js
+++ b/src/core/plugins/spec/actions.js
@@ -19,7 +19,7 @@ export const LOG_REQUEST = "spec_log_request"
 export const CLEAR_RESPONSE = "spec_clear_response"
 export const CLEAR_REQUEST = "spec_clear_request"
 export const CLEAR_VALIDATE_PARAMS = "spec_clear_validate_param"
-export const UPDATE_OPERATION_VALUE = "spec_update_operation_value"
+export const UPDATE_OPERATION_META_VALUE = "spec_UPDATE_OPERATION_META_VALUE"
 export const UPDATE_RESOLVED = "spec_update_resolved"
 export const SET_SCHEME = "set_scheme"
 
@@ -150,14 +150,14 @@ export function clearValidateParams( payload ){
 
 export function changeConsumesValue(path, value) {
   return {
-    type: UPDATE_OPERATION_VALUE,
+    type: UPDATE_OPERATION_META_VALUE,
     payload:{ path, value, key: "consumes_value" }
   }
 }
 
 export function changeProducesValue(path, value) {
   return {
-    type: UPDATE_OPERATION_VALUE,
+    type: UPDATE_OPERATION_META_VALUE,
     payload:{ path, value, key: "produces_value" }
   }
 }

--- a/src/core/plugins/spec/actions.js
+++ b/src/core/plugins/spec/actions.js
@@ -19,7 +19,7 @@ export const LOG_REQUEST = "spec_log_request"
 export const CLEAR_RESPONSE = "spec_clear_response"
 export const CLEAR_REQUEST = "spec_clear_request"
 export const CLEAR_VALIDATE_PARAMS = "spec_clear_validate_param"
-export const UPDATE_OPERATION_META_VALUE = "spec_UPDATE_OPERATION_META_VALUE"
+export const UPDATE_OPERATION_META_VALUE = "spec_update_operation_meta_value"
 export const UPDATE_RESOLVED = "spec_update_resolved"
 export const SET_SCHEME = "set_scheme"
 

--- a/src/core/plugins/spec/reducers.js
+++ b/src/core/plugins/spec/reducers.js
@@ -108,9 +108,16 @@ export default {
   },
 
   [UPDATE_OPERATION_META_VALUE]: (state, { payload: { path, value, key } }) => {
-    let operationPath = ["meta", "paths", ...path]
+    // path is a pathMethod tuple... can't change the name now.
+    let operationPath = ["resolved", "paths", ...path]
+    let metaPath = ["meta", "paths", ...path]
 
-    return state.setIn([...operationPath, key], fromJS(value))
+    if(!state.getIn(operationPath)) {
+      // do nothing if the operation does not exist
+      return state
+    }
+
+    return state.setIn([...metaPath, key], fromJS(value))
   },
 
   [CLEAR_RESPONSE]: (state, { payload: { path, method } } ) =>{

--- a/src/core/plugins/spec/reducers.js
+++ b/src/core/plugins/spec/reducers.js
@@ -52,8 +52,8 @@ export default {
   },
 
   [VALIDATE_PARAMS]: ( state, { payload: { pathMethod, isOAS3 } } ) => {
-    let operation = state.getIn( [ "resolved", "paths", ...pathMethod ] )
-    let isXml = /xml/i.test(operation.get("consumes_value"))
+    let meta = state.getIn( [ "meta", "paths", ...pathMethod ] )
+    let isXml = /xml/i.test(meta.get("consumes_value"))
 
     return state.updateIn( [ "resolved", "paths", ...pathMethod, "parameters" ], fromJS([]), parameters => {
       return parameters.withMutations( parameters => {

--- a/src/core/plugins/spec/reducers.js
+++ b/src/core/plugins/spec/reducers.js
@@ -12,7 +12,7 @@ import {
   SET_REQUEST,
   SET_MUTATED_REQUEST,
   UPDATE_RESOLVED,
-  UPDATE_OPERATION_VALUE,
+  UPDATE_OPERATION_META_VALUE,
   CLEAR_RESPONSE,
   CLEAR_REQUEST,
   CLEAR_VALIDATE_PARAMS,
@@ -107,11 +107,9 @@ export default {
     return state.setIn( [ "mutatedRequests", path, method ], fromJSOrdered(req))
   },
 
-  [UPDATE_OPERATION_VALUE]: (state, { payload: { path, value, key } }) => {
-    let operationPath = ["resolved", "paths", ...path]
-    if(!state.getIn(operationPath)) {
-      return state
-    }
+  [UPDATE_OPERATION_META_VALUE]: (state, { payload: { path, value, key } }) => {
+    let operationPath = ["meta", "paths", ...path]
+
     return state.setIn([...operationPath, key], fromJS(value))
   },
 

--- a/src/core/plugins/spec/selectors.js
+++ b/src/core/plugins/spec/selectors.js
@@ -306,7 +306,8 @@ export function parametersIncludeType(parameters, typeValue="") {
 export function contentTypeValues(state, pathMethod) {
   pathMethod = pathMethod || []
   let op = spec(state).getIn(["paths", ...pathMethod], fromJS({}))
-  let meta = spec(state).getIn(["paths", ...pathMethod], fromJS({}))
+  let meta = state.getIn(["meta", "paths", ...pathMethod], fromJS({}))
+
   const parameters = op.get("parameters") || new List()
 
   const requestContentType = (
@@ -326,6 +327,12 @@ export function contentTypeValues(state, pathMethod) {
 export function operationConsumes(state, pathMethod) {
   pathMethod = pathMethod || []
   return spec(state).getIn(["paths", ...pathMethod, "consumes"], fromJS({}))
+}
+
+// Get the currently selected produces value for an operation
+export function currentProducesFor(state, pathMethod) {
+  pathMethod = pathMethod || []
+  return state.getIn(["meta", "paths", ...pathMethod, "produces_value"], "")
 }
 
 export const operationScheme = ( state, path, method ) => {

--- a/src/core/plugins/spec/selectors.js
+++ b/src/core/plugins/spec/selectors.js
@@ -306,10 +306,11 @@ export function parametersIncludeType(parameters, typeValue="") {
 export function contentTypeValues(state, pathMethod) {
   pathMethod = pathMethod || []
   let op = spec(state).getIn(["paths", ...pathMethod], fromJS({}))
+  let meta = spec(state).getIn(["paths", ...pathMethod], fromJS({}))
   const parameters = op.get("parameters") || new List()
 
   const requestContentType = (
-    op.get("consumes_value") ? op.get("consumes_value")
+    meta.get("consumes_value") ? meta.get("consumes_value")
       : parametersIncludeType(parameters, "file") ? "multipart/form-data"
       : parametersIncludeType(parameters, "formData") ? "application/x-www-form-urlencoded"
       : undefined
@@ -317,7 +318,7 @@ export function contentTypeValues(state, pathMethod) {
 
   return fromJS({
     requestContentType,
-    responseContentType: op.get("produces_value")
+    responseContentType: meta.get("produces_value")
   })
 }
 

--- a/src/core/plugins/spec/selectors.js
+++ b/src/core/plugins/spec/selectors.js
@@ -307,6 +307,7 @@ export function contentTypeValues(state, pathMethod) {
   pathMethod = pathMethod || []
   let op = spec(state).getIn(["paths", ...pathMethod], fromJS({}))
   let meta = state.getIn(["meta", "paths", ...pathMethod], fromJS({}))
+  let producesValue = currentProducesFor(state, pathMethod)
 
   const parameters = op.get("parameters") || new List()
 
@@ -319,7 +320,7 @@ export function contentTypeValues(state, pathMethod) {
 
   return fromJS({
     requestContentType,
-    responseContentType: meta.get("produces_value")
+    responseContentType: producesValue
   })
 }
 
@@ -332,7 +333,19 @@ export function operationConsumes(state, pathMethod) {
 // Get the currently selected produces value for an operation
 export function currentProducesFor(state, pathMethod) {
   pathMethod = pathMethod || []
-  return state.getIn(["meta", "paths", ...pathMethod, "produces_value"], "")
+
+  const operation = spec(state).getIn(["paths", ...pathMethod], null)
+
+  if(operation === null) {
+    // return nothing if the operation does not exist
+    return
+  }
+
+  const currentProducesValue = state.getIn(["meta", "paths", ...pathMethod, "produces_value"], null)
+  const firstProducesArrayItem = operation.getIn(["produces", 0], null)
+
+  return currentProducesValue || firstProducesArrayItem || "application/json"
+
 }
 
 export const operationScheme = ( state, path, method ) => {

--- a/test/core/plugins/spec-reducer.js
+++ b/test/core/plugins/spec-reducer.js
@@ -7,7 +7,7 @@ describe("spec plugin - reducer", function(){
 
   describe("update operation value", function() {
     it("should update the operation at the specified key", () => {
-      const updateOperationValue = reducer["spec_update_operation_value"]
+      const updateOperationValue = reducer["spec_UPDATE_OPERATION_META_VALUE"]
 
       const state = fromJS({
         resolved: {
@@ -46,7 +46,7 @@ describe("spec plugin - reducer", function(){
     })
 
     it("shouldn't throw an error if we try to update the consumes_value of a null operation", () => {
-      const updateOperationValue = reducer["spec_update_operation_value"]
+      const updateOperationValue = reducer["spec_UPDATE_OPERATION_META_VALUE"]
 
       const state = fromJS({
         resolved: {

--- a/test/core/plugins/spec/reducer.js
+++ b/test/core/plugins/spec/reducer.js
@@ -5,8 +5,8 @@ import reducer from "corePlugins/spec/reducers"
 
 describe("spec plugin - reducer", function(){
 
-  describe("update operation value", function() {
-    it("should update the operation at the specified key", () => {
+  describe("update operation meta value", function() {
+    it("should update the operation metadata at the specified key", () => {
       const updateOperationValue = reducer["spec_UPDATE_OPERATION_META_VALUE"]
 
       const state = fromJS({
@@ -34,7 +34,15 @@ describe("spec plugin - reducer", function(){
           "paths": {
             "/pet": {
               "post": {
-                "description": "my operation",
+                "description": "my operation"
+              }
+            }
+          }
+        },
+        meta: {
+          paths: {
+            "/pet": {
+              post: {
                 "consumes_value": "application/json"
               }
             }

--- a/test/core/plugins/spec/reducer.js
+++ b/test/core/plugins/spec/reducer.js
@@ -7,7 +7,7 @@ describe("spec plugin - reducer", function(){
 
   describe("update operation meta value", function() {
     it("should update the operation metadata at the specified key", () => {
-      const updateOperationValue = reducer["spec_UPDATE_OPERATION_META_VALUE"]
+      const updateOperationValue = reducer["spec_update_operation_meta_value"]
 
       const state = fromJS({
         resolved: {
@@ -54,7 +54,7 @@ describe("spec plugin - reducer", function(){
     })
 
     it("shouldn't throw an error if we try to update the consumes_value of a null operation", () => {
-      const updateOperationValue = reducer["spec_UPDATE_OPERATION_META_VALUE"]
+      const updateOperationValue = reducer["spec_update_operation_meta_value"]
 
       const state = fromJS({
         resolved: {

--- a/test/core/plugins/spec/selectors.js
+++ b/test/core/plugins/spec/selectors.js
@@ -83,6 +83,71 @@ describe("spec plugin - selectors", function(){
       })
     })
 
+    it("should default to the first `produces` array value if current is not set", function(){
+      // Given
+      let state = fromJS({
+        resolved: {
+          paths: {
+            "/one": {
+              get: {
+                produces: [
+                  "application/xml",
+                  "application/whatever"
+                ]
+              }
+            }
+          }
+        },
+        meta: {
+          paths: {
+            "/one": {
+              get: {
+                "consumes_value": "one"
+              }
+            }
+          }
+        }
+      })
+
+      // When
+      let contentTypes = contentTypeValues(state, [ "/one", "get" ])
+      // Then
+      expect(contentTypes.toJS()).toEqual({
+        requestContentType: "one",
+        responseContentType: "application/xml"
+      })
+    })
+
+    it("should default to `application/json` if a default produces value is not available", function(){
+      // Given
+      let state = fromJS({
+        resolved: {
+          paths: {
+            "/one": {
+              get: {}
+            }
+          }
+        },
+        meta: {
+          paths: {
+            "/one": {
+              get: {
+                "consumes_value": "one"
+              }
+            }
+          }
+        }
+      })
+
+      // When
+      let contentTypes = contentTypeValues(state, [ "/one", "get" ])
+      // Then
+      expect(contentTypes.toJS()).toEqual({
+        requestContentType: "one",
+        responseContentType: "application/json"
+      })
+    })
+
     it("should prioritize consumes value first from an operation", function(){
       // Given
       let state = fromJS({
@@ -158,7 +223,7 @@ describe("spec plugin - selectors", function(){
       expect(contentTypes.toJS().requestContentType).toEqual("application/x-www-form-urlencoded")
     })
 
-    it("should be ok, if no operation found", function(){
+    it("should return nothing, if the operation does not exist", function(){
       // Given
       let state = fromJS({ })
 

--- a/test/core/plugins/spec/selectors.js
+++ b/test/core/plugins/spec/selectors.js
@@ -58,6 +58,13 @@ describe("spec plugin - selectors", function(){
         resolved: {
           paths: {
             "/one": {
+              get: {}
+            }
+          }
+        },
+        meta: {
+          paths: {
+            "/one": {
               get: {
                 "consumes_value": "one",
                 "produces_value": "two"
@@ -83,10 +90,18 @@ describe("spec plugin - selectors", function(){
           paths: {
             "/one": {
               get: {
-                "consumes_value": "one",
-                "parameters": [{  
+                "parameters": [{
                   "type": "file"
                 }],
+              }
+            }
+          }
+        },
+        meta: {
+          paths: {
+            "/one": {
+              get: {
+                "consumes_value": "one",
               }
             }
           }
@@ -106,7 +121,7 @@ describe("spec plugin - selectors", function(){
           paths: {
             "/one": {
               get: {
-                "parameters": [{  
+                "parameters": [{
                   "type": "file"
                 }],
               }
@@ -128,7 +143,7 @@ describe("spec plugin - selectors", function(){
           paths: {
             "/one": {
               get: {
-                "parameters": [{  
+                "parameters": [{
                   "type": "formData"
                 }],
               }


### PR DESCRIPTION
Fixes https://github.com/swagger-api/swagger-ui/issues/3998.

This is a 90% solution. The ContentType select components still transmit their default values, but the consumes/produces logic was removed from OperationContainer, so that logic only runs when it has to.