### PR TITLE
fix: default to empty object for pathItems in `updateJsonSpec` wrap-action

### DIFF
--- a/src/core/plugins/spec/wrap-actions.js
+++ b/src/core/plugins/spec/wrap-actions.js
@@ -12,7 +12,7 @@ export const updateJsonSpec = (ori, {specActions}) => (...args) => {
 
   // Trigger resolution of any path-level $refs.
   const [json] = args
-  const pathItems = get(json, ["paths"])
+  const pathItems = get(json, ["paths"]) || {}
   const pathItemKeys = Object.keys(pathItems)
 
   pathItemKeys.forEach(k => {


### PR DESCRIPTION
Fixes #4784.