### PR TITLE
Remove one remaining reference to Titillium (Google Web Fonts)

### DIFF
--- a/src/style/_layout.scss
+++ b/src/style/_layout.scss
@@ -648,7 +648,7 @@
   text-align: center;
   padding: 5px;
   border-radius: 4px;
-  font-family: 'Titillium Web', sans-serif;
+  font-family: sans-serif;
   font-weight: 600;
   color: white;
   font-size: 14px;


### PR DESCRIPTION
Follow up to #4598

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

#4598 missed a reference to the `Titillium Web` font, which was previously provided by Google Web Fonts.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Clean up. We shouldn't reference this font anymore. It's not really urgent, as the font will only if there is a `@font-face` declaration for it somewhere. The `swagger-ui-express` project still does that in their template, which was how I noticed this: https://github.com/scottie1984/swagger-ui-express/blob/bef977310e04ea415d2510ce52ca2a923a038752/indexTemplate.html#L7

(~~~I'll make~~~ I have made a separate PR to that project to get that line removed: https://github.com/scottie1984/swagger-ui-express/pull/88)

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Didn't test it to be honest.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
