### PR TITLE
fix(deeplinking): expand containing tag when expanding an operation

### DIFF
--- a/src/core/plugins/deep-linking/layout.js
+++ b/src/core/plugins/deep-linking/layout.js
@@ -77,6 +77,13 @@ export const parseDeepLinkHash = (rawHash) => ({ layoutActions, layoutSelectors,
 
     const isShownKey = layoutSelectors.isShownKeyFromUrlHashArray(hashArray)
 
+    const [type, tagId, operationId] = isShownKey
+
+    if(isShownKey[0] === "operations") {
+      // we're going to show an operation, so we need to expand the tag as well
+      layoutActions.show(layoutSelectors.isShownKeyFromUrlHashArray([tagId]))
+    }
+
     layoutActions.show(isShownKey, true) // TODO: 'show' operation tag
     layoutActions.scrollTo(isShownKey)
   }

--- a/src/core/plugins/deep-linking/layout.js
+++ b/src/core/plugins/deep-linking/layout.js
@@ -77,9 +77,9 @@ export const parseDeepLinkHash = (rawHash) => ({ layoutActions, layoutSelectors,
 
     const isShownKey = layoutSelectors.isShownKeyFromUrlHashArray(hashArray)
 
-    const [type, tagId, operationId] = isShownKey
+    const [type, tagId] = isShownKey
 
-    if(isShownKey[0] === "operations") {
+    if(type === "operations") {
       // we're going to show an operation, so we need to expand the tag as well
       layoutActions.show(layoutSelectors.isShownKeyFromUrlHashArray([tagId]))
     }

--- a/test/e2e-cypress/tests/deep-linking.js
+++ b/test/e2e-cypress/tests/deep-linking.js
@@ -76,12 +76,12 @@ describe("Deep linking feature", () => {
       it("should expand a tag", () => {
         cy.visit(`${baseUrl}&docExpansion=none#/myTag`)
           .get(`.opblock-tag-section.is-open`)
-          .should("exist")
+          .should("have.length", 1)
       })
       it("should expand an operation", () => {
         cy.visit(`${baseUrl}&docExpansion=none#/myTag/myOperation`)
-          .get(`.opblock-tag-section.is-open`)
-          .should("exist")
+          .get(`.opblock.is-open`)
+          .should("have.length", 1)
       })
     })
   })
@@ -162,12 +162,12 @@ describe("Deep linking feature", () => {
       it("should expand a tag", () => {
         cy.visit(`${baseUrl}&docExpansion=none#/myTag`)
           .get(`.opblock-tag-section.is-open`)
-          .should("exist")
+          .should("have.length", 1)
       })
       it("should expand an operation", () => {
         cy.visit(`${baseUrl}&docExpansion=none#/myTag/myOperation`)
-          .get(`.opblock-tag-section.is-open`)
-          .should("exist")
+          .get(`.opblock.is-open`)
+          .should("have.length", 1)
       })
     })
   })

--- a/test/e2e-cypress/tests/deep-linking.js
+++ b/test/e2e-cypress/tests/deep-linking.js
@@ -71,6 +71,19 @@ describe("Deep linking feature", () => {
           .should("exist")
       })
     })
+
+    describe("regular Operation with `docExpansion: none` enabled", function() {
+      it("should expand a tag", () => {
+        cy.visit(`${baseUrl}&docExpansion=none#/myTag`)
+          .get(`.opblock-tag-section.is-open`)
+          .should("exist")
+      })
+      it("should expand an operation", () => {
+        cy.visit(`${baseUrl}&docExpansion=none#/myTag/myOperation`)
+          .get(`.opblock-tag-section.is-open`)
+          .should("exist")
+      })
+    })
   })
   describe("in OpenAPI 3", () => {
     const baseUrl = "/?deepLinking=true&url=/documents/features/deep-linking.swagger.yaml"
@@ -141,6 +154,19 @@ describe("Deep linking feature", () => {
         cy.visit(`${baseUrl}${correctFragment}`)
           .reload()
           .get(`${elementToGet}.is-open`)
+          .should("exist")
+      })
+    })
+
+    describe("regular Operation with `docExpansion: none` enabled", function () {
+      it("should expand a tag", () => {
+        cy.visit(`${baseUrl}&docExpansion=none#/myTag`)
+          .get(`.opblock-tag-section.is-open`)
+          .should("exist")
+      })
+      it("should expand an operation", () => {
+        cy.visit(`${baseUrl}&docExpansion=none#/myTag/myOperation`)
+          .get(`.opblock-tag-section.is-open`)
           .should("exist")
       })
     })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

This PR adds logic to expand an Operation's containing tag when expanding the operation itself as a result of parsing a deep link fragment.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes #4817.

This is a regression, if I had to guess, #4349 broke the functionality.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I added e2e tests!

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.