### PR TITLE
fix: default to empty ImmutableMap when schema is missing

### DIFF
--- a/src/core/components/models.jsx
+++ b/src/core/components/models.jsx
@@ -63,7 +63,7 @@ export default class Models extends Component {
 
             const content = <ModelWrapper name={ name }
               expandDepth={ defaultModelsExpandDepth }
-              schema={ schema }
+              schema={ schema  || Im.Map() }
               specPath={Im.List([...specPathBase, name])}
               getComponent={ getComponent }
               specSelectors={ specSelectors }


### PR DESCRIPTION
Fixes swagger-api/swagger-ui#4291.