### PR TITLE
ref #3958, support utf16 fragments on the deeplink plugin

### DIFF
--- a/src/core/plugins/deep-linking/index.js
+++ b/src/core/plugins/deep-linking/index.js
@@ -9,7 +9,8 @@ export default function() {
         wrapActions: {
           loaded: (ori, system) => (...args) => {
             ori(...args)
-            const hash = window.location.hash
+            // location.hash was an UTF-16 String, here is required UTF-8
+            const hash = decodeURIComponent(window.location.hash)
             system.layoutActions.parseDeepLinkHash(hash)
           }
         }

--- a/src/core/plugins/deep-linking/layout.js
+++ b/src/core/plugins/deep-linking/layout.js
@@ -73,7 +73,7 @@ export const parseDeepLinkHash = (rawHash) => ({ layoutActions, layoutSelectors,
       hash = hash.slice(1)
     }
 
-    const hashArray = hash.split("/").map(val => (val || "").replace(/%20/g, " "))
+    const hashArray = hash.split("/").map(val => (val || ""))
 
     const isShownKey = layoutSelectors.isShownKeyFromUrlHashArray(hashArray)
 

--- a/src/core/plugins/deep-linking/layout.js
+++ b/src/core/plugins/deep-linking/layout.js
@@ -32,9 +32,9 @@ export const show = (ori, { getConfigs, layoutSelectors }) => (...args) => {
     }
 
     if (urlHashArray.length === 2) {
-      setHash(createDeepLinkPath(`/${type}/${assetName}`))
+      setHash(createDeepLinkPath(`/${encodeURIComponent(type)}/${encodeURIComponent(assetName)}`))
     } else if (urlHashArray.length === 1) {
-      setHash(createDeepLinkPath(`/${type}`))
+      setHash(createDeepLinkPath(`/${encodeURIComponent(type)}`))
     }
 
   } catch (e) {

--- a/test/e2e-cypress/static/documents/features/deep-linking.openapi.yaml
+++ b/test/e2e-cypress/static/documents/features/deep-linking.openapi.yaml
@@ -25,6 +25,14 @@ paths:
             application/json:
               schema:
                 type: object
+  /utf16fragments:
+    head:
+      operationId: "пошел"
+      tags: ["шеллы"]
+      summary: an operation
+      responses:
+        "200":
+          description: ok
   /withUnderscores:
     patch:
       operationId: "underscore_Operation"
@@ -48,11 +56,3 @@ paths:
             application/json:
               schema:
                 type: object
-  /utf16fragments:
-    put:
-      operationId: "пошел"
-      tags: ["шеллы"]
-      summary: an operation
-      responses:
-        "200":
-          description: ok

--- a/test/e2e-cypress/static/documents/features/deep-linking.openapi.yaml
+++ b/test/e2e-cypress/static/documents/features/deep-linking.openapi.yaml
@@ -48,3 +48,11 @@ paths:
             application/json:
               schema:
                 type: object
+  /utf16fragments:
+    put:
+      operationId: "пошел"
+      tags: ["шеллы"]
+      summary: an operation
+      responses:
+        "200":
+          description: ok

--- a/test/e2e-cypress/static/documents/features/deep-linking.swagger.yaml
+++ b/test/e2e-cypress/static/documents/features/deep-linking.swagger.yaml
@@ -28,6 +28,10 @@ paths:
   /noOperationId:
     put:
       tags: ["tagTwo"]
+  /utf16fragments:
+    put:
+      operationId: "пошел"
+      tags: ["шеллы"]
       summary: an operation
       responses:
         "200":

--- a/test/e2e-cypress/static/documents/features/deep-linking.swagger.yaml
+++ b/test/e2e-cypress/static/documents/features/deep-linking.swagger.yaml
@@ -17,6 +17,10 @@ paths:
       responses:
         "200":
           description: ok
+  /utf16fragments:
+    head:
+      operationId: "пошел"
+      tags: ["шеллы"]
   /withUnderscores:
     patch:
       operationId: "underscore_Operation"
@@ -28,11 +32,3 @@ paths:
   /noOperationId:
     put:
       tags: ["tagTwo"]
-  /utf16fragments:
-    put:
-      operationId: "пошел"
-      tags: ["шеллы"]
-      summary: an operation
-      responses:
-        "200":
-          description: ok

--- a/test/e2e-cypress/tests/deep-linking.js
+++ b/test/e2e-cypress/tests/deep-linking.js
@@ -195,19 +195,6 @@ describe("Deep linking feature", () => {
           .should("have.length", 1)
       })
     })
