### PR TITLE
MAINTAINER deprecated. Use LABEL.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.5
 
-MAINTAINER fehguy
+LABEL maintainer="fehguy"
 
 ENV VERSION "v2.2.10"
 ENV FOLDER "swagger-ui-2.2.10"


### PR DESCRIPTION
Should use LABEL now instead of MAINTAINER.

See: https://docs.docker.com/engine/reference/builder/#maintainer-deprecated

<!--- Provide a general summary of your changes in the Title above -->

### Description
MAINTAINTER instruction set is deprecated and LABEL maintainer="" should be used now instead.



### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Follows the new standard 
<!--- If it fixes an open issue, please link to the issue here. -->
N/A
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->



### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
Built the docker image locally using these changes.
<!--- Include details of your testing environment, and the tests you ran to -->
Shouldn't cause any problems with the rest of the code base.
<!--- see how your change affects other areas of the code, etc. -->
N/A


### Screenshots (if appropriate):
SEE: https://docs.docker.com/engine/reference/builder/#maintainer-deprecated


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.