### PR TITLE
bug(deeplinking): escaping is breaking whitespaces & underscored tags/ids

### DIFF
--- a/src/core/components/operation.jsx
+++ b/src/core/components/operation.jsx
@@ -1,7 +1,7 @@
 import React, { PureComponent } from "react"
 import PropTypes from "prop-types"
 import { getList } from "core/utils"
-import { getExtensions, sanitizeUrl, createDeepLinkPath } from "core/utils"
+import { getExtensions, sanitizeUrl, escapeDeepLinkPath } from "core/utils"
 import { Iterable, List } from "immutable"
 import ImPropTypes from "react-immutable-proptypes"
 
@@ -112,7 +112,7 @@ export default class Operation extends PureComponent {
     let onChangeKey = [ path, method ] // Used to add values to _this_ operation ( indexed by path and method )
 
     return (
-        <div className={deprecated ? "opblock opblock-deprecated" : isShown ? `opblock opblock-${method} is-open` : `opblock opblock-${method}`} id={createDeepLinkPath(isShownKey.join("-"))} >
+        <div className={deprecated ? "opblock opblock-deprecated" : isShown ? `opblock opblock-${method} is-open` : `opblock opblock-${method}`} id={escapeDeepLinkPath(isShownKey.join("-"))} >
         <OperationSummary operationProps={operationProps} toggleShown={toggleShown} getComponent={getComponent} authActions={authActions} authSelectors={authSelectors} specPath={specPath} />
           <Collapse isOpened={isShown}>
             <div className="opblock-body">

--- a/src/core/plugins/deep-linking/layout.js
+++ b/src/core/plugins/deep-linking/layout.js
@@ -73,7 +73,7 @@ export const parseDeepLinkHash = (rawHash) => ({ layoutActions, layoutSelectors,
       hash = hash.slice(1)
     }
 
-    const hashArray = hash.split("/").map(val => (val || "").replace(/_/g, " "))
+    const hashArray = hash.split("/").map(val => (val || "").replace(/%20/g, " "))
 
     const isShownKey = layoutSelectors.isShownKeyFromUrlHashArray(hashArray)
 

--- a/src/core/plugins/deep-linking/layout.js
+++ b/src/core/plugins/deep-linking/layout.js
@@ -77,14 +77,31 @@ export const parseDeepLinkHash = (rawHash) => ({ layoutActions, layoutSelectors,
 
     const isShownKey = layoutSelectors.isShownKeyFromUrlHashArray(hashArray)
 
-    const [type, tagId] = isShownKey
+    const [type, tagId, maybeOperationId] = isShownKey
 
     if(type === "operations") {
       // we're going to show an operation, so we need to expand the tag as well
-      layoutActions.show(layoutSelectors.isShownKeyFromUrlHashArray([tagId]))
+      const tagIsShownKey = layoutSelectors.isShownKeyFromUrlHashArray([tagId])
+      layoutActions.show(tagIsShownKey)
+
+      // If an `_` is present, trigger the legacy escaping behavior to be safe
+      // TODO: remove this in v4.0, it is deprecated
+      if(tagId.indexOf("_") > -1) {
+        console.warn("Warning: escaping deep link whitespace with `_` will be unsupported in v4.0, use `%20` instead.")
+        layoutActions.show(tagIsShownKey.map(val => val.replace(/_/g, " ")), true)
+      }
     }
 
-    layoutActions.show(isShownKey, true) // TODO: 'show' operation tag
+    layoutActions.show(isShownKey, true)
+
+    // If an `_` is present, trigger the legacy escaping behavior to be safe
+    // TODO: remove this in v4.0, it is deprecated
+    if (tagId.indexOf("_") > -1 || maybeOperationId.indexOf("_") > -1) {
+      console.warn("Warning: escaping deep link whitespace with `_` will be unsupported in v4.0, use `%20` instead.")
+      layoutActions.show(isShownKey.map(val => val.replace(/_/g, " ")), true)
+    }
+
+    // Scroll to the newly expanded entity
     layoutActions.scrollTo(isShownKey)
   }
 }

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -733,8 +733,10 @@ export function getAcceptControllingResponse(responses) {
   return suitable2xxResponse || suitableDefaultResponse
 }
 
-export const createDeepLinkPath = (str) => typeof str == "string" || str instanceof String ? str.trim().replace(/\s/g, "_") : ""
-export const escapeDeepLinkPath = (str) => cssEscape( createDeepLinkPath(str) )
+// suitable for use in URL fragments
+export const createDeepLinkPath = (str) => typeof str == "string" || str instanceof String ? str.trim().replace(/\s/g, "%20") : ""
+// suitable for use in CSS classes and ids
+export const escapeDeepLinkPath = (str) => cssEscape( createDeepLinkPath(str).replace(/%20/g, "_") )
 
 export const getExtensions = (defObj) => defObj.filter((v, k) => /^x-/.test(k))
 export const getCommonExtensions = (defObj) => defObj.filter((v, k) => /^pattern|maxLength|minLength|maximum|minimum/.test(k))

--- a/test/core/utils.js
+++ b/test/core/utils.js
@@ -991,12 +991,12 @@ describe("utils", function() {
   describe("createDeepLinkPath", function() {
     it("creates a deep link path replacing spaces with underscores", function() {
       const result = createDeepLinkPath("tag id with spaces")
-      expect(result).toEqual("tag_id_with_spaces")
+      expect(result).toEqual("tag%20id%20with%20spaces")
     })
 
     it("trims input when creating a deep link path", function() {
       let result = createDeepLinkPath("  spaces before and after    ")
-      expect(result).toEqual("spaces_before_and_after")
+      expect(result).toEqual("spaces%20before%20and%20after")
 
       result = createDeepLinkPath("  ")
       expect(result).toEqual("")
@@ -1035,6 +1035,16 @@ describe("utils", function() {
     it("escapes a deep link path with an id selector", function() {
       const result = escapeDeepLinkPath("hello#world")
       expect(result).toEqual("hello\\#world")
+    })
+
+    it("escapes a deep link path with a space", function() {
+      const result = escapeDeepLinkPath("hello world")
+      expect(result).toEqual("hello_world")
+    })
+
+    it("escapes a deep link path with a percent-encoded space", function() {
+      const result = escapeDeepLinkPath("hello%20world")
+      expect(result).toEqual("hello_world")
     })
   })
 

--- a/test/e2e-cypress/static/documents/features/deep-linking.openapi.yaml
+++ b/test/e2e-cypress/static/documents/features/deep-linking.openapi.yaml
@@ -25,6 +25,18 @@ paths:
             application/json:
               schema:
                 type: object
+  /withUnderscores:
+    patch:
+      operationId: "underscore_Operation"
+      tags: ["underscore_Tag"]
+      summary: an operation
+      responses:
+        '200':
+          description: a pet to be returned
+          content: 
+            application/json:
+              schema:
+                type: object
   /noOperationId:
     put:
       tags: ["tagTwo"]

--- a/test/e2e-cypress/static/documents/features/deep-linking.openapi.yaml
+++ b/test/e2e-cypress/static/documents/features/deep-linking.openapi.yaml
@@ -25,3 +25,14 @@ paths:
             application/json:
               schema:
                 type: object
+  /noOperationId:
+    put:
+      tags: ["tagTwo"]
+      summary: some operations are anonymous...
+      responses:
+        '200':
+          description: a pet to be returned
+          content: 
+            application/json:
+              schema:
+                type: object

--- a/test/e2e-cypress/static/documents/features/deep-linking.swagger.yaml
+++ b/test/e2e-cypress/static/documents/features/deep-linking.swagger.yaml
@@ -17,6 +17,14 @@ paths:
       responses:
         "200":
           description: ok
+  /withUnderscores:
+    patch:
+      operationId: "underscore_Operation"
+      tags: ["underscore_Tag"]
+      summary: an operation
+      responses:
+        "200":
+          description: ok
   /noOperationId:
     put:
       tags: ["tagTwo"]

--- a/test/e2e-cypress/static/documents/features/deep-linking.swagger.yaml
+++ b/test/e2e-cypress/static/documents/features/deep-linking.swagger.yaml
@@ -17,3 +17,10 @@ paths:
       responses:
         "200":
           description: ok
+  /noOperationId:
+    put:
+      tags: ["tagTwo"]
+      summary: an operation
+      responses:
+        "200":
+          description: ok

--- a/test/e2e-cypress/tests/deep-linking.js
+++ b/test/e2e-cypress/tests/deep-linking.js
@@ -72,6 +72,40 @@ describe("Deep linking feature", () => {
       })
     })
 
+    describe("Operation with no operationId", () => {
+      const elementToGet = ".opblock-put"
+      const correctElementId = "operations-tagTwo-put_noOperationId"
+      const correctFragment = "#/tagTwo/put_noOperationId"
+
+      it("should generate a correct element ID", () => {
+        cy.get(elementToGet)
+          .should("have.id", correctElementId)
+      })
+
+      it("should add the correct element fragment to the URL when expanded", () => {
+        cy.get(elementToGet)
+          .click()
+          .window()
+          .should("have.deep.property", "location.hash", correctFragment)
+      })
+
+      it("should provide an anchor link that has the correct fragment as href", () => {
+        cy.get(elementToGet)
+          .find("a")
+          .should("have.attr", "href", correctFragment)
+          .click()
+          .should("have.attr", "href", correctFragment) // should be valid after expanding
+
+      })
+
+      it("should expand the operation when reloaded", () => {
+        cy.visit(`${baseUrl}${correctFragment}`)
+          .reload()
+          .get(`${elementToGet}.is-open`)
+          .should("exist")
+      })
+    })
+
     describe("regular Operation with `docExpansion: none` enabled", function() {
       it("should expand a tag", () => {
         cy.visit(`${baseUrl}&docExpansion=none#/myTag`)
@@ -128,6 +162,40 @@ describe("Deep linking feature", () => {
       const elementToGet = ".opblock-post"
       const correctElementId = "operations-my_Tag-my_Operation"
       const correctFragment = "#/my_Tag/my_Operation"
+
+      it("should generate a correct element ID", () => {
+        cy.get(elementToGet)
+          .should("have.id", correctElementId)
+      })
+
+      it("should add the correct element fragment to the URL when expanded", () => {
+        cy.get(elementToGet)
+          .click()
+          .window()
+          .should("have.deep.property", "location.hash", correctFragment)
+      })
+
+      it("should provide an anchor link that has the correct fragment as href", () => {
+        cy.get(elementToGet)
+          .find("a")
+          .should("have.attr", "href", correctFragment)
+          .click()
+          .should("have.attr", "href", correctFragment) // should be valid after expanding
+
+      })
+
+      it("should expand the operation when reloaded", () => {
+        cy.visit(`${baseUrl}${correctFragment}`)
+          .reload()
+          .get(`${elementToGet}.is-open`)
+          .should("exist")
+      })
+    })
+
+    describe("Operation with no operationId", () => {
+      const elementToGet = ".opblock-put"
+      const correctElementId = "operations-tagTwo-put_noOperationId"
+      const correctFragment = "#/tagTwo/put_noOperationId"
 
       it("should generate a correct element ID", () => {
         cy.get(elementToGet)

--- a/test/e2e-cypress/tests/deep-linking.js
+++ b/test/e2e-cypress/tests/deep-linking.js
@@ -72,6 +72,40 @@ describe("Deep linking feature", () => {
       })
     })
 
+    describe("Operation with underscores in tag+id", () => {
+      const elementToGet = ".opblock-patch"
+      const correctElementId = "operations-underscore_Tag-underscore_Operation"
+      const correctFragment = "#/underscore_Tag/underscore_Operation"
+
+      it("should generate a correct element ID", () => {
+        cy.get(elementToGet)
+          .should("have.id", correctElementId)
+      })
+
+      it("should add the correct element fragment to the URL when expanded", () => {
+        cy.get(elementToGet)
+          .click()
+          .window()
+          .should("have.deep.property", "location.hash", correctFragment)
+      })
+
+      it("should provide an anchor link that has the correct fragment as href", () => {
+        cy.get(elementToGet)
+          .find("a")
+          .should("have.attr", "href", correctFragment)
+          .click()
+          .should("have.attr", "href", correctFragment) // should be valid after expanding
+
+      })
+
+      it("should expand the operation when reloaded", () => {
+        cy.visit(`${baseUrl}${correctFragment}`)
+          .reload()
+          .get(`${elementToGet}.is-open`)
+          .should("exist")
+      })
+    })
+
     describe("Operation with no operationId", () => {
       const elementToGet = ".opblock-put"
       const correctElementId = "operations-tagTwo-put_noOperationId"
@@ -162,6 +196,40 @@ describe("Deep linking feature", () => {
       const elementToGet = ".opblock-post"
       const correctElementId = "operations-my_Tag-my_Operation"
       const correctFragment = "#/my_Tag/my_Operation"
+
+      it("should generate a correct element ID", () => {
+        cy.get(elementToGet)
+          .should("have.id", correctElementId)
+      })
+
+      it("should add the correct element fragment to the URL when expanded", () => {
+        cy.get(elementToGet)
+          .click()
+          .window()
+          .should("have.deep.property", "location.hash", correctFragment)
+      })
+
+      it("should provide an anchor link that has the correct fragment as href", () => {
+        cy.get(elementToGet)
+          .find("a")
+          .should("have.attr", "href", correctFragment)
+          .click()
+          .should("have.attr", "href", correctFragment) // should be valid after expanding
+
+      })
+
+      it("should expand the operation when reloaded", () => {
+        cy.visit(`${baseUrl}${correctFragment}`)
+          .reload()
+          .get(`${elementToGet}.is-open`)
+          .should("exist")
+      })
+    })
+
+    describe("Operation with underscores in tag+id", () => {
+      const elementToGet = ".opblock-patch"
+      const correctElementId = "operations-underscore_Tag-underscore_Operation"
+      const correctFragment = "#/underscore_Tag/underscore_Operation"
 
       it("should generate a correct element ID", () => {
         cy.get(elementToGet)

--- a/test/e2e-cypress/tests/deep-linking.js
+++ b/test/e2e-cypress/tests/deep-linking.js
@@ -41,7 +41,7 @@ describe("Deep linking feature", () => {
     describe("Operation with whitespace in tag+id", () => {
       const elementToGet = ".opblock-post"
       const correctElementId = "operations-my_Tag-my_Operation"
-      const correctFragment = "#/my_Tag/my_Operation"
+      const correctFragment = "#/my%20Tag/my%20Operation"
 
       it("should generate a correct element ID", () => {
         cy.get(elementToGet)
@@ -195,7 +195,7 @@ describe("Deep linking feature", () => {
     describe("Operation with whitespace in tag+id", () => {
       const elementToGet = ".opblock-post"
       const correctElementId = "operations-my_Tag-my_Operation"
-      const correctFragment = "#/my_Tag/my_Operation"
+      const correctFragment = "#/my%20Tag/my%20Operation"
 
       it("should generate a correct element ID", () => {
         cy.get(elementToGet)

--- a/test/e2e-cypress/tests/deep-linking.js
+++ b/test/e2e-cypress/tests/deep-linking.js
@@ -42,6 +42,7 @@ describe("Deep linking feature", () => {
       const elementToGet = ".opblock-post"
       const correctElementId = "operations-my_Tag-my_Operation"
       const correctFragment = "#/my%20Tag/my%20Operation"
+      const legacyFragment = "#/my_Tag/my_Operation"
 
       it("should generate a correct element ID", () => {
         cy.get(elementToGet)
@@ -66,6 +67,13 @@ describe("Deep linking feature", () => {
 
       it("should expand the operation when reloaded", () => {
         cy.visit(`${baseUrl}${correctFragment}`)
+          .reload()
+          .get(`${elementToGet}.is-open`)
+          .should("exist")
+      })
+
+      it("should expand the operation when reloaded and provided the legacy fragment", () => {
+        cy.visit(`${baseUrl}${legacyFragment}`)
           .reload()
           .get(`${elementToGet}.is-open`)
           .should("exist")
@@ -196,6 +204,7 @@ describe("Deep linking feature", () => {
       const elementToGet = ".opblock-post"
       const correctElementId = "operations-my_Tag-my_Operation"
       const correctFragment = "#/my%20Tag/my%20Operation"
+      const legacyFragment = "#/my_Tag/my_Operation"
 
       it("should generate a correct element ID", () => {
         cy.get(elementToGet)
@@ -220,6 +229,13 @@ describe("Deep linking feature", () => {
 
       it("should expand the operation when reloaded", () => {
         cy.visit(`${baseUrl}${correctFragment}`)
+          .reload()
+          .get(`${elementToGet}.is-open`)
+          .should("exist")
+      })
+
+      it("should expand the operation when reloaded and provided the legacy fragment", () => {
+        cy.visit(`${baseUrl}${legacyFragment}`)
           .reload()
           .get(`${elementToGet}.is-open`)
           .should("exist")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

This PR improves our Deep Linking implementation:
- Tags and operationIds that contain underscores and whitespace are now tested and working properly
- Operations lacking operationIds are now tested and working properly
- Tag and operationId whitespace is now escaped with `%20` instead of `_`
- Links relying on `_`-based escaping are still supported, but deprecated and tagged for removal in v4.0

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes #4895 and may also solve #4929.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I added new unit and integration tests, and modified a few existing ones.

There should be no breaking changes to overall functionality, as the new tests cover any gaps left by modifications to the existing tests.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [x] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.