### PR TITLE
housekeeping: `xml` -> `@kyleshockey/xml`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -141,6 +141,14 @@
       "resolved": "https://registry.npmjs.org/@kyleshockey/object-assign-deep/-/object-assign-deep-0.4.2.tgz",
       "integrity": "sha1-hJAPDu/DcnmPR1G1JigwuCCJIuw="
     },
+    "@kyleshockey/xml": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@kyleshockey/xml/-/xml-1.0.2.tgz",
+      "integrity": "sha512-iMo32MPLcI9cPxs3YL5kmKxKgDmkSZDCFEqIT5eRk7d/Ll8r4X3SwGYSigzALd6+RHWlFEmjL1QyaQ15xDZFlw==",
+      "requires": {
+        "stream": "^0.0.2"
+      }
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -5600,6 +5608,11 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.0"
       }
+    },
+    "emitter-component": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/emitter-component/-/emitter-component-1.1.1.tgz",
+      "integrity": "sha1-Bl4tvtaVm/RwZ57avq95gdEAOrY="
     },
     "emojis-list": {
       "version": "2.1.0",
@@ -20542,6 +20555,14 @@
         "graceful-fs": "^4.1.3"
       }
     },
+    "stream": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stream/-/stream-0.0.2.tgz",
+      "integrity": "sha1-f1Nj8Ff2WSxVlfALyAon9c7B8O8=",
+      "requires": {
+        "emitter-component": "^1.1.1"
+      }
+    },
     "stream-browserify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
@@ -22455,11 +22476,6 @@
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
       "dev": true
-    },
-    "xml": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
-      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU="
     },
     "xml-but-prettier": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@braintree/sanitize-url": "^2.0.2",
     "@kyleshockey/js-yaml": "^1.0.1",
     "@kyleshockey/object-assign-deep": "^0.4.2",
+    "@kyleshockey/xml": "^1.0.2",
     "base64-js": "^1.2.0",
     "classnames": "^2.2.5",
     "core-js": "^2.5.1",
@@ -77,8 +78,6 @@
     "serialize-error": "^2.1.0",
     "swagger-client": "^3.8.21",
     "url-parse": "^1.1.8",
-    "webpack-dev-server": "^2.11.1",
-    "xml": "1.0.1",
     "xml-but-prettier": "^1.0.1",
     "zenscroll": "^4.0.2"
   },
@@ -142,6 +141,7 @@
     "webpack": "^3.1.0",
     "webpack-bundle-size-analyzer": "^2.5.0",
     "webpack-cli": "^2.0.4",
+    "webpack-dev-server": "^2.11.1",
     "worker-loader": "^1.1.1"
   },
   "config": {

--- a/src/core/plugins/samples/fn.js
+++ b/src/core/plugins/samples/fn.js
@@ -1,5 +1,5 @@
 import { objectify, isFunc, normalizeArray, deeplyStripKey } from "core/utils"
-import XML from "xml"
+import XML from "@kyleshockey/xml"
 import memoizee from "memoizee"
 
 const primitives = {


### PR DESCRIPTION
This PR migrates Swagger UI to using [my browser-compatible fork of `xml`](https://www.npmjs.com/package/@kyleshockey/xml).

Addresses (likely fixes) #4971.

_Bonus: this fixes a logical error I made in #4984 - `webpack-dev-server` is now actually in devDependencies._