### PR TITLE
housekeeping: migrate back to reselect@2

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "redux": "^3.x.x",
     "redux-immutable": "3.0.8",
     "remarkable": "^1.7.1",
-    "reselect": "^3.0.1",
+    "reselect": "^2.5.4",
     "serialize-error": "^2.1.0",
     "swagger-client": "^3.8.7",
     "url-parse": "^1.1.8",


### PR DESCRIPTION
for now!

reselect@3 has [a breaking change](https://github.com/reduxjs/reselect/releases/tag/v3.0.0) that impacts some of our use cases.
