### PR TITLE
Fix(auth): improper resolution of relative token urls

### DIFF
--- a/test/core/plugins/auth/actions.js
+++ b/test/core/plugins/auth/actions.js
@@ -1,0 +1,75 @@
+/* eslint-env mocha */
+import expect, { createSpy } from "expect"
+import { authorizeRequest } from "corePlugins/auth/actions"
+
+describe("auth plugin - actions", () => {
+
+  describe("authorizeRequest", () => {
+
+    [
+      [
+        {
+          oas3: true,
+          server: "https://host/resource",
+          scheme: "http",
+          host: null,
+          url: "http://specs/file",
+        },
+        "https://host/authorize"
+      ],
+      [
+        {
+          oas3: false,
+          server: null,
+          scheme: "https",
+          host: undefined,
+          url: "https://specs/file",
+        },
+        "https://specs/authorize"
+      ],
+      [
+        {
+          oas3: false,
+          server: null,
+          scheme: "https",
+          host: "host",
+          url: "http://specs/file",
+        },
+        "https://host/authorize"
+      ],
+    ].forEach(([{oas3, server, scheme, host, url}, expectedFetchUrl]) => {
+      it("should resolve authorization endpoint against the server URL", () => {
+
+        // Given
+        const data = {
+          url: "/authorize"
+        }
+        const system = {
+          fn: {
+            fetch: createSpy().andReturn(Promise.resolve())
+          },
+          getConfigs: () => ({}),
+          authSelectors: {
+            getConfigs: () => ({})
+          },
+          oas3Selectors: {
+            selectedServer: () => server
+          },
+          specSelectors: {
+            isOAS3: () => oas3,
+            operationScheme: () => scheme,
+            host: () => host,
+            url: () => url
+          }
+        }
+
+        // When
+        authorizeRequest(data)(system)
+
+        // Then
+        expect(system.fn.fetch.calls.length).toEqual(1)
+        expect(system.fn.fetch.calls[0].arguments[0]).toInclude({url: expectedFetchUrl})
+      })
+    })
+  })
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
From the OAS: 

> Moreover, almost all other URLs in an API definition, including OAuth 2 flow endpoints, termsOfService, external documentation URL and others, can be specified relative to the server URL.

This patch should make Swagger-UI apply that statement for token urls. Currently token urls are resolved always against the host that serves Swagger-UI.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->



### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The patch contains relevant additional tests. They cover both v2 and v3 of OAS.
I've been using the provided `test/e2e/specs/petstore.json` and a private `yaml` spec to discover possible input variables to the tested method.

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
