### PR TITLE
fix(try-it-out): stringify numerical initial values in ParameterRow

### DIFF
--- a/src/core/components/parameter-row.jsx
+++ b/src/core/components/parameter-row.jsx
@@ -2,9 +2,8 @@ import React, { Component } from "react"
 import { Map } from "immutable"
 import PropTypes from "prop-types"
 import ImPropTypes from "react-immutable-proptypes"
-import toString from "lodash/toString"
 import win from "core/window"
-import { getExtensions, getCommonExtensions } from "core/utils"
+import { getExtensions, getCommonExtensions, numberToString } from "core/utils"
 
 export default class ParameterRow extends Component {
   static propTypes = {
@@ -54,7 +53,7 @@ export default class ParameterRow extends Component {
     }
 
     if ( value !== undefined && value !== paramValue ) {
-      this.onChangeWrapper(toString(value))
+      this.onChangeWrapper(numberToString(value))
     }
 
     this.setDefaultValue()
@@ -89,7 +88,7 @@ export default class ParameterRow extends Component {
           || paramWithMeta.getIn(["schema", "default"])
       }
       if(newValue !== undefined) {
-        this.onChangeWrapper(toString(newValue))
+        this.onChangeWrapper(numberToString(newValue))
       }
     }
   }

--- a/src/core/components/parameter-row.jsx
+++ b/src/core/components/parameter-row.jsx
@@ -2,6 +2,7 @@ import React, { Component } from "react"
 import { Map } from "immutable"
 import PropTypes from "prop-types"
 import ImPropTypes from "react-immutable-proptypes"
+import toString from "lodash/toString"
 import win from "core/window"
 import { getExtensions, getCommonExtensions } from "core/utils"
 
@@ -53,7 +54,7 @@ export default class ParameterRow extends Component {
     }
 
     if ( value !== undefined && value !== paramValue ) {
-      this.onChangeWrapper(value)
+      this.onChangeWrapper(toString(value))
     }
 
     this.setDefaultValue()
@@ -88,7 +89,7 @@ export default class ParameterRow extends Component {
           || paramWithMeta.getIn(["schema", "default"])
       }
       if(newValue !== undefined) {
-        this.onChangeWrapper(newValue)
+        this.onChangeWrapper(toString(newValue))
       }
     }
   }

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -781,3 +781,11 @@ export function stringify(thing) {
 
   return thing.toString()
 }
+
+export function numberToString(thing) {
+  if(typeof thing === "number") {
+    return thing.toString()
+  }
+
+  return thing
+}

--- a/test/e2e/scenarios/bugs/4756.js
+++ b/test/e2e/scenarios/bugs/4756.js
@@ -1,0 +1,43 @@
+describe("bug #4756: enum initial values", function () {
+  let mainPage
+  beforeEach(function (client, done) {
+    mainPage = client
+      .url("localhost:3230")
+      .page.main()
+
+    client.waitForElementVisible(".download-url-input:not([disabled])", 5000)
+      .pause(2000)
+      .clearValue(".download-url-input")
+      .setValue(".download-url-input", "http://localhost:3230/test-specs/bugs/4756.yaml")
+      .click("button.download-url-button")
+      .pause(1000)
+
+    done()
+  })
+
+  afterEach(function (client, done) {
+    done()
+  })
+
+  it("sets a required initial value based the first enum value", function (client) {
+    client.waitForElementVisible(".opblock-tag-section", 10000)
+      .click("#operations-default-post_zero")
+      .waitForElementVisible(".opblock.is-open", 5000)
+      .click("button.btn.try-out__btn")
+      .click("button.btn.execute")
+      .waitForElementVisible(".request-url", 2000)
+      .assert.containsText(".request-url > pre", "http://www.example.com/test/API/zero?one=0")
+    client.end()
+  })
+
+  it("sets a required initial value based on a default value", function (client) {
+    client.waitForElementVisible(".opblock-tag-section", 10000)
+      .click("#operations-default-post_one")
+      .waitForElementVisible(".opblock.is-open", 5000)
+      .click("button.btn.try-out__btn")
+      .click("button.btn.execute")
+      .waitForElementVisible(".request-url", 2000)
+      .assert.containsText(".request-url > pre", "http://www.example.com/test/API/one?one=1")
+    client.end()
+  })
+})

--- a/test/e2e/specs/bugs/4756.yaml
+++ b/test/e2e/specs/bugs/4756.yaml
@@ -1,0 +1,51 @@
+swagger: '2.0'
+info:
+  title: test doc
+  description: 'test doc '
+  license:
+    name: Copyright @2018
+  version: 1.0.0
+host: www.example.com
+basePath: /test/API
+tags:
+  - name: devices
+    description: devices
+schemes:
+  - http
+  - https
+consumes:
+  - application/x-www-form-urlencoded
+produces:
+  - application/json
+paths:
+  /zero:
+    post:
+      parameters:
+        - in: query
+          name: one
+          type: string
+          required: true
+          enum: 
+            - 0
+            - 1
+      responses:
+        200:
+          description: 'response'
+          examples: 
+            application/json: {"error":0}
+  /one:
+    post:
+      parameters:
+        - in: query
+          name: one
+          type: string
+          required: true
+          default: 1
+          enum: 
+            - 0
+            - 1
+      responses:
+        200:
+          description: 'response'
+          examples: 
+            application/json: {"error":0}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

This PR ensures that numerical initial values are always converted to strings, which brings the initial values that make it into state into line with the values resulting from user input.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes #4756.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I added two new e2e tests.


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.