### PR TITLE
Try-It-Out `Consumes` value regression

### DIFF
--- a/src/core/plugins/spec/selectors.js
+++ b/src/core/plugins/spec/selectors.js
@@ -46,9 +46,31 @@ export const specResolvedSubtree = (state, path) => {
   return state.getIn(["resolvedSubtrees", ...path], undefined)
 }
 
+const mergerFn = (oldVal, newVal) => {
+  if(newVal.get("$$ref")) {
+    // resolver artifacts indicated that this key was directly resolved
+    // so we should drop the old value entirely
+    return newVal
+  }
+
+  if(Map.isMap(oldVal) && Map.isMap(newVal)) {
+    return Map().mergeWith(
+      mergerFn,
+      oldVal,
+      newVal
+    )
+  }
+
+  return newVal
+}
+
 export const specJsonWithResolvedSubtrees = createSelector(
   state,
-  spec => Map().merge(spec.get("json"), spec.get("resolvedSubtrees"))
+  spec => Map().mergeWith(
+    mergerFn,
+    spec.get("json"),
+    spec.get("resolvedSubtrees")
+  )
 )
 
 // Default Spec ( as an object )

--- a/src/core/plugins/spec/selectors.js
+++ b/src/core/plugins/spec/selectors.js
@@ -47,13 +47,13 @@ export const specResolvedSubtree = (state, path) => {
 }
 
 const mergerFn = (oldVal, newVal) => {
-  if(newVal.get("$$ref")) {
-    // resolver artifacts indicated that this key was directly resolved
-    // so we should drop the old value entirely
-    return newVal
-  }
-
   if(Map.isMap(oldVal) && Map.isMap(newVal)) {
+    if(newVal.get("$$ref")) {
+      // resolver artifacts indicated that this key was directly resolved
+      // so we should drop the old value entirely
+      return newVal
+    }
+
     return Map().mergeWith(
       mergerFn,
       oldVal,

--- a/src/core/plugins/spec/selectors.js
+++ b/src/core/plugins/spec/selectors.js
@@ -369,7 +369,7 @@ export function contentTypeValues(state, pathMethod) {
 // Get the consumes/produces by path
 export function operationConsumes(state, pathMethod) {
   pathMethod = pathMethod || []
-  return state.getIn(["meta", ...pathMethod, "consumes"], fromJS({}))
+  return specJsonWithResolvedSubtrees(state).getIn(["paths", ...pathMethod, "consumes"], fromJS({}))
 }
 
 // Get the currently selected produces value for an operation

--- a/test/core/plugins/spec/selectors.js
+++ b/test/core/plugins/spec/selectors.js
@@ -1,7 +1,13 @@
 /* eslint-env mocha */
 import expect from "expect"
 import { fromJS } from "immutable"
-import { parameterValues, contentTypeValues, operationScheme } from "corePlugins/spec/selectors"
+import {
+  parameterValues,
+  contentTypeValues,
+  operationScheme,
+  specJsonWithResolvedSubtrees,
+  operationConsumes
+} from "corePlugins/spec/selectors"
 
 describe("spec plugin - selectors", function(){
 
@@ -238,6 +244,34 @@ describe("spec plugin - selectors", function(){
 
   })
 
+  describe("operationConsumes", function(){
+    it("should return the operationConsumes for an operation", function(){
+      // Given
+      let state = fromJS({
+        json: {
+          paths: {
+            "/one": {
+              get: {
+                consumes: [
+                  "application/xml",
+                  "application/something-else"
+                ]
+              }
+            }
+          }
+        }
+      })
+
+      // When
+      let contentTypes = operationConsumes(state, [ "/one", "get" ])
+      // Then
+      expect(contentTypes.toJS()).toEqual([
+        "application/xml",
+        "application/something-else"
+      ])
+    })
+  })
+
   describe("operationScheme", function(){
 
     it("should return the correct scheme for a remote spec that doesn't specify a scheme", function(){
@@ -276,5 +310,4 @@ describe("spec plugin - selectors", function(){
     // })
 
   })
-
 })

--- a/test/core/plugins/spec/selectors.js
+++ b/test/core/plugins/spec/selectors.js
@@ -310,4 +310,55 @@ describe("spec plugin - selectors", function(){
     // })
 
   })
+
+
+  describe("specJsonWithResolvedSubtrees", function(){
+
+    it("should return a correctly merged tree", function(){
+      // Given
+      let state = fromJS({
+        json: {
+          definitions: {
+            Asdf: {
+              $ref: "#/some/path",
+              randomKey: "this should be removed b/c siblings of $refs must be removed, per the specification",
+              description: "same for this key"
+            },
+            Fgsfds: {
+              $ref: "#/another/path"
+            },
+            OtherDef: {
+              description: "has no refs"
+            }
+          }
+        },
+        resolvedSubtrees: {
+          definitions: {
+            Asdf: {
+              type: "object",
+              $$ref: "#/some/path"
+            }
+          }
+        }
+      })
+
+      // When
+      let result = specJsonWithResolvedSubtrees(state)
+      // Then
+      expect(result.toJS()).toEqual({
+        definitions: {
+          Asdf: {
+            type: "object",
+            $$ref: "#/some/path"
+          },
+          Fgsfds: {
+            $ref: "#/another/path"
+          },
+          OtherDef: {
+            description: "has no refs"
+          }
+        }
+      })
+    })
+  })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

This PR fixes a selector bug that was causing incorrect defaulting to an `application/json` consumes value, and fixes some precision issues in the new `specJsonWithResolvedSubtrees` selector.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes #4257.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

New unit tests!

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
