### PR TITLE
url from query parameter

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -74,7 +74,7 @@ window.onload = function() {
   
   // Build a system
   const ui = SwaggerUIBundle({
-    url: "http://petstore.swagger.io/v2/swagger.json",
+    url: (new URL(location)).searchParams.get("url") || "http://petstore.swagger.io/v2/swagger.json",
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [


### PR DESCRIPTION
This allows setting the pre-filled URL to be injected via the page's query parameter.
E.g. http://example.com would provide a link http://example.com/api/v1/doc/?url=./openui.yaml with no need to modify the dist/index.html.
Provided as-is, please review for browser compatibility!

I am just now reading the template and had a quick look to the contributing guidelines and wondered whether I should cancel my contribution. No, I will not install npm. No, I will not try to find out whether dist/index.html is generated from elsewhere in the repo. The patch works in my latest released firefox.

However, I am still sure that providing this as a pr is still better than just as a verbose issue. HTH anyway.