### PR TITLE
fix: sample generation for nested object schemas

### DIFF
--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -37,7 +37,7 @@ export function objectify (thing) {
   if(!isObject(thing))
     return {}
   if(isImmutable(thing))
-    return thing.toObject()
+    return thing.toJS()
   return thing
 }
 

--- a/test/core/plugins/samples/fn.js
+++ b/test/core/plugins/samples/fn.js
@@ -1,7 +1,35 @@
+import { fromJS } from "immutable"
 import { createXMLExample, sampleFromSchema } from "corePlugins/samples/fn"
 import expect from "expect"
 
 describe("sampleFromSchema", function() {
+  it("handles Immutable.js objects for nested schemas", function () {
+    var definition = fromJS({
+      "type": "object",
+      "properties": {
+        "json": {
+          "type": "object",
+          "example": {
+            "a": "string"
+          },
+          "properties": {
+            "a": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    })
+
+    var expected = {
+      json: {
+        a: "string"
+      }
+    }
+
+    expect(sampleFromSchema(definition, { includeReadOnly: false })).toEqual(expected)
+  })
+
   it("returns object with no readonly fields for parameter", function () {
     var definition = {
       type: "object",


### PR DESCRIPTION
Fixes #4646.

<img width="885" alt="image" src="https://user-images.githubusercontent.com/680248/41443455-d4c35f62-6ff1-11e8-8e88-3162c3a6ee10.png">
