### PR TITLE
 improvement: handle more invalid Swagger/OpenAPI version values gracefully

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lint-fix": "eslint --cache --ext '.js,.jsx' src test --fix",
     "test": "run-s just-test-in-node lint-errors",
     "test-in-node": "run-s lint-errors just-test-in-node",
-    "just-test-in-node": "mocha --require test/setup.js --recursive --compilers js:babel-core/register test/core test/components test/bugs test/swagger-ui-dist-package test/xss",
+    "just-test-in-node": "mocha --require test/setup.js --recursive --compilers js:babel-core/register --require source-map-support test/core test/components test/bugs test/swagger-ui-dist-package test/xss",
     "just-check-coverage": "nyc npm run just-test-in-node",
     "test-e2e": "sleep 3 && nightwatch test/e2e/scenarios/ --config test/e2e/nightwatch.json",
     "e2e-initial-render": "nightwatch test/e2e/scenarios/ --config test/e2e/nightwatch.json --group initial-render",

--- a/src/core/plugins/oas3/helpers.js
+++ b/src/core/plugins/oas3/helpers.js
@@ -2,16 +2,20 @@ import React from "react"
 
 export function isOAS3(jsSpec) {
   const oasVersion = jsSpec.get("openapi")
-  if(!oasVersion) {
+  if(typeof oasVersion !== "string") {
     return false
   }
 
-  return oasVersion.startsWith("3.0.")
+  // we gate against `3.1` becasue we want to explicitly opt into supporting it
+  // at some point in the future -- KS, 7/2018
+
+  // starts with, but is not `3.0.` exactly
+  return oasVersion.startsWith("3.0.") && oasVersion.length > 4
 }
 
 export function isSwagger2(jsSpec) {
   const swaggerVersion = jsSpec.get("swagger")
-  if(!swaggerVersion) {
+  if(typeof swaggerVersion !== "string") {
     return false
   }
 

--- a/test/core/plugins/oas3/helpers.js
+++ b/test/core/plugins/oas3/helpers.js
@@ -10,7 +10,7 @@ const isSwagger2Shorthand = (version) => isSwagger2(fromJS({
   swagger: version
 }))
 
-describe.only("isOAS3", function () {
+describe("isOAS3", function () {
   it("should recognize valid OAS3 version values", function () {
     expect(isOAS3Shorthand("3.0.0")).toEqual(true)
     expect(isOAS3Shorthand("3.0.1")).toEqual(true)
@@ -39,7 +39,7 @@ describe.only("isOAS3", function () {
   })
 })
 
-describe.only("isSwagger2", function () {
+describe("isSwagger2", function () {
   it("should recognize valid Swagger 2.0 version values", function () {
     expect(isSwagger2Shorthand("2.0")).toEqual(true)
     expect(isSwagger2Shorthand("2.0-rc0")).toEqual(true)

--- a/test/core/plugins/oas3/helpers.js
+++ b/test/core/plugins/oas3/helpers.js
@@ -1,0 +1,68 @@
+import { fromJS } from "immutable"
+import { isOAS3, isSwagger2 } from "corePlugins/oas3/helpers"
+import expect from "expect"
+
+const isOAS3Shorthand = (version) => isOAS3(fromJS({
+  openapi: version
+}))
+
+const isSwagger2Shorthand = (version) => isSwagger2(fromJS({
+  swagger: version
+}))
+
+describe.only("isOAS3", function () {
+  it("should recognize valid OAS3 version values", function () {
+    expect(isOAS3Shorthand("3.0.0")).toEqual(true)
+    expect(isOAS3Shorthand("3.0.1")).toEqual(true)
+    expect(isOAS3Shorthand("3.0.11111")).toEqual(true)
+    expect(isOAS3Shorthand("3.0.0-rc0")).toEqual(true)
+  })
+
+  it("should fail for invalid OAS3 version values", function () {
+    expect(isOAS3Shorthand("3.0")).toEqual(false)
+    expect(isOAS3Shorthand("3.0.")).toEqual(false)
+    expect(isOAS3Shorthand("2.0")).toEqual(false)
+  })
+
+  it("should gracefully fail for non-string values", function () {
+    expect(isOAS3Shorthand(3.0)).toEqual(false)
+    expect(isOAS3Shorthand(3)).toEqual(false)
+    expect(isOAS3Shorthand({})).toEqual(false)
+    expect(isOAS3Shorthand(null)).toEqual(false)
+  })
+
+  it("should gracefully fail when `openapi` field is missing", function () {
+    expect(isOAS3(fromJS({
+      openApi: "3.0.0"
+    }))).toEqual(false)
+    expect(isOAS3Shorthand(null)).toEqual(false)
+  })
+})
+
+describe.only("isSwagger2", function () {
+  it("should recognize valid Swagger 2.0 version values", function () {
+    expect(isSwagger2Shorthand("2.0")).toEqual(true)
+    expect(isSwagger2Shorthand("2.0-rc0")).toEqual(true)
+  })
+
+  it("should fail for invalid Swagger 2.0 version values", function () {
+    expect(isSwagger2Shorthand("3.0")).toEqual(false)
+    expect(isSwagger2Shorthand("3.0.")).toEqual(false)
+    expect(isSwagger2Shorthand("2.1")).toEqual(false)
+    expect(isSwagger2Shorthand("1.2")).toEqual(false)
+    expect(isSwagger2Shorthand("2")).toEqual(false)
+  })
+
+  it("should gracefully fail for non-string values", function () {
+    expect(isSwagger2Shorthand(2.0)).toEqual(false)
+    expect(isSwagger2Shorthand(2)).toEqual(false)
+    expect(isSwagger2Shorthand({})).toEqual(false)
+    expect(isSwagger2Shorthand(null)).toEqual(false)
+  })
+
+  it("should gracefully fail when `swagger` field is missing", function () {
+    expect(isSwagger2(fromJS({
+      Swagger: "2.0"
+    }))).toEqual(false)
+  })
+})


### PR DESCRIPTION
This PR:
- Tightens our `isSwagger2` and `isOAS3` implementations to handle non-string values
- Fixes an edge case where `openapi: "3.0."` was being marked as valid OAS3
- Enables source maps in Mocha in order to get accurate stack trace line numbers