-
-    describe("UTF16 fragments with `docExpansion: none` enabled", function() {
-      it("should expand the tag(шеллы)", () => {
-        cy.visit(`${baseUrl}&docExpansion=none#/%D1%88%D0%B5%D0%BB%D0%BB%D1%8B`)
-          .get(`.opblock-tag-section.is-open`)
-          .should("have.length", 1)
-      })
-      it("should expand the operation(пошел)", () => {
-        cy.visit(`${baseUrl}&docExpansion=none#/%D1%88%D0%B5%D0%BB%D0%BB%D1%8B/%D0%BF%D0%BE%D1%88%D0%B5%D0%BB`)
-          .get(`.opblock.is-open`)
-          .should("have.length", 1)
-      })
-    })
   })
   describe("in OpenAPI 3", () => {
     const baseUrl = "/?deepLinking=true&url=/documents/features/deep-linking.openapi.yaml"

--- a/test/e2e-cypress/tests/deep-linking.js
+++ b/test/e2e-cypress/tests/deep-linking.js
@@ -114,6 +114,41 @@ describe("Deep linking feature", () => {
       })
     })
 
+    describe("Operation with UTF-16 characters", () => {
+      const elementToGet = ".opblock-head"
+      const correctElementId = "operations-шеллы-пошел"
+      const correctFragment = "#/%D1%88%D0%B5%D0%BB%D0%BB%D1%8B/%D0%BF%D0%BE%D1%88%D0%B5%D0%BB"
+      const correctHref = "#/шеллы/пошел"
+
+      it("should generate a correct element ID", () => {
+        cy.get(elementToGet)
+          .should("have.id", correctElementId)
+      })
+
+      it("should add the correct element fragment to the URL when expanded", () => {
+        cy.get(elementToGet)
+          .click()
+          .window()
+          .should("have.deep.property", "location.hash", correctFragment)
+      })
+
+      it("should provide an anchor link that has the correct fragment as href", () => {
+        cy.get(elementToGet)
+          .find("a")
+          .should("have.attr", "href", correctHref)
+          .click()
+          .should("have.attr", "href", correctHref) // should be valid after expanding
+
+      })
+
+      it("should expand the operation when reloaded", () => {
+        cy.visit(`${baseUrl}${correctFragment}`)
+          .reload()
+          .get(`${elementToGet}.is-open`)
+          .should("exist")
+      })
+    })
+
     describe("Operation with no operationId", () => {
       const elementToGet = ".opblock-put"
       const correctElementId = "operations-tagTwo-put_noOperationId"
@@ -289,6 +324,41 @@ describe("Deep linking feature", () => {
       })
     })
 
+    describe("Operation with UTF-16 characters", () => {
+      const elementToGet = ".opblock-head"
+      const correctElementId = "operations-шеллы-пошел"
+      const correctFragment = "#/%D1%88%D0%B5%D0%BB%D0%BB%D1%8B/%D0%BF%D0%BE%D1%88%D0%B5%D0%BB"
+      const correctHref = "#/шеллы/пошел"
+
+      it("should generate a correct element ID", () => {
+        cy.get(elementToGet)
+          .should("have.id", correctElementId)
+      })
+
+      it("should add the correct element fragment to the URL when expanded", () => {
+        cy.get(elementToGet)
+          .click()
+          .window()
+          .should("have.deep.property", "location.hash", correctFragment)
+      })
+
+      it("should provide an anchor link that has the correct fragment as href", () => {
+        cy.get(elementToGet)
+          .find("a")
+          .should("have.attr", "href", correctHref)
+          .click()
+          .should("have.attr", "href", correctHref) // should be valid after expanding
+
+      })
+
+      it("should expand the operation when reloaded", () => {
+        cy.visit(`${baseUrl}${correctFragment}`)
+          .reload()
+          .get(`${elementToGet}.is-open`)
+          .should("exist")
+      })
+    })
+
     describe("Operation with no operationId", () => {
       const elementToGet = ".opblock-put"
       const correctElementId = "operations-tagTwo-put_noOperationId"
@@ -331,19 +401,6 @@ describe("Deep linking feature", () => {
       })
       it("should expand an operation", () => {
         cy.visit(`${baseUrl}&docExpansion=none#/myTag/myOperation`)
-          .get(`.opblock.is-open`)
-          .should("have.length", 1)
-      })
-    })
-
-    describe("UTF16 fragments with `docExpansion: none` enabled", function() {
-      it("should expand the tag(шеллы)", () => {
-        cy.visit(`${baseUrl}&docExpansion=none#/%D1%88%D0%B5%D0%BB%D0%BB%D1%8B`)
-          .get(`.opblock-tag-section.is-open`)
-          .should("have.length", 1)
-      })
-      it("should expand the operation(пошел)", () => {
-        cy.visit(`${baseUrl}&docExpansion=none#/%D1%88%D0%B5%D0%BB%D0%BB%D1%8B/%D0%BF%D0%BE%D1%88%D0%B5%D0%BB`)
           .get(`.opblock.is-open`)
           .should("have.length", 1)
       })

--- a/test/e2e-cypress/tests/deep-linking.js
+++ b/test/e2e-cypress/tests/deep-linking.js
@@ -160,6 +160,19 @@ describe("Deep linking feature", () => {
           .should("have.length", 1)
       })
     })
+
+    describe("UTF16 fragments with `docExpansion: none` enabled", function() {
+      it("should expand the tag(шеллы)", () => {
+        cy.visit(`${baseUrl}&docExpansion=none#/%D1%88%D0%B5%D0%BB%D0%BB%D1%8B`)
+          .get(`.opblock-tag-section.is-open`)
+          .should("have.length", 1)
+      })
+      it("should expand the operation(пошел)", () => {
+        cy.visit(`${baseUrl}&docExpansion=none#/%D1%88%D0%B5%D0%BB%D0%BB%D1%8B/%D0%BF%D0%BE%D1%88%D0%B5%D0%BB`)
+          .get(`.opblock.is-open`)
+          .should("have.length", 1)
+      })
+    })
   })
   describe("in OpenAPI 3", () => {
     const baseUrl = "/?deepLinking=true&url=/documents/features/deep-linking.openapi.yaml"
@@ -318,6 +331,19 @@ describe("Deep linking feature", () => {
       })
       it("should expand an operation", () => {
         cy.visit(`${baseUrl}&docExpansion=none#/myTag/myOperation`)
+          .get(`.opblock.is-open`)
+          .should("have.length", 1)
+      })
+    })
+
+    describe("UTF16 fragments with `docExpansion: none` enabled", function() {
+      it("should expand the tag(шеллы)", () => {
+        cy.visit(`${baseUrl}&docExpansion=none#/%D1%88%D0%B5%D0%BB%D0%BB%D1%8B`)
+          .get(`.opblock-tag-section.is-open`)
+          .should("have.length", 1)
+      })
+      it("should expand the operation(пошел)", () => {
+        cy.visit(`${baseUrl}&docExpansion=none#/%D1%88%D0%B5%D0%BB%D0%BB%D1%8B/%D0%BF%D0%BE%D1%88%D0%B5%D0%BB`)
           .get(`.opblock.is-open`)
           .should("have.length", 1)
       })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

1. let `deep-link` plugin to support the UTF-16 fragments

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->



### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`npm run e2e-cypress`

```
  Deep linking feature
    in Swagger 2
      UTF16 fragments with `docExpansion: none` enabled
        ✓ should expand the tag(шеллы) (1164ms)
        ✓ should expand the operation(пошел) (1257ms)
    in OpenAPI 3
      UTF16 fragments with `docExpansion: none` enabled
        ✓ should expand the tag(шеллы) (1265ms)
        ✓ should expand the operation(пошел) (1143ms)
```

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
