### PR TITLE
improvement: urlencoded Request Body rendering

### DIFF
--- a/src/core/plugins/oas3/components/request-body.jsx
+++ b/src/core/plugins/oas3/components/request-body.jsx
@@ -70,6 +70,8 @@ const RequestBody = ({
               const required = schemaForContentType.get("required", List()).includes(key)
               const type = prop.get("type")
               const format = prop.get("format")
+              const currentValue = requestBodyValue.get(key)
+              const initialValue = prop.get("default") || prop.get("example") || ""
 
               const isFile = type === "string" && (format === "binary" || format === "base64")
 
@@ -95,7 +97,7 @@ const RequestBody = ({
                           schema={prop}
                           description={key + " - " + prop.get("description")}
                           getComponent={getComponent}
-                          value={requestBodyValue.get(key)}
+                          value={currentValue === undefined ? initialValue : currentValue}
                           onChange={(value) => {
                             onChange(value, [key])
                           }}

--- a/src/core/plugins/oas3/components/request-body.jsx
+++ b/src/core/plugins/oas3/components/request-body.jsx
@@ -2,7 +2,7 @@ import React from "react"
 import PropTypes from "prop-types"
 import ImPropTypes from "react-immutable-proptypes"
 import { getSampleSchema } from "core/utils"
-import { Map, OrderedMap } from "immutable"
+import { Map, OrderedMap, List } from "immutable"
 
 const RequestBody = ({
   requestBody,
@@ -59,6 +59,7 @@ const RequestBody = ({
     || contentType.indexOf("multipart/") === 0))
   {
     const JsonSchemaForm = getComponent("JsonSchemaForm")
+    const HighlightCode = getComponent("highlightCode")
     const schemaForContentType = requestBody.getIn(["content", contentType, "schema"], OrderedMap())
     const bodyProperties = schemaForContentType.getIn([ "properties"], OrderedMap())
     requestBodyValue = Map.isMap(requestBodyValue) ? requestBodyValue : OrderedMap()
@@ -68,6 +69,7 @@ const RequestBody = ({
         <tbody>
           {
             bodyProperties.map((prop, key) => {
+              debugger
               const required = schemaForContentType.get("required", List()).includes(key)
               const type = prop.get("type")
               const format = prop.get("format")
@@ -89,18 +91,18 @@ const RequestBody = ({
                         </div>
                       </td>
                       <td className="col parameters-col_description">
-                        {isExecute ?
-                        <JsonSchemaForm
+                        { prop.get("description") }
+                        {isExecute ? <div><JsonSchemaForm
                           fn={fn}
                           dispatchInitialValue={!isFile}
                           schema={prop}
+                          description={key + " - " + prop.get("description")}
                           getComponent={getComponent}
                           value={requestBodyValue.get(key)}
                           onChange={(value) => {
                             onChange(value, [key])
                           }}
-                          />
-                        : <HighlightCode className="example" value={ getSampleSchema(prop) } />}
+                        /></div> : null }
                       </td>
                       </tr>
             })

--- a/src/core/plugins/oas3/components/request-body.jsx
+++ b/src/core/plugins/oas3/components/request-body.jsx
@@ -1,7 +1,6 @@
 import React from "react"
 import PropTypes from "prop-types"
 import ImPropTypes from "react-immutable-proptypes"
-import { getSampleSchema } from "core/utils"
 import { Map, OrderedMap, List } from "immutable"
 
 const RequestBody = ({
@@ -59,7 +58,6 @@ const RequestBody = ({
     || contentType.indexOf("multipart/") === 0))
   {
     const JsonSchemaForm = getComponent("JsonSchemaForm")
-    const HighlightCode = getComponent("highlightCode")
     const schemaForContentType = requestBody.getIn(["content", contentType, "schema"], OrderedMap())
     const bodyProperties = schemaForContentType.getIn([ "properties"], OrderedMap())
     requestBodyValue = Map.isMap(requestBodyValue) ? requestBodyValue : OrderedMap()
@@ -69,7 +67,6 @@ const RequestBody = ({
         <tbody>
           {
             bodyProperties.map((prop, key) => {
-              debugger
               const required = schemaForContentType.get("required", List()).includes(key)
               const type = prop.get("type")
               const format = prop.get("format")

--- a/src/core/plugins/oas3/components/request-body.jsx
+++ b/src/core/plugins/oas3/components/request-body.jsx
@@ -95,7 +95,7 @@ const RequestBody = ({
                           dispatchInitialValue={!isFile}
                           schema={prop}
                           getComponent={getComponent}
-                          value={requestBodyValue.get(key) || getSampleSchema(prop)}
+                          value={requestBodyValue.get(key)}
                           onChange={(value) => {
                             onChange(value, [key])
                           }}

--- a/src/core/plugins/oas3/components/request-body.jsx
+++ b/src/core/plugins/oas3/components/request-body.jsx
@@ -59,8 +59,8 @@ const RequestBody = ({
     || contentType.indexOf("multipart/") === 0))
   {
     const JsonSchemaForm = getComponent("JsonSchemaForm")
-    const HighlightCode = getComponent("highlightCode")
-    const bodyProperties = requestBody.getIn(["content", contentType, "schema", "properties"], OrderedMap())
+    const schemaForContentType = requestBody.getIn(["content", contentType, "schema"], OrderedMap())
+    const bodyProperties = schemaForContentType.getIn([ "properties"], OrderedMap())
     requestBodyValue = Map.isMap(requestBodyValue) ? requestBodyValue : OrderedMap()
 
     return <div className="table-container">
@@ -68,7 +68,7 @@ const RequestBody = ({
         <tbody>
           {
             bodyProperties.map((prop, key) => {
-              const required = prop.get("required")
+              const required = schemaForContentType.get("required", List()).includes(key)
               const type = prop.get("type")
               const format = prop.get("format")
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

This PR improves the rendering and Try-It-Out UI for `application/x-www-form-urlencoded` and `multipart/*` object-schema Request Bodies.

Specifically:
- use a Media Type schema's `required` array for marking required properties
- don't use a generated schema value as a default
- improve the static/Try-It-Out layout to more closely mimic vanilla parameters
- use `property.default` and `property.example` as _initial_ values

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes #4643, and private issue ID `SWOS-39`.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually.


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.