### PR TITLE
Additional fix of #4048, more error messages from authorization call

### DIFF
--- a/src/core/plugins/auth/actions.js
+++ b/src/core/plugins/auth/actions.js
@@ -202,11 +202,28 @@ export const authorizeRequest = ( data ) => ( { fn, getConfigs, authActions, err
   })
   .catch(e => {
     let err = new Error(e)
+    let message = err.message;
+    // swagger-js wraps the response (if available) into the e.response property;
+    // investigate to check whether there are more details on why the authorization
+    // request failed (according to RFC 6479).
+    // See also https://github.com/swagger-api/swagger-ui/issues/4048
+    if (e.response && e.response.data) {
+      const errData = e.response.data
+      try {
+        const jsonResponse = typeof errData === 'string' ? JSON.parse(errData) : errData
+        if (jsonResponse.error)
+          message += `, error: ${jsonResponse.error}`;
+        if (jsonResponse.error_description)
+          message += `, description: ${jsonResponse.error_description}`
+      } catch (jsonError) {
+        // Ignore
+      }
+    }
     errActions.newAuthErr( {
       authId: name,
       level: "error",
       source: "auth",
-      message: err.message
+      message: message
     } )
   })
 }

--- a/src/core/plugins/auth/actions.js
+++ b/src/core/plugins/auth/actions.js
@@ -202,7 +202,7 @@ export const authorizeRequest = ( data ) => ( { fn, getConfigs, authActions, err
   })
   .catch(e => {
     let err = new Error(e)
-    let message = err.message;
+    let message = err.message
     // swagger-js wraps the response (if available) into the e.response property;
     // investigate to check whether there are more details on why the authorization
     // request failed (according to RFC 6479).
@@ -210,9 +210,9 @@ export const authorizeRequest = ( data ) => ( { fn, getConfigs, authActions, err
     if (e.response && e.response.data) {
       const errData = e.response.data
       try {
-        const jsonResponse = typeof errData === 'string' ? JSON.parse(errData) : errData
+        const jsonResponse = typeof errData === "string" ? JSON.parse(errData) : errData
         if (jsonResponse.error)
-          message += `, error: ${jsonResponse.error}`;
+          message += `, error: ${jsonResponse.error}`
         if (jsonResponse.error_description)
           message += `, description: ${jsonResponse.error_description}`
       } catch (jsonError) {


### PR DESCRIPTION
- Inspect the error and error_description properties of the response, if available

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

In case an authorization request fails, the response code usually is (by RFC6479) a 400 or 401, and thus fn.fetch (from swagger-js) throws an error instead of returning the response body.

Swagger-js also returns the actual response in the error which is thrown, and by parsing that response and checking whether "error" and "error_description" are available, it's possible to help the user see why the Authorization Server rejected the authorization request (also by RFC).

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

This is an additional fix of #4048, in the Resource Owner Password Grant and Client Credentials flows, where the error message is returned as a JSON payload from the token POST request. See RFC 6479 for the spec: The return body is specified to look like this:

```
{
  "error": "<oauth2 error code string>",
  "error_description": "<authorization server specific error messages>"
}
```

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This was manually tested using https://wicked.haufe.io in a developer setup, so that I could switch out the `dist` folder we are using from `swagger-ui-dist`.

### Screenshots (if appropriate):

Before change:

![image](https://user-images.githubusercontent.com/7326883/43829991-95bcf0fa-9b00-11e8-9d5e-3fbb2e411d7a.png)

After change:

![image](https://user-images.githubusercontent.com/7326883/43830042-b72dcc6e-9b00-11e8-9483-187ff542b692.png)

The error message is what the Authorization Server issues as `error` and `error_description` in the response to the token request.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
