### PR TITLE
fix(topbar): remove href from Swagger logo

### DIFF
--- a/src/plugins/topbar/topbar.jsx
+++ b/src/plugins/topbar/topbar.jsx
@@ -140,7 +140,7 @@ export default class Topbar extends React.Component {
       <div className="topbar">
         <div className="wrapper">
           <div className="topbar-wrapper">
-            <Link href="#">
+            <Link>
               <img height="30" width="30" src={ Logo } alt="Swagger UI"/>
               <span>swagger</span>
             </Link>


### PR DESCRIPTION
Fixes #4527.

- this `href` didn't serve any visible or known purpose
- it was added before prior to 3.0.0 and has not been modified since
  - see UX 8ab65d3b
- the `Link` was kept, since the anchor was needed to preserve the current layout.