### PR TITLE
[FIX] avoid nested `url` option replacement when $API_URLS contains `url: *,` pattern

### DIFF
--- a/docker-run.sh
+++ b/docker-run.sh
@@ -55,7 +55,7 @@ fi
 
 # replace `url` with `urls` option if API_URLS is set
 if [[ -n "$API_URLS" ]]; then
-    sed -i "s|url: .*,|urls: $API_URLS,|g" $INDEX_FILE
+    sed -i "s|^\(\s*\)url: .*,|\1urls: $API_URLS,|g" $INDEX_FILE
 fi
 
 # replace the PORT that nginx listens on if PORT is supplied


### PR DESCRIPTION
### Description
When executing docker-run.sh with $API_URLS env matching `url: *,` pattern, it will do nested replacement each time the container is restarted. Example with `$API_URLS="[{url: '/swagger.yml', name : 'Test API'}]"` :

In `dist/index.html` :
```
        url: "http://petstore.swagger.io/v2/swagger.json",
```
will become at first start of the container :
```
        urls: [{url: '/swagger.yml', name : 'Test API'}],
```
then at second start :
```
        urls: [{urls: [{url: '/swagger.yml', name : 'Test API'}],
```
then at third start :
```
        urls: [{urls: [{urls: [{url: '/swagger.yml', name : 'Test API'}],
```
etc...

### Motivation and Context

### How Has This Been Tested?
By creating a container from the Dockerfile, starting and restarting it multiple times.

### Screenshots (if appropriate):

## Checklist

### My PR contains... 
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
