### PR TITLE
hide deprecated properties in examples

### DIFF
--- a/src/core/plugins/samples/fn.js
+++ b/src/core/plugins/samples/fn.js
@@ -52,6 +52,9 @@ export const sampleFromSchema = (schema, config={}) => {
     let props = objectify(properties)
     let obj = {}
     for (var name in props) {
+      if ( props[name] && props[name].deprecated ) {
+        continue
+      }
       if ( props[name] && props[name].readOnly && !includeReadOnly ) {
         continue
       }

--- a/test/core/plugins/samples/fn.js
+++ b/test/core/plugins/samples/fn.js
@@ -79,6 +79,30 @@ describe("sampleFromSchema", function() {
     expect(sampleFromSchema(definition, { includeReadOnly: true })).toEqual(expected)
   })
 
+  it("returns object without deprecated fields for parameter", function () {
+    var definition = {
+      type: "object",
+      properties: {
+        id: {
+          type: "integer"
+        },
+        deprecatedProperty: {
+          deprecated: true,
+          type: "string"
+        }
+      },
+      xml: {
+        name: "animals"
+      }
+    }
+
+    var expected = {
+      id: 0
+    }
+
+    expect(sampleFromSchema(definition)).toEqual(expected)
+  })
+
   it("returns object without writeonly fields for parameter", function () {
     var definition = {
       type: "object",


### PR DESCRIPTION
Hide deprecated properties in schema examples

### Motivation and Context

Showing deprecated properties in examples gives false impression that they are still current and should be used. This PR hides deprecated properties from examples shown in the UI, so new users are less likely to use deprecated properties by copy/pasting examples, or by using the examples as a form of ad-hoc documentation.

### How Has This Been Tested?

Deprecated a property, verified that it does not appear in the example section of a POST request body.

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [x] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [ ] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
