### PR TITLE
fix: path-item $ref produces/consumes inheritance

### DIFF
--- a/src/core/components/operation.jsx
+++ b/src/core/components/operation.jsx
@@ -83,7 +83,6 @@ export default class Operation extends PureComponent {
 
     let operation = operationProps.getIn(["op"])
     let responses = operation.get("responses")
-    let produces = operation.get("produces")
     let parameters = getList(operation, ["parameters"])
     let operationScheme = specSelectors.operationScheme(path, method)
     let isShownKey = ["operations", tag, operationId]
@@ -216,7 +215,7 @@ export default class Operation extends PureComponent {
                     specSelectors={ specSelectors }
                     oas3Actions={oas3Actions}
                     specActions={ specActions }
-                    produces={ produces }
+                    produces={specSelectors.producesOptionsFor([path, method]) }
                     producesValue={ specSelectors.currentProducesFor([path, method]) }
                     specPath={specPath.push("responses")}
                     path={ path }

--- a/src/core/components/parameter-row.jsx
+++ b/src/core/components/parameter-row.jsx
@@ -129,7 +129,7 @@ export default class ParameterRow extends Component {
       : <ParamBody getComponent={getComponent}
                    fn={fn}
                    param={param}
-                   consumes={ specSelectors.operationConsumes(pathMethod) }
+                   consumes={ specSelectors.consumesOptionsFor(pathMethod) }
                    consumesValue={ specSelectors.contentTypeValues(pathMethod).get("requestContentType") }
                    onChange={this.onChangeWrapper}
                    onChangeConsumes={onChangeConsumes}

--- a/src/core/plugins/spec/selectors.js
+++ b/src/core/plugins/spec/selectors.js
@@ -425,7 +425,7 @@ export function currentProducesFor(state, pathMethod) {
 
 }
 
-// Get the currently selected produces value for an operation
+// Get the produces options for an operation
 export function producesOptionsFor(state, pathMethod) {
   pathMethod = pathMethod || []
 

--- a/src/core/plugins/spec/selectors.js
+++ b/src/core/plugins/spec/selectors.js
@@ -425,6 +425,27 @@ export function currentProducesFor(state, pathMethod) {
 
 }
 
+// Get the currently selected produces value for an operation
+export function producesOptionsFor(state, pathMethod) {
+  pathMethod = pathMethod || []
+
+  const spec = specJsonWithResolvedSubtrees(state)
+  const operation = spec.getIn([ "paths", ...pathMethod], null)
+
+  if(operation === null) {
+    // return nothing if the operation does not exist
+    return
+  }
+
+  const [path] = pathMethod
+
+  const operationProduces = operation.get("produces", null)
+  const pathItemProduces = spec.getIn(["paths", path, "produces"], null)
+  const globalProduces = spec.getIn(["produces"], null)
+
+  return operationProduces || pathItemProduces || globalProduces
+}
+
 export const operationScheme = ( state, path, method ) => {
   let url = state.get("url")
   let matchResult = url.match(/^([a-z][a-z0-9+\-.]*):/)

--- a/src/core/plugins/spec/selectors.js
+++ b/src/core/plugins/spec/selectors.js
@@ -446,6 +446,27 @@ export function producesOptionsFor(state, pathMethod) {
   return operationProduces || pathItemProduces || globalProduces
 }
 
+// Get the consumes options for an operation
+export function consumesOptionsFor(state, pathMethod) {
+  pathMethod = pathMethod || []
+
+  const spec = specJsonWithResolvedSubtrees(state)
+  const operation = spec.getIn(["paths", ...pathMethod], null)
+
+  if (operation === null) {
+    // return nothing if the operation does not exist
+    return
+  }
+
+  const [path] = pathMethod
+
+  const operationConsumes = operation.get("consumes", null)
+  const pathItemConsumes = spec.getIn(["paths", path, "consumes"], null)
+  const globalConsumes = spec.getIn(["consumes"], null)
+
+  return operationConsumes || pathItemConsumes || globalConsumes
+}
+
 export const operationScheme = ( state, path, method ) => {
   let url = state.get("url")
   let matchResult = url.match(/^([a-z][a-z0-9+\-.]*):/)

--- a/src/core/plugins/spec/selectors.js
+++ b/src/core/plugins/spec/selectors.js
@@ -401,12 +401,6 @@ export function contentTypeValues(state, pathMethod) {
   })
 }
 
-// Get the consumes/produces by path
-export function operationConsumes(state, pathMethod) {
-  pathMethod = pathMethod || []
-  return specJsonWithResolvedSubtrees(state).getIn(["paths", ...pathMethod, "consumes"], fromJS({}))
-}
-
 // Get the currently selected produces value for an operation
 export function currentProducesFor(state, pathMethod) {
   pathMethod = pathMethod || []

--- a/test/core/plugins/spec/selectors.js
+++ b/test/core/plugins/spec/selectors.js
@@ -16,7 +16,8 @@ import {
   operationWithMeta,
   parameterWithMeta,
   parameterWithMetaByIdentity,
-  parameterInclusionSettingFor
+  parameterInclusionSettingFor,
+  consumesOptionsFor
 } from "../../../../src/core/plugins/spec/selectors"
 
 describe("spec plugin - selectors", function(){
@@ -875,6 +876,136 @@ describe("spec plugin - selectors", function(){
       })
 
       const result = producesOptionsFor(state, ["/", "get"])
+
+      expect(result.toJS()).toEqual([
+        "path-item/one",
+        "path-item/two",
+      ])
+    })
+  })
+  describe("consumesOptionsFor", function() {
+    it("should return an operation consumes value", function () {
+      const state = fromJS({
+        json: {
+          paths: {
+            "/": {
+              "get": {
+                description: "my operation",
+                consumes: [
+                  "operation/one",
+                  "operation/two",
+                ]
+              }
+            }
+          }
+        }
+      })
+
+      const result = consumesOptionsFor(state, ["/", "get"])
+
+      expect(result.toJS()).toEqual([
+        "operation/one",
+        "operation/two",
+      ])
+    })
+    it("should return a path item consumes value", function () {
+      const state = fromJS({
+        json: {
+          paths: {
+            "/": {
+              "get": {
+                description: "my operation",
+                consumes: [
+                  "path-item/one",
+                  "path-item/two",
+                ]
+              }
+            }
+          }
+        }
+      })
+
+      const result = consumesOptionsFor(state, ["/", "get"])
+
+      expect(result.toJS()).toEqual([
+        "path-item/one",
+        "path-item/two",
+      ])
+    })
+    it("should return a global consumes value", function () {
+      const state = fromJS({
+        json: {
+          consumes: [
+            "global/one",
+            "global/two",
+          ],
+          paths: {
+            "/": {
+              "get": {
+                description: "my operation"
+              }
+            }
+          }
+        }
+      })
+
+      const result = consumesOptionsFor(state, ["/", "get"])
+
+      expect(result.toJS()).toEqual([
+        "global/one",
+        "global/two",
+      ])
+    })
+    it("should favor an operation consumes value over a path-item value", function () {
+      const state = fromJS({
+        json: {
+          paths: {
+            "/": {
+              consumes: [
+                "path-item/one",
+                "path-item/two",
+              ],
+              "get": {
+                description: "my operation",
+                consumes: [
+                  "operation/one",
+                  "operation/two",
+                ]
+              }
+            }
+          }
+        }
+      })
+
+      const result = consumesOptionsFor(state, ["/", "get"])
+
+      expect(result.toJS()).toEqual([
+        "operation/one",
+        "operation/two",
+      ])
+    })
+    it("should favor a path-item consumes value over a global value", function () {
+      const state = fromJS({
+        json: {
+          consumes: [
+            "global/one",
+            "global/two",
+          ],
+          paths: {
+            "/": {
+              consumes: [
+                "path-item/one",
+                "path-item/two",
+              ],
+              "get": {
+                description: "my operation"
+              }
+            }
+          }
+        }
+      })
+
+      const result = consumesOptionsFor(state, ["/", "get"])
 
       expect(result.toJS()).toEqual([
         "path-item/one",

--- a/test/core/plugins/spec/selectors.js
+++ b/test/core/plugins/spec/selectors.js
@@ -753,7 +753,7 @@ describe("spec plugin - selectors", function(){
     })
   })
   describe("producesOptionsFor", function() {
-    it("should return an operation consumes value", function () {
+    it("should return an operation produces value", function () {
       const state = fromJS({
         json: {
           paths: {
@@ -777,7 +777,7 @@ describe("spec plugin - selectors", function(){
         "operation/two",
       ])
     })
-    it("should return a path item consumes value", function () {
+    it("should return a path item produces value", function () {
       const state = fromJS({
         json: {
           paths: {
@@ -801,7 +801,7 @@ describe("spec plugin - selectors", function(){
         "path-item/two",
       ])
     })
-    it("should return a global consumes value", function () {
+    it("should return a global produces value", function () {
       const state = fromJS({
         json: {
           produces: [

--- a/test/core/plugins/spec/selectors.js
+++ b/test/core/plugins/spec/selectors.js
@@ -7,7 +7,6 @@ import {
   contentTypeValues,
   operationScheme,
   specJsonWithResolvedSubtrees,
-  operationConsumes,
   producesOptionsFor,
 } from "corePlugins/spec/selectors"
 
@@ -253,34 +252,6 @@ describe("spec plugin - selectors", function(){
       })
     })
 
-  })
-
-  describe("operationConsumes", function(){
-    it("should return the operationConsumes for an operation", function(){
-      // Given
-      let state = fromJS({
-        json: {
-          paths: {
-            "/one": {
-              get: {
-                consumes: [
-                  "application/xml",
-                  "application/something-else"
-                ]
-              }
-            }
-          }
-        }
-      })
-
-      // When
-      let contentTypes = operationConsumes(state, [ "/one", "get" ])
-      // Then
-      expect(contentTypes.toJS()).toEqual([
-        "application/xml",
-        "application/something-else"
-      ])
-    })
   })
 
   describe("operationScheme", function(){

--- a/test/core/plugins/spec/selectors.js
+++ b/test/core/plugins/spec/selectors.js
@@ -7,7 +7,8 @@ import {
   contentTypeValues,
   operationScheme,
   specJsonWithResolvedSubtrees,
-  operationConsumes
+  operationConsumes,
+  producesOptionsFor,
 } from "corePlugins/spec/selectors"
 
 import Petstore from "./assets/petstore.json"
@@ -749,6 +750,136 @@ describe("spec plugin - selectors", function(){
       const result = parameterInclusionSettingFor(state, ["/", "get"], "param", "query")
 
       expect(result).toEqual(true)
+    })
+  })
+  describe("producesOptionsFor", function() {
+    it("should return an operation consumes value", function () {
+      const state = fromJS({
+        json: {
+          paths: {
+            "/": {
+              "get": {
+                description: "my operation",
+                produces: [
+                  "operation/one",
+                  "operation/two",
+                ]
+              }
+            }
+          }
+        }
+      })
+
+      const result = producesOptionsFor(state, ["/", "get"])
+
+      expect(result.toJS()).toEqual([
+        "operation/one",
+        "operation/two",
+      ])
+    })
+    it("should return a path item consumes value", function () {
+      const state = fromJS({
+        json: {
+          paths: {
+            "/": {
+              "get": {
+                description: "my operation",
+                produces: [
+                  "path-item/one",
+                  "path-item/two",
+                ]
+              }
+            }
+          }
+        }
+      })
+
+      const result = producesOptionsFor(state, ["/", "get"])
+
+      expect(result.toJS()).toEqual([
+        "path-item/one",
+        "path-item/two",
+      ])
+    })
+    it("should return a global consumes value", function () {
+      const state = fromJS({
+        json: {
+          produces: [
+            "global/one",
+            "global/two",
+          ],
+          paths: {
+            "/": {
+              "get": {
+                description: "my operation"
+              }
+            }
+          }
+        }
+      })
+
+      const result = producesOptionsFor(state, ["/", "get"])
+
+      expect(result.toJS()).toEqual([
+        "global/one",
+        "global/two",
+      ])
+    })
+    it("should favor an operation produces value over a path-item value", function () {
+      const state = fromJS({
+        json: {
+          paths: {
+            "/": {
+              produces: [
+                "path-item/one",
+                "path-item/two",
+              ],
+              "get": {
+                description: "my operation",
+                produces: [
+                  "operation/one",
+                  "operation/two",
+                ]
+              }
+            }
+          }
+        }
+      })
+
+      const result = producesOptionsFor(state, ["/", "get"])
+
+      expect(result.toJS()).toEqual([
+        "operation/one",
+        "operation/two",
+      ])
+    })
+    it("should favor a path-item produces value over a global value", function () {
+      const state = fromJS({
+        json: {
+          produces: [
+            "global/one",
+            "global/two",
+          ],
+          paths: {
+            "/": {
+              produces: [
+                "path-item/one",
+                "path-item/two",
+              ],
+              "get": {
+                description: "my operation"
+              }
+            }
+          }
+        }
+      })
+
+      const result = producesOptionsFor(state, ["/", "get"])
+
+      expect(result.toJS()).toEqual([
+        "path-item/one",
+        "path-item/two",
+      ])
     })
   })
 })

--- a/test/e2e-cypress/static/documents/bugs/5043/status.yaml
+++ b/test/e2e-cypress/static/documents/bugs/5043/status.yaml
@@ -1,0 +1,26 @@
+---
+paths:
+  findByStatus:
+    get:
+      tags:
+      - "pet"
+      summary: "Finds Pets by status"
+      description: "Multiple status values can be provided with comma separated strings"
+      operationId: "findPetsByStatus"
+      parameters:
+      - name: "status"
+        in: "query"
+        description: "Status values that need to be considered for filter"
+        required: true
+        type: "array"
+        items:
+          type: "string"
+          enum:
+          - "available"
+          - "pending"
+          - "sold"
+          default: "available"
+        collectionFormat: "multi"
+      responses:
+        200:
+          description: ok

--- a/test/e2e-cypress/static/documents/bugs/5043/status.yaml
+++ b/test/e2e-cypress/static/documents/bugs/5043/status.yaml
@@ -9,18 +9,9 @@ paths:
       operationId: "findPetsByStatus"
       parameters:
       - name: "status"
-        in: "query"
-        description: "Status values that need to be considered for filter"
-        required: true
-        type: "array"
-        items:
-          type: "string"
-          enum:
-          - "available"
-          - "pending"
-          - "sold"
-          default: "available"
-        collectionFormat: "multi"
+        in: "body"
+        schema:
+          type: string
       responses:
         200:
           description: ok

--- a/test/e2e-cypress/static/documents/bugs/5043/swagger.yaml
+++ b/test/e2e-cypress/static/documents/bugs/5043/swagger.yaml
@@ -1,0 +1,42 @@
+swagger: "2.0"
+info:
+  description: "This is a sample server Petstore server.  You can find out more about     Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).      For this sample, you can use the api key `special-key` to test the authorization     filters."
+  version: "1.0.0"
+  title: "Swagger Petstore"
+  termsOfService: "http://swagger.io/terms/"
+  contact:
+    email: "apiteam@swagger.io"
+  license:
+    name: "Apache 2.0"
+    url: "http://www.apache.org/licenses/LICENSE-2.0.html"
+host: "petstore.swagger.io"
+basePath: "/v2"
+produces:
+  - application/json
+  - application/xml
+  - text/csv
+consumes:
+  - application/json
+schemes:
+- "https"
+- "http"
+paths:
+  /pet:
+    post:
+      tags:
+      - "pet"
+      summary: "Add a new pet to the store"
+      description: ""
+      operationId: "addPet"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "Pet object that needs to be added to the store"
+        required: true
+        schema:
+          $ref: "#/definitions/Pet"
+      responses:
+        405:
+          description: "Invalid input"
+  /pet/findByStatus:
+    $ref: "status.yaml#/paths/findByStatus"

--- a/test/e2e-cypress/static/documents/bugs/5043/swagger.yaml
+++ b/test/e2e-cypress/static/documents/bugs/5043/swagger.yaml
@@ -17,6 +17,8 @@ produces:
   - text/csv
 consumes:
   - application/json
+  - application/xml
+  - text/csv
 schemes:
 - "https"
 - "http"

--- a/test/e2e-cypress/tests/bugs/5043.js
+++ b/test/e2e-cypress/tests/bugs/5043.js
@@ -1,0 +1,18 @@
+import repeat from "lodash/repeat"
+
+describe("#5043: path-level $ref path items should inherit global consumes", () => {
+  it("should render consumes options correctly", () => {
+    cy
+      .visit("/?url=/documents/bugs/5043/swagger.yaml")
+      .get("#operations-pet-findPetsByStatus")
+      .click()
+      .get(".try-out__btn")
+      .click()
+      .get(".content-type")
+      .contains("application/json")
+      .get(".content-type")
+      .contains("application/xml")
+      .get(".content-type")
+      .contains("text/csv")
+  })
+})

--- a/test/e2e-cypress/tests/bugs/5043.js
+++ b/test/e2e-cypress/tests/bugs/5043.js
@@ -1,6 +1,6 @@
 import repeat from "lodash/repeat"
 
-describe("#5043: path-level $ref path items should inherit global consumes", () => {
+describe("#5043: path-level $ref path items should inherit global consumes/produces", () => {
   it("should render consumes options correctly", () => {
     cy
       .visit("/?url=/documents/bugs/5043/swagger.yaml")
@@ -13,6 +13,20 @@ describe("#5043: path-level $ref path items should inherit global consumes", () 
       .get(".content-type")
       .contains("application/xml")
       .get(".content-type")
+      .contains("text/csv")
+  })
+  it("should render produces options correctly", () => {
+    cy
+      .visit("/?url=/documents/bugs/5043/swagger.yaml")
+      .get("#operations-pet-findPetsByStatus")
+      .click()
+      .get(".try-out__btn")
+      .click()
+      .get(".body-param-content-type select")
+      .contains("application/json")
+      .get(".body-param-content-type select")
+      .contains("application/xml")
+      .get(".body-param-content-type select")
       .contains("text/csv")
   })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

This PR introduces new spec selectors that correctly inherit `consumes` and `produces` values across resolved subtrees in state, according to OpenAPI 2.0's inheritance rules.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes #5043.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I added unit tests for the new selectors, and Cypress integration tests for the specific case mentioned in #5043.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [ ] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.