### PR TITLE
add primitive factory method for string/date

### DIFF
--- a/src/core/plugins/samples/fn.js
+++ b/src/core/plugins/samples/fn.js
@@ -6,6 +6,7 @@ const primitives = {
   "string": () => "string",
   "string_email": () => "user@example.com",
   "string_date-time": () => new Date().toISOString(),
+  "string_date": () => new Date().toISOString().substring(0, 10),
   "number": () => 0,
   "number_float": () => 0.0,
   "integer": () => 0,

--- a/test/core/plugins/samples/fn.js
+++ b/test/core/plugins/samples/fn.js
@@ -238,6 +238,28 @@ describe("sampleFromSchema", function() {
     expect(sampleFromSchema(definition, { includeWriteOnly: true })).toEqual(expected)
   })
 
+  it("returns example value for date-time property", function() {
+    var definition = {
+      type: "string",
+      format: "date-time"
+    }
+
+    var expected = new Date().toISOString()
+
+    expect(sampleFromSchema(definition)).toEqual(expected)
+  })
+
+  it("returns example value for date property", function() {
+    var definition = {
+      type: "string",
+      format: "date"
+    }
+
+    var expected = new Date().toISOString().substring(0, 10)
+
+    expect(sampleFromSchema(definition)).toEqual(expected)
+  })
+
   describe("for array type", function() {
     it("returns array with sample of array type", function() {
       var definition = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Adds an example value provider for "date" format strings.

Given:
```
"properties": {
   "myDateField": {
      "type":"string", 
      "format":"date"
   }
}
```

Should provide an example ISO-formatted date-only string, such as
```
"2018-11-13"
```

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->
Previously, these fields would be represented in request/response "Example Value" payloads as simply "string". This change provides semantic context, similar to other primitive values (number, boolean, etc).


### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit tests to cover sample values for both "date" and "date-time" formats.


### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
