### PR TITLE
Fix #4813 resolve referenced securitySchemes

### DIFF
--- a/src/core/plugins/oas3/spec-extensions/wrap-selectors.js
+++ b/src/core/plugins/oas3/spec-extensions/wrap-selectors.js
@@ -1,4 +1,5 @@
 import { createSelector } from "reselect"
+import { specJsonWithResolvedSubtrees } from "../../spec/selectors"
 import { Map } from "immutable"
 import { isOAS3 as isOAS3Helper, isSwagger2 as isSwagger2Helper } from "../helpers"
 
@@ -53,7 +54,7 @@ export const hasHost = onlyOAS3((state) => {
 })
 
 export const securityDefinitions = onlyOAS3(createSelector(
-  spec,
+  specJsonWithResolvedSubtrees,
   spec => spec.getIn(["components", "securitySchemes"]) || null
 ))
 

--- a/src/core/plugins/spec/wrap-actions.js
+++ b/src/core/plugins/spec/wrap-actions.js
@@ -22,6 +22,9 @@ export const updateJsonSpec = (ori, {specActions}) => (...args) => {
       specActions.requestResolvedSubtree(["paths", k])
     }
   })
+
+  // Trigger resolution of any securitySchemes-level $refs.
+  specActions.requestResolvedSubtree(["components", "securitySchemes"])
 }
 
 // Log the request ( just for debugging, shouldn't affect prod )


### PR DESCRIPTION
Fixes #4813 by resolving referenced security schemes.

### Description
securitySchemes were up till now not resolved.


### Motivation and Context
The spec allows for them: https://swagger.io/specification/#componentsObject.


### How Has This Been Tested?
By providing a schema where this is the case.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.

I could not find how to make an automated test for this.  If this is needed, I will require some pointers on where to do it.
