### PR TITLE
fix: gracefully handle empty request bodies

### DIFF
--- a/src/core/plugins/oas3/components/request-body.jsx
+++ b/src/core/plugins/oas3/components/request-body.jsx
@@ -29,11 +29,11 @@ const RequestBody = ({
 
   const mediaTypeValue = requestBodyContent.get(contentType)
 
-  const isObjectContent = mediaTypeValue.getIn(["schema", "type"]) === "object"
-
   if(!mediaTypeValue) {
     return null
   }
+
+  const isObjectContent = mediaTypeValue.getIn(["schema", "type"]) === "object"
 
   if(
     contentType === "application/octet-stream"

--- a/src/core/plugins/oas3/wrap-components/parameters.jsx
+++ b/src/core/plugins/oas3/wrap-components/parameters.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from "react"
 import PropTypes from "prop-types"
-import Im, { Map } from "immutable"
+import Im, { Map, List } from "immutable"
 import ImPropTypes from "react-immutable-proptypes"
 import { OAS3ComponentWrapFactory } from "../helpers"
 
@@ -177,7 +177,7 @@ class Parameters extends Component {
               <label>
                 <ContentType
                   value={oas3Selectors.requestContentType(...pathMethod)}
-                  contentTypes={ requestBody.get("content").keySeq() }
+                  contentTypes={ requestBody.get("content", List()).keySeq() }
                   onChange={(value) => {
                     oas3Actions.setRequestContentType({ value, pathMethod })
                   }}

--- a/test/e2e-cypress/static/documents/bugs/4838.yaml
+++ b/test/e2e-cypress/static/documents/bugs/4838.yaml
@@ -1,0 +1,12 @@
+openapi: "3.0.0"
+
+paths:
+  /some/route:
+    post:
+      description: This should be visible
+      tags:
+        - Some
+      requestBody: {}
+      responses:
+        '200':
+          description: Description

--- a/test/e2e-cypress/tests/bugs/4838.js
+++ b/test/e2e-cypress/tests/bugs/4838.js
@@ -1,0 +1,11 @@
+import repeat from "lodash/repeat"
+
+describe("#4838: empty request bodies result in endless loading", () => {
+  it("should render model content changes correctly", () => {
+    cy
+      .visit("/?url=/documents/bugs/4838.yaml")
+      .get("#operations-Some-post_some_route")
+      .click()
+      .contains("This should be visible")
+  })
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

This PR modifies OAS3 Parameters and OAS3 RequestBody to more kindly handle invalid request body values.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes #4838.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added a Cypress test case.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.