### PR TITLE
fix(tio-params): disable empty values for required+enum booleans

### DIFF
--- a/src/core/json-schema-components.js
+++ b/src/core/json-schema-components.js
@@ -201,7 +201,7 @@ export class JsonSchema_boolean extends Component {
 
   onEnumChange = (val) => this.props.onChange(val)
   render() {
-    let { getComponent, value, errors, schema } = this.props
+    let { getComponent, value, errors, schema, required } = this.props
     errors = errors.toJS ? errors.toJS() : []
 
     const Select = getComponent("Select")
@@ -210,7 +210,7 @@ export class JsonSchema_boolean extends Component {
                     title={ errors.length ? errors : ""}
                     value={ String(value) }
                     allowedValues={ fromJS(schema.enum || ["true", "false"]) }
-                    allowEmptyValue={ true }
+                    allowEmptyValue={ !schema.enum || !required }
                     onChange={ this.onEnumChange }/>)
   }
 }

--- a/test/components/json-schema-form.js
+++ b/test/components/json-schema-form.js
@@ -86,6 +86,54 @@ describe("<JsonSchemaForm/>", function(){
       expect(wrapper.find("select option").eq(2).text()).toEqual("false")
     })
 
+
+    it("should render the correct options for an enum boolean parameter", function(){
+
+      let props = {
+        getComponent: getComponentStub,
+        value: "",
+        onChange: () => {},
+        keyName: "",
+        fn: {},
+        schema: {
+          type: "boolean",
+          enum: ["true"]
+        }
+      }
+
+      let wrapper = render(<JsonSchemaForm {...props}/>)
+
+      expect(wrapper.find("select").length).toEqual(1)
+      expect(wrapper.find("select option").length).toEqual(2)
+      expect(wrapper.find("select option").eq(0).text()).toEqual("--")
+      expect(wrapper.find("select option").eq(1).text()).toEqual("true")
+      expect(wrapper.find("select option:checked").first().text()).toEqual("--")
+    })
+
+    it("should render the correct options for a required boolean parameter", function(){
+
+      let props = {
+        getComponent: getComponentStub,
+        value: "",
+        onChange: () => {},
+        keyName: "",
+        fn: {},
+        schema: {
+          type: "boolean",
+          required: true
+        }
+      }
+
+      let wrapper = render(<JsonSchemaForm {...props}/>)
+
+      expect(wrapper.find("select").length).toEqual(1)
+      expect(wrapper.find("select option").length).toEqual(3)
+      expect(wrapper.find("select option").eq(0).text()).toEqual("--")
+      expect(wrapper.find("select option").eq(1).text()).toEqual("true")
+      expect(wrapper.find("select option").eq(2).text()).toEqual("false")
+      expect(wrapper.find("select option:checked").first().text()).toEqual("--")
+    })
+
     it("should render the correct options for a required enum boolean parameter", function(){
 
       let props = {
@@ -105,7 +153,8 @@ describe("<JsonSchemaForm/>", function(){
 
       expect(wrapper.find("select").length).toEqual(1)
       expect(wrapper.find("select option").length).toEqual(1)
-      expect(wrapper.find("select option").first().text()).toEqual("true")
+      expect(wrapper.find("select option").eq(0).text()).toEqual("true")
+      expect(wrapper.find("select option:checked").first().text()).toEqual("true")
     })
   })
   describe("objects", function() {


### PR DESCRIPTION
followup for #4613 

test with this definition:

```yaml
openapi: 3.0.1
info:
  version: 0.0.0
  title: test
paths:
  /ping:
    get:
      parameters:
        - in: query
          name: RequiredEnum
          required: true
          schema:
            type: boolean
            enum:
            - true
        - in: query
          name: RequiredNoEnum
          required: true
          schema:
            type: boolean
        - in: query
          name: OptionalEnum
          schema:
            type: boolean
            enum:
            - true
        - in: query
          name: OptionalNoEnum
          schema:
            type: boolean
      responses:
        "200":
          description: OK
```