### PR TITLE
markdown components classname isn't required

### DIFF
--- a/src/core/components/providers/markdown.jsx
+++ b/src/core/components/providers/markdown.jsx
@@ -35,7 +35,7 @@ function Markdown({ source, className = "" }) {
 
 Markdown.propTypes = {
     source: PropTypes.string.isRequired,
-    className: PropTypes.string.isRequired
+    className: PropTypes.string
 }
 
 export default Markdown


### PR DESCRIPTION
### Description

markdown components has a default value for classname, so it isn't reuqired

### Motivation and Context

warning message in developer mode, see #4363 

### How Has This Been Tested?

i tested the petstore and it is still working

## Checklist

### My PR contains... 
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
