### PR TITLE
fix: resolved model data invalidation detection

### DIFF
--- a/src/core/components/models.jsx
+++ b/src/core/components/models.jsx
@@ -59,7 +59,7 @@ export default class Models extends Component {
             const rawSchema = specSelectors.specJson().getIn(fullPath, Im.Map())
             const displayName = schema.get("title") || rawSchema.get("title") || name
 
-            if(layoutSelectors.isShown(["models", name], false) && schema === undefined) {
+            if(layoutSelectors.isShown(["models", name], false) && (schema.size === 0 && rawSchema.size > 0)) {
               // Firing an action in a container render is not great,
               // but it works for now.
               this.props.specActions.requestResolvedSubtree([...this.getSchemaBasePath(), name])

--- a/test/e2e-cypress/static/documents/bugs/editor-1868.yaml
+++ b/test/e2e-cypress/static/documents/bugs/editor-1868.yaml
@@ -1,0 +1,13 @@
+swagger: "2.0"
+
+paths:
+  /:
+    get:
+      description: wow
+
+definitions:
+  MyModel:
+    type: object
+    properties:
+      a: 
+        type: string

--- a/test/e2e-cypress/tests/bugs/editor-1868.js
+++ b/test/e2e-cypress/tests/bugs/editor-1868.js
@@ -1,0 +1,26 @@
+import repeat from "lodash/repeat"
+
+describe("Editor #1868: model changes break rendering", () => {
+  it("should render model content changes correctly", () => {
+    cy
+      .visit("/?url=/documents/bugs/editor-1868.yaml")
+
+      .get(".model-toggle.collapsed")
+      .click()
+
+      .get("#model-MyModel")
+      .contains("a")
+
+      .window()
+      .then(win => {
+        // Simulate Swagger Editor updating a model
+        const content = win.ui.specSelectors.specStr()
+        win.ui.specActions.updateSpec(content + `\n      b:\n        type: string`)
+      })
+
+      .get("#model-MyModel")
+      .contains("a")
+      .get("#model-MyModel")
+      .contains("b")
+  })
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

This PR uses Immutable's `size` property to detect invalidated subtree data, instead of checking for `undefined`.

#4542, which added the default `Im.Map()` fallback values, introduced this issue.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes swagger-api/swagger-editor#1868.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I added an end-to-end test 😄 

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [ ] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
