### PR TITLE
Encode query string value for validator badge url

### DIFF
--- a/src/core/components/online-validator-badge.jsx
+++ b/src/core/components/online-validator-badge.jsx
@@ -54,8 +54,8 @@ export default class OnlineValidatorBadge extends React.Component {
         }
 
         return (<span style={{ float: "right"}}>
-                <a target="_blank" href={`${ sanitizedValidatorUrl }/debug?url=${ this.state.url }`}>
-                    <ValidatorImage src={`${ sanitizedValidatorUrl }?url=${ this.state.url }`} alt="Online validator badge"/>
+                <a target="_blank" href={`${ sanitizedValidatorUrl }/debug?url=${ encodeURIComponent(this.state.url) }`}>
+                    <ValidatorImage src={`${ sanitizedValidatorUrl }?url=${ encodeURIComponent(this.state.url) }`} alt="Online validator badge"/>
                 </a>
             </span>)
     }

--- a/test/components/online-validator-badge.js
+++ b/test/components/online-validator-badge.js
@@ -1,0 +1,79 @@
+/* eslint-env mocha */
+import React from "react"
+import expect, { createSpy } from "expect"
+import { mount } from "enzyme"
+import { fromJS, Map } from "immutable"
+import OnlineValidatorBadge from "components/online-validator-badge"
+
+describe("<OnlineValidatorBadge/>", function () {
+  it("should render a validator link and image correctly for the default validator", function () {
+    // When
+    const props = {
+      getConfigs: () => ({}),
+      getComponent: () => null,
+      specSelectors: {
+        url: () => "swagger.json"
+      }
+    }
+    const wrapper = mount(
+     <OnlineValidatorBadge {...props} />
+    )
+
+    // Then
+    expect(wrapper.find("a").props().href).toEqual(
+      "https://online.swagger.io/validator/debug?url=swagger.json"
+    )
+    expect(wrapper.find("ValidatorImage").length).toEqual(1)
+    expect(wrapper.find("ValidatorImage").props().src).toEqual(
+      "https://online.swagger.io/validator?url=swagger.json"
+    )
+  })
+  it("should encode a definition URL correctly", function () {
+    // When
+    const props = {
+      getConfigs: () => ({}),
+      getComponent: () => null,
+      specSelectors: {
+        url: () => "http://google.com/swagger.json"
+      }
+    }
+    const wrapper = mount(
+      <OnlineValidatorBadge {...props} />
+    )
+
+    // Then
+    expect(wrapper.find("a").props().href).toEqual(
+      "https://online.swagger.io/validator/debug?url=http%3A%2F%2Fgoogle.com%2Fswagger.json"
+    )
+    expect(wrapper.find("ValidatorImage").length).toEqual(1)
+    expect(wrapper.find("ValidatorImage").props().src).toEqual(
+      "https://online.swagger.io/validator?url=http%3A%2F%2Fgoogle.com%2Fswagger.json"
+    )
+  })
+  it.skip("should resolve a definition URL against the browser's location", function () {
+    // TODO: mock `window`
+    // When
+
+    const props = {
+      getConfigs: () => ({}),
+      getComponent: () => null,
+      specSelectors: {
+        url: () => "http://google.com/swagger.json"
+      }
+    }
+    const wrapper = mount(
+      <OnlineValidatorBadge {...props} />
+    )
+
+    // Then
+    expect(wrapper.find("a").props().href).toEqual(
+      "https://online.swagger.io/validator/debug?url=http%3A%2F%2Fgoogle.com%2Fswagger.json"
+    )
+    expect(wrapper.find("ValidatorImage").length).toEqual(1)
+    expect(wrapper.find("ValidatorImage").props().src).toEqual(
+      "https://online.swagger.io/validator?url=http%3A%2F%2Fgoogle.com%2Fswagger.json"
+    )
+  })
+  // should resolve a definition URL against the browser's location
+
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Encode query string value for validator badge url; both link url and badge image url.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->
Fixes #4658 


### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All tests are passing.


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
