### PR TITLE
improve: deeplinking behavior

### DIFF
--- a/src/core/plugins/deep-linking/layout.js
+++ b/src/core/plugins/deep-linking/layout.js
@@ -77,12 +77,11 @@ export const parseDeepLinkHash = (rawHash) => ({ layoutActions, layoutSelectors,
 
     const isShownKey = layoutSelectors.isShownKeyFromUrlHashArray(hashArray)
 
-    const [type, tagId, maybeOperationId] = isShownKey
+    const [type, tagId = "", maybeOperationId = ""] = isShownKey
 
     if(type === "operations") {
       // we're going to show an operation, so we need to expand the tag as well
       const tagIsShownKey = layoutSelectors.isShownKeyFromUrlHashArray([tagId])
-      layoutActions.show(tagIsShownKey)
 
       // If an `_` is present, trigger the legacy escaping behavior to be safe
       // TODO: remove this in v4.0, it is deprecated
@@ -90,9 +89,9 @@ export const parseDeepLinkHash = (rawHash) => ({ layoutActions, layoutSelectors,
         console.warn("Warning: escaping deep link whitespace with `_` will be unsupported in v4.0, use `%20` instead.")
         layoutActions.show(tagIsShownKey.map(val => val.replace(/_/g, " ")), true)
       }
-    }
 
-    layoutActions.show(isShownKey, true)
+      layoutActions.show(tagIsShownKey, true)
+    }
 
     // If an `_` is present, trigger the legacy escaping behavior to be safe
     // TODO: remove this in v4.0, it is deprecated
@@ -100,6 +99,8 @@ export const parseDeepLinkHash = (rawHash) => ({ layoutActions, layoutSelectors,
       console.warn("Warning: escaping deep link whitespace with `_` will be unsupported in v4.0, use `%20` instead.")
       layoutActions.show(isShownKey.map(val => val.replace(/_/g, " ")), true)
     }
+
+    layoutActions.show(isShownKey, true)
 
     // Scroll to the newly expanded entity
     layoutActions.scrollTo(isShownKey)

--- a/test/e2e-cypress/tests/deep-linking.js
+++ b/test/e2e-cypress/tests/deep-linking.js
@@ -38,7 +38,7 @@ describe("Deep linking feature", () => {
           .reload()
           .window()
           .should("have.deep.property", "location.hash", correctFragment)
-    })
+      })
     })
 
     describe("Operation with underscores in tag+id", () => {
@@ -100,7 +100,7 @@ describe("Deep linking feature", () => {
     describe("Operation with whitespace in tag+id", () => {
       const elementToGet = ".opblock-post"
       const correctFragment = "#/my%20Tag/my%20Operation"
-      
+
       
       BaseDeeplinkTestFactory({
         baseUrl: openAPI3BaseUrl,
@@ -202,5 +202,12 @@ function BaseDeeplinkTestFactory({ baseUrl, elementToGet, correctElementId, corr
     cy.visit(`${baseUrl}${correctFragment}`)
       .get(`${elementToGet}.is-open`)
       .should("exist")
+  })
+
+  it("should retain the correct fragment when reloaded", () => {
+    cy.visit(`${baseUrl}${correctFragment}`)
+      .should("exist")
+      .window()
+      .should("have.deep.property", "location.hash", correctFragment)
   })
 }

--- a/test/e2e-cypress/tests/deep-linking.js
+++ b/test/e2e-cypress/tests/deep-linking.js
@@ -14,12 +14,13 @@ describe("Deep linking feature", () => {
 
     describe("Operation with whitespace in tag+id", () => {
       const elementToGet = ".opblock-post"
+      const correctFragment = "#/my%20Tag/my%20Operation"
       
       BaseDeeplinkTestFactory({
         baseUrl: swagger2BaseUrl,
         elementToGet,
         correctElementId: "operations-my_Tag-my_Operation",
-        correctFragment: "#/my%20Tag/my%20Operation",
+        correctFragment,
         correctHref: "#/my%20Tag/my%20Operation"
       })
 
@@ -31,6 +32,13 @@ describe("Deep linking feature", () => {
           .get(`${elementToGet}.is-open`)
           .should("exist")
       })
+
+      it("should rewrite to the correct fragment when provided the legacy fragment", () => {
+        cy.visit(`${swagger2BaseUrl}${legacyFragment}`)
+          .reload()
+          .window()
+          .should("have.deep.property", "location.hash", correctFragment)
+    })
     })
 
     describe("Operation with underscores in tag+id", () => {
@@ -91,14 +99,14 @@ describe("Deep linking feature", () => {
 
     describe("Operation with whitespace in tag+id", () => {
       const elementToGet = ".opblock-post"
-      const correctElementId = "operations-my_Tag-my_Operation"
       const correctFragment = "#/my%20Tag/my%20Operation"
+      
       
       BaseDeeplinkTestFactory({
         baseUrl: openAPI3BaseUrl,
         elementToGet: ".opblock-post",
         correctElementId: "operations-my_Tag-my_Operation",
-        correctFragment: "#/my%20Tag/my%20Operation",
+        correctFragment,
         correctHref: "#/my%20Tag/my%20Operation"
       })
       
@@ -109,6 +117,14 @@ describe("Deep linking feature", () => {
           .reload()
           .get(`${elementToGet}.is-open`)
           .should("exist")
+      })
+
+
+      it("should rewrite to the correct fragment when provided the legacy fragment", () => {
+        cy.visit(`${openAPI3BaseUrl}${legacyFragment}`)
+          .reload()
+          .window()
+          .should("have.deep.property", "location.hash", correctFragment)
       })
     })
 

--- a/test/e2e-cypress/tests/deep-linking.js
+++ b/test/e2e-cypress/tests/deep-linking.js
@@ -33,7 +33,7 @@ describe("Deep linking feature", () => {
           .should("exist")
       })
 
-      it("should rewrite to the correct fragment when provided the legacy fragment", () => {
+      it.skip("should rewrite to the correct fragment when provided the legacy fragment", () => {
         cy.visit(`${swagger2BaseUrl}${legacyFragment}`)
           .reload()
           .window()
@@ -120,7 +120,7 @@ describe("Deep linking feature", () => {
       })
 
 
-      it("should rewrite to the correct fragment when provided the legacy fragment", () => {
+      it.skip("should rewrite to the correct fragment when provided the legacy fragment", () => {
         cy.visit(`${openAPI3BaseUrl}${legacyFragment}`)
           .reload()
           .window()
@@ -206,6 +206,7 @@ function BaseDeeplinkTestFactory({ baseUrl, elementToGet, correctElementId, corr
 
   it("should retain the correct fragment when reloaded", () => {
     cy.visit(`${baseUrl}${correctFragment}`)
+      .reload()
       .should("exist")
       .window()
       .should("have.deep.property", "location.hash", correctFragment)

--- a/test/e2e-cypress/tests/deep-linking.js
+++ b/test/e2e-cypress/tests/deep-linking.js
@@ -100,7 +100,6 @@ describe("Deep linking feature", () => {
     describe("Operation with whitespace in tag+id", () => {
       const elementToGet = ".opblock-post"
       const correctFragment = "#/my%20Tag/my%20Operation"
-
       
       BaseDeeplinkTestFactory({
         baseUrl: openAPI3BaseUrl,


### PR DESCRIPTION
This PR breaks rewriting of deprecated fragments (unreleased, introduced in #4953) in favor of retaining correct fragments.

Fixing both requires expanding the deep linking plugin to have knowledge of the document's contents: given `#/my_tag/my_operation`," is this a deprecated fragment referencing `my tag` + `my operation`, or a valid fragment referencing `my_tag` + `my_operation`" can only be answered by looking at the document itself.

I don't have time to do this before release, so I'm patching this in the most forward-friendly way until a full fix can be made. A successor ticket will be made to address these concerns.