### PR TITLE
Fix "Download File" link in response-body in Internet Explorer

### DIFF
--- a/src/core/components/response-body.jsx
+++ b/src/core/components/response-body.jsx
@@ -48,9 +48,9 @@ export default class ResponseBody extends React.Component {
         }
 
         if(window.navigator.msSaveOrOpenBlob) {	
-		       bodyEl = <div><a href={ href } onClick={() => window.navigator.msSaveOrOpenBlob(blob, download)}>{ "Download file" }</a></div>			
+            bodyEl = <div><a href={ href } onClick={() => window.navigator.msSaveOrOpenBlob(blob, download)}>{ "Download file" }</a></div>			
         } else {			
-          bodyEl = <div><a href={ href } download={ download }>{ "Download file" }</a></div>
+            bodyEl = <div><a href={ href } download={ download }>{ "Download file" }</a></div>
         }
       } else {
         bodyEl = <pre>Download headers detected but your browser does not support downloading binary via XHR (Blob).</pre>

--- a/src/core/components/response-body.jsx
+++ b/src/core/components/response-body.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types"
 import formatXml from "xml-but-prettier"
 import lowerCase from "lodash/lowerCase"
 import { extractFileNameFromContentDispositionHeader } from "core/utils"
+import win from "core/window"
 
 export default class ResponseBody extends React.Component {
 
@@ -48,7 +49,7 @@ export default class ResponseBody extends React.Component {
         }
 
         if(window.navigator.msSaveOrOpenBlob) {
-            bodyEl = <div><a href={ href } onClick={() => window.navigator.msSaveOrOpenBlob(blob, download)}>{ "Download file" }</a></div>
+            bodyEl = <div><a href={ href } onClick={() => win.navigator.msSaveOrOpenBlob(blob, download)}>{ "Download file" }</a></div>
         } else {
             bodyEl = <div><a href={ href } download={ download }>{ "Download file" }</a></div>
         }

--- a/src/core/components/response-body.jsx
+++ b/src/core/components/response-body.jsx
@@ -48,7 +48,7 @@ export default class ResponseBody extends React.Component {
         }
 
         if(window.navigator.msSaveOrOpenBlob) {	
-		      bodyEl = <div><a href={ href } onClick={() => window.navigator.msSaveOrOpenBlob(blob, download)}>{ "Download file" }</a></div>			
+		       bodyEl = <div><a href={ href } onClick={() => window.navigator.msSaveOrOpenBlob(blob, download)}>{ "Download file" }</a></div>			
         } else {			
           bodyEl = <div><a href={ href } download={ download }>{ "Download file" }</a></div>
         }

--- a/src/core/components/response-body.jsx
+++ b/src/core/components/response-body.jsx
@@ -48,7 +48,7 @@ export default class ResponseBody extends React.Component {
           }
         }
 
-        if(window.navigator.msSaveOrOpenBlob) {
+        if(win.navigator.msSaveOrOpenBlob) {
             bodyEl = <div><a href={ href } onClick={() => win.navigator.msSaveOrOpenBlob(blob, download)}>{ "Download file" }</a></div>
         } else {
             bodyEl = <div><a href={ href } download={ download }>{ "Download file" }</a></div>

--- a/src/core/components/response-body.jsx
+++ b/src/core/components/response-body.jsx
@@ -48,7 +48,7 @@ export default class ResponseBody extends React.Component {
           }
         }
 
-        if(win.navigator.msSaveOrOpenBlob) {
+        if(win.navigator && win.navigator.msSaveOrOpenBlob) {
             bodyEl = <div><a href={ href } onClick={() => win.navigator.msSaveOrOpenBlob(blob, download)}>{ "Download file" }</a></div>
         } else {
             bodyEl = <div><a href={ href } download={ download }>{ "Download file" }</a></div>

--- a/src/core/components/response-body.jsx
+++ b/src/core/components/response-body.jsx
@@ -47,9 +47,9 @@ export default class ResponseBody extends React.Component {
           }
         }
 
-        if(window.navigator.msSaveOrOpenBlob) {	
-            bodyEl = <div><a href={ href } onClick={() => window.navigator.msSaveOrOpenBlob(blob, download)}>{ "Download file" }</a></div>			
-        } else {			
+        if(window.navigator.msSaveOrOpenBlob) {
+            bodyEl = <div><a href={ href } onClick={() => window.navigator.msSaveOrOpenBlob(blob, download)}>{ "Download file" }</a></div>
+        } else {
             bodyEl = <div><a href={ href } download={ download }>{ "Download file" }</a></div>
         }
       } else {

--- a/src/core/components/response-body.jsx
+++ b/src/core/components/response-body.jsx
@@ -47,7 +47,11 @@ export default class ResponseBody extends React.Component {
           }
         }
 
-        bodyEl = <div><a href={ href } download={ download }>{ "Download file" }</a></div>
+        if(window.navigator.msSaveOrOpenBlob) {	
+		      bodyEl = <div><a href={ href } onClick={() => window.navigator.msSaveOrOpenBlob(blob, download)}>{ "Download file" }</a></div>			
+        } else {			
+          bodyEl = <div><a href={ href } download={ download }>{ "Download file" }</a></div>
+        }
       } else {
         bodyEl = <pre>Download headers detected but your browser does not support downloading binary via XHR (Blob).</pre>
       }


### PR DESCRIPTION

The error can be seen on this :
http://swashbuckletest.azurewebsites.net/swagger/ui/index#/Image/Image_Put
When opened with Internet explorer, clicking the link does nothing.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
In internet explorer, the "Download File" button is shown as a link, but when clicked nothing happens.
Right clicking the link and selecting Save as... will ignore file name, and only display the blob name.
The file has the proper content though. 

Internet explorer uses window.navigator.msSaveOrOpenBlob to save files.

Branching in this file, will allow proper functionality to the link, while having no breaking changes.



This way, the internet explorer little window in the middle of the bottom of the screen will pop up, with the proper filename.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The download link is not working in IE
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/swagger-api/swagger-ui/issues/3364
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->



### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Built using NPM, added to WebApi project, built,  opened Swagger, clicked on Download File link, and asserted the Save window appeared.


### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
