### PR TITLE
bugfix: fix issue #5040

### DIFF
--- a/src/core/curlify.js
+++ b/src/core/curlify.js
@@ -23,7 +23,7 @@ export default function curl( request ){
       for( let [ k,v ] of request.get("body").entrySeq()) {
         curlified.push( "-F" )
         if (v instanceof win.File) {
-          curlified.push( `"${k}=@${v.name};type=${v.type}"` )
+          curlified.push( `"${k}=@${v.name}${v.type?';type=' + v.type : ''}"` )
         } else {
           curlified.push( `"${k}=${v}"` )
         }

--- a/test/core/curlify.js
+++ b/test/core/curlify.js
@@ -163,6 +163,26 @@ describe("curlify", function() {
         expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"content-type: multipart/form-data\" -F \"id=123\" -F \"file=@file.txt;type=text/plain\"")
     })
 
+    it("should print a curl without form data type if type is unknown", function() {
+      var file = new win.File()
+      file.name = "file.txt"
+      file.type = ''
+
+      var req = {
+        url: "http://example.com",
+        method: "POST",
+        headers: { "content-type": "multipart/form-data" },
+        body: {
+          id: "123",
+          file
+        }
+      }
+
+      let curlified = curl(Im.fromJS(req))
+
+      expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"content-type: multipart/form-data\" -F \"id=123\" -F \"file=@file.txt\"")
+    })
+
     it("prints a curl post statement from an object", function() {
         var req = {
             url: "http://example.com",
@@ -194,5 +214,4 @@ describe("curlify", function() {
 
         expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"accept: application/json\" -d \"{\\\"id\\\":\\\"foo'bar\\\"}\"")
     })
-
 })

--- a/test/core/curlify.js
+++ b/test/core/curlify.js
@@ -214,4 +214,5 @@ describe("curlify", function() {
 
         expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"accept: application/json\" -d \"{\\\"id\\\":\\\"foo'bar\\\"}\"")
     })
+
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Generated curl command for multipart/form-data file will not include a blank 'type' which causes curl to be invalid



### Motivation and Context
Fixes #5040 



### How Has This Been Tested?
Added unit test. Local run against petstore swagger def.



### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/30060871/48861165-cf52c780-ed77-11e8-8bfa-7a16f62ddfa2.png)



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
