### PR TITLE
fix: attempt to display Blob response bodies as text

### DIFF
--- a/src/core/components/response-body.jsx
+++ b/src/core/components/response-body.jsx
@@ -47,7 +47,7 @@ export default class ResponseBody extends React.PureComponent {
   }
 
   componentDidUpdate(prevProps) {
-    this.updateParsedContent(prevProps)
+    this.updateParsedContent(prevProps.content)
   }
 
   render() {

--- a/src/core/components/response-body.jsx
+++ b/src/core/components/response-body.jsx
@@ -26,7 +26,6 @@ export default class ResponseBody extends React.PureComponent {
     }
 
     if(content && content instanceof Blob) {
-      // IE11 safe?
       var reader = new FileReader()
       reader.onload = () => {
         this.setState({

--- a/src/core/components/response-body.jsx
+++ b/src/core/components/response-body.jsx
@@ -20,7 +20,6 @@ export default class ResponseBody extends React.PureComponent {
 
   updateParsedContent = (prevContent) => {
     const { content } = this.props
-    debugger
 
     if(prevContent === content) {
       return

--- a/src/core/components/response-body.jsx
+++ b/src/core/components/response-body.jsx
@@ -5,7 +5,10 @@ import lowerCase from "lodash/lowerCase"
 import { extractFileNameFromContentDispositionHeader } from "core/utils"
 import win from "core/window"
 
-export default class ResponseBody extends React.Component {
+export default class ResponseBody extends React.PureComponent {
+  state = {
+    parsedContent: null
+  }
 
   static propTypes = {
     content: PropTypes.any.isRequired,
@@ -15,8 +18,41 @@ export default class ResponseBody extends React.Component {
     url: PropTypes.string
   }
 
+  updateParsedContent = (prevContent) => {
+    const { content } = this.props
+    debugger
+
+    if(prevContent === content) {
+      return
+    }
+
+    if(content && content instanceof Blob) {
+      // IE11 safe?
+      var reader = new FileReader()
+      reader.onload = () => {
+        this.setState({
+          parsedContent: reader.result
+        })
+      }
+      reader.readAsText(content)
+    } else {
+      this.setState({
+        parsedContent: content.toString()
+      })
+    }
+  }
+
+  componentDidMount() {
+    this.updateParsedContent(null)
+  }
+
+  componentDidUpdate(prevProps) {
+    this.updateParsedContent(prevProps)
+  }
+
   render() {
     let { content, contentType, url, headers={}, getComponent } = this.props
+    const { parsedContent } = this.state
     const HighlightCode = getComponent("highlightCode")
     let body, bodyEl
     url = url || ""
@@ -95,7 +131,22 @@ export default class ResponseBody extends React.Component {
       bodyEl = <HighlightCode downloadable value={ content } />
     } else if ( content.size > 0 ) {
       // We don't know the contentType, but there was some content returned
-      bodyEl = <div>Unknown response type</div>
+      if(parsedContent) {
+        // We were able to squeeze something out of content
+        // in `updateParsedContent`, so let's display it
+        bodyEl = <div>
+          <p className="i">
+            Unrecognized response type; displaying content as text.
+          </p>
+          <HighlightCode downloadable value={ parsedContent } />
+        </div>
+
+      } else {
+        // Give up
+        bodyEl = <p className="i">
+          Unrecognized response type; unable to display.
+        </p>
+      }
     } else {
       // We don't know the contentType and there was no content returned
       bodyEl = null

--- a/src/style/_layout.scss
+++ b/src/style/_layout.scss
@@ -632,6 +632,7 @@
   > .microlight {
     overflow-y: auto;
     max-height: 400px;
+    min-height: 6em;
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Attempt to parse Blob response bodies to text and display the content, if no other content handler can use the data.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes a case in #4406, where incorrect usage of `Content-Type: application/javascript` was precluding the user from viewing the response.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually. 😬 

### Screenshots (if appropriate):

<img width="1792" alt="messages image 1833814538" src="https://user-images.githubusercontent.com/680248/38761127-293412dc-3f35-11e8-970e-1f7f6451ee68.png">

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.