### PR TITLE
control Schemes select with state

### DIFF
--- a/src/core/components/schemes.jsx
+++ b/src/core/components/schemes.jsx
@@ -37,12 +37,12 @@ export default class Schemes extends React.Component {
   }
 
   render() {
-    let { schemes } = this.props
+    let { schemes, currentScheme } = this.props
 
     return (
       <label htmlFor="schemes">
         <span className="schemes-title">Schemes</span>
-        <select onChange={ this.onChange }>
+        <select onChange={ this.onChange } value={currentScheme}>
           { schemes.valueSeq().map(
             ( scheme ) => <option value={ scheme } key={ scheme }>{ scheme }</option>
           ).toArray()}


### PR DESCRIPTION
Fixes an issue uncovered in https://github.com/swagger-api/swagger-ui/issues/4435, wherein the application's current scheme state would update but the Schemes component would still display the last scheme selected through user interaction with itself.