### PR TITLE
improvement: re-enable and improve Models jump-to-path

### DIFF
--- a/src/core/components/models.jsx
+++ b/src/core/components/models.jsx
@@ -41,6 +41,7 @@ export default class Models extends Component {
     const ModelWrapper = getComponent("ModelWrapper")
     const Collapse = getComponent("Collapse")
     const ModelCollapse = getComponent("ModelCollapse")
+    const JumpToPath = getComponent("JumpToPath")
 
     return <section className={ showModels ? "models is-open" : "models"}>
       <h4 onClick={() => layoutActions.show("models", !showModels)}>
@@ -64,11 +65,13 @@ export default class Models extends Component {
               this.props.specActions.requestResolvedSubtree([...this.getSchemaBasePath(), name])
             }
 
+            const specPath = Im.List([...specPathBase, name])
+
             const content = <ModelWrapper name={ name }
               expandDepth={ defaultModelsExpandDepth }
               schema={ schema || Im.Map() }
               displayName={displayName}
-              specPath={Im.List([...specPathBase, name])}
+              specPath={specPath}
               getComponent={ getComponent }
               specSelectors={ specSelectors }
               getConfigs = {getConfigs}
@@ -82,6 +85,7 @@ export default class Models extends Component {
             </span>
 
             return <div id={ `model-${name}` } className="model-container" key={ `models-section-${name}` }>
+              <span className="models-jump-to-path"><JumpToPath specPath={specPath} /></span>
               <ModelCollapse
                 classes="model-box"
                 collapsedContent={this.getCollapsedContent(name)}

--- a/src/style/_models.scss
+++ b/src/style/_models.scss
@@ -166,6 +166,7 @@ section.models
     .model-container
     {
         margin: 0 20px 15px;
+        position: relative;
 
         transition: all .5s;
 
@@ -185,6 +186,13 @@ section.models
         &:last-of-type
         {
             margin: 0 20px;
+        }
+
+        .models-jump-to-path {
+          position: absolute;
+          top: 8px;
+          right: 5px;
+          opacity: 0.65;
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/swagger-api/swagger-editor/issues/1791.

This one took longer that it should have - I initially explored an implementation that sat between ModelWrapper and Model... it was not nearly as succinct.

The JumpToPath is prettier than before, IMO - it's in the top right corner of the Model container, instead of wedged next to the data itself:

![](http://g.recordit.co/PUdN9jhbJA.gif)

