### PR TITLE
feature: add individual CSS classes to info items

### DIFF
--- a/src/core/components/info.jsx
+++ b/src/core/components/info.jsx
@@ -38,7 +38,7 @@ class Contact extends React.Component {
     const Link = getComponent("Link")
 
     return (
-      <div>
+      <div className="info__contact">
         { url && <div><Link href={ sanitizeUrl(url) } target="_blank">{ name } - Website</Link></div> }
         { email &&
           <Link href={sanitizeUrl(`mailto:${email}`)}>
@@ -66,7 +66,7 @@ class License extends React.Component {
     let url = license.get("url")
 
     return (
-      <div>
+      <div className="info__license">
         {
           url ? <Link target="_blank" href={ sanitizeUrl(url) }>{ name }</Link>
         : <span>{ name }</span>
@@ -133,7 +133,7 @@ export default class Info extends React.Component {
         </div>
 
         {
-          termsOfService && <div>
+          termsOfService && <div className="info__tos">
             <Link target="_blank" href={ sanitizeUrl(termsOfService) }>Terms of service</Link>
           </div>
         }
@@ -141,7 +141,7 @@ export default class Info extends React.Component {
         {contact && contact.size ? <Contact getComponent={getComponent} data={ contact } /> : null }
         {license && license.size ? <License getComponent={getComponent} license={ license } /> : null }
         { externalDocsUrl ?
-            <Link target="_blank" href={sanitizeUrl(externalDocsUrl)}>{externalDocsDescription || externalDocsUrl}</Link>
+            <Link className="info__extdocs" target="_blank" href={sanitizeUrl(externalDocsUrl)}>{externalDocsDescription || externalDocsUrl}</Link>
         : null }
 
       </div>


### PR DESCRIPTION
### Description
This makes it easier to style them individually or retrieve the elements in user scripts. We’re not assigning any style to those CSS classes, just the classes to the elements; because some of them are optional, they cannot be retrieved by (or styled with) an nth-child scheme.


### Motivation and Context
This makes user CSS like the following work better:

    /* these will break once we use externalDocsUrl */
    .info > :last-child:before {
        content:"Licence: ";
    }
    .info > :nth-last-child(2) > div:before {
        content:"Developer: ";
    }

The goal behind this is to allow the user some minimal styling in the `index.htm` file that runs swagger-ui-dist, without having to learn just another programming language. This is the first half of this (being able to style the individual information items); the second half (being able to add a logo and have it scaled to the height of the top bar) is currently beyond my knowledge with the technologies used by swagger-ui (so we currently insert the logo before `.title`), but if you wish to help me out, implement it ☺

### How Has This Been Tested?
Not at all. I don’t know JSX.


### My PR contains... 
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [x] My changes can and should be tested manually before merging.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
