### PR TITLE
Single quote curl json body

### DIFF
--- a/src/core/curlify.js
+++ b/src/core/curlify.js
@@ -30,7 +30,7 @@ export default function curl( request ){
       }
     } else {
       curlified.push( "-d" )
-      curlified.push( JSON.stringify( request.get("body") ).replace(/\\n/g, "") )
+      curlified.push( `'${JSON.stringify( request.get("body") ).replace(/'/g, "'\\''")}'` )
     }
   }
 

--- a/test/core/curlify.js
+++ b/test/core/curlify.js
@@ -22,7 +22,7 @@ describe("curlify", function() {
 
         let curlified = curl(Im.fromJS(req))
 
-        expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"Accept: application/json\" -H  \"content-type: application/json\" -d {\"id\":0,\"name\":\"doggie\",\"status\":\"available\"}")
+        expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"Accept: application/json\" -H  \"content-type: application/json\" -d '{\"id\":0,\"name\":\"doggie\",\"status\":\"available\"}'")
     })
 
     it("does not change the case of header in curl", function() {
@@ -78,7 +78,7 @@ describe("curlify", function() {
 
         let curlified = curl(Im.fromJS(req))
 
-        expect(curlified).toEqual("curl -X GET \"http://swaggerhub.com/v1/one?name=john|smith\" -H  \"accept: application/json\" -d {\"description\":\"<b>Test</b>\"}")
+        expect(curlified).toEqual("curl -X GET \"http://swaggerhub.com/v1/one?name=john|smith\" -H  \"accept: application/json\" -d '{\"description\":\"<b>Test</b>\"}'")
     })
 
     it("handles post body with html", function() {
@@ -95,7 +95,7 @@ describe("curlify", function() {
 
         let curlified = curl(Im.fromJS(req))
 
-        expect(curlified).toEqual("curl -X POST \"http://swaggerhub.com/v1/one?name=john|smith\" -H  \"accept: application/json\" -d {\"description\":\"<b>Test</b>\"}")
+        expect(curlified).toEqual("curl -X POST \"http://swaggerhub.com/v1/one?name=john|smith\" -H  \"accept: application/json\" -d '{\"description\":\"<b>Test</b>\"}'")
     })
 
     it("handles post body with special chars", function() {
@@ -110,7 +110,7 @@ describe("curlify", function() {
 
         let curlified = curl(Im.fromJS(req))
 
-        expect(curlified).toEqual("curl -X POST \"http://swaggerhub.com/v1/one?name=john|smith\" -d {\"description\":\"@prefix nif:<http://persistence.uni-leipzig.org/nlp2rdf/ontologies/nif-core#> .@prefix itsrdf: <http://www.w3.org/2005/11/its/rdf#> .\"}")
+        expect(curlified).toEqual("curl -X POST \"http://swaggerhub.com/v1/one?name=john|smith\" -d '{\"description\":\"@prefix nif:<http://persistence.uni-leipzig.org/nlp2rdf/ontologies/nif-core#> .\\n@prefix itsrdf: <http://www.w3.org/2005/11/its/rdf#> .\"}'")
     })
 
     it("handles delete form with parameters", function() {
@@ -177,7 +177,7 @@ describe("curlify", function() {
 
         let curlified = curl(Im.fromJS(req))
 
-        expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"accept: application/json\" -d {\"id\":10101}")
+        expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"accept: application/json\" -d '{\"id\":10101}'")
     })
 
     it("prints a curl post statement from a string containing a single quote", function() {
@@ -192,7 +192,7 @@ describe("curlify", function() {
 
         let curlified = curl(Im.fromJS(req))
 
-        expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"accept: application/json\" -d \"{\\\"id\\\":\\\"foo'bar\\\"}\"")
+        expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"accept: application/json\" -d '\"{\\\"id\\\":\\\"foo'\\''bar\\\"}\"'")
     })
 
 })


### PR DESCRIPTION
### Description
Use [strong quote](http://wiki.bash-hackers.org/syntax/quoting#strong_quoting) to allow special characters in JSON request body, e.g.

```json
{
  "field": "([#!'\"$&()*,:;<=>?@^`{|}\\])"
}
```

But I have doubts: why `\n` is removed from request body (https://github.com/swagger-api/swagger-ui/blob/master/src/core/curlify.js#L33) while in some cases when a field is a multi-line text? I've removed this logic from the code and I'm NOT SURE it's right.

``` javascript
// description is a multi-line text in this case:
let body = {
  "description": "LINE 1\nLINE 2\nLINE 3"
}
console.log(JSON.stringify(body))
// {"description":"LINE 1\nLINE 2\nLINE 3"}
console.log(JSON.stringify(body){"description":"LINE 1LINE 2LINE 3"})
// {"description":"LINE 1LINE 2LINE 3"}
```


### Motivation and Context
Generated curl shell script won't work if request body includes special characters.
Fixes #4651



### How Has This Been Tested?
Test scripts are changed accordingly. All tests are passing. This will change the output of the curl component. And there is no other dependents.


## Checklist

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
