### PR TITLE
Submit boolean parameters as numbers otherwise 'false' is a true stri…

### DIFF
--- a/src/core/components/layout-utils.jsx
+++ b/src/core/components/layout-utils.jsx
@@ -186,7 +186,17 @@ export class Select extends React.Component {
         { allowEmptyValue ? <option value="">--</option> : null }
         {
           allowedValues.map(function (item, key) {
-            return <option key={ key } value={ String(item) }>{ String(item) }</option>
+            switch(item) {
+              case 'true':
+                value = 1;
+                break;
+              case 'false':
+                value = 0;
+                break;
+              default:
+                value = String(item);
+              }
+            return <option key={ key } value={ value }>{ String(item) }</option>
           })
         }
       </select>

--- a/src/core/components/layout-utils.jsx
+++ b/src/core/components/layout-utils.jsx
@@ -187,14 +187,14 @@ export class Select extends React.Component {
         {
           allowedValues.map(function (item, key) {
             switch(item) {
-              case 'true':
-                value = 1;
-                break;
-              case 'false':
-                value = 0;
-                break;
+              case "true":
+                value = 1
+                break
+              case "false":
+                value = 0
+                break
               default:
-                value = String(item);
+                value = String(item)
               }
             return <option key={ key } value={ value }>{ String(item) }</option>
           })


### PR DESCRIPTION
The problem is when having this notation in the Doctrine notation parameters:

```
* type="boolean",
```
Swagger UI renders it as dropdown and i can select true or false. But also "true" or "false" (as string!) is going to be submitted. On the other end after i chose false, i receive a string "false". When i cast this to bool i receive true because "false" is a true string. I expect that when i submit with value false, then at the other end when i receive a string, it has to be "0".

I dont like the solution of this:

```
 * type="array",
 *  @SWG\Items(
 *     type="string",
 *     enum={"1","0"},
 *   ),
```
I want to explicit document a boolean parameter.

In the changes i explicit check for "true" & "false", because these values are hard coded as defaults for the boolean type, when no enum were specified. See `src\core\json-schema-components.js` -> `JsonSchema_boolean`.
The combination of type boolean and enum does not change anything.

Now with these changes i receive this in the UI as expected:

```
<select>
    <option value="1">true</option>
    <option value="0">false</option>
</select>
```
