### PR TITLE
fix: tag deep link escaping inconsistencies

### DIFF
--- a/src/core/components/operation-tag.jsx
+++ b/src/core/components/operation-tag.jsx
@@ -2,7 +2,7 @@ import React from "react"
 import PropTypes from "prop-types"
 import ImPropTypes from "react-immutable-proptypes"
 import Im from "immutable"
-import { createDeepLinkPath, sanitizeUrl } from "core/utils"
+import { createDeepLinkPath, escapeDeepLinkPath, sanitizeUrl } from "core/utils"
 
 export default class OperationTag extends React.Component {
 
@@ -52,7 +52,8 @@ export default class OperationTag extends React.Component {
     let tagExternalDocsDescription = tagObj.getIn(["tagDetails", "externalDocs", "description"])
     let tagExternalDocsUrl = tagObj.getIn(["tagDetails", "externalDocs", "url"])
 
-    let isShownKey = ["operations-tag", createDeepLinkPath(tag)]
+    // let isShownKey = ["operations-tag", createDeepLinkPath(tag)]
+    let isShownKey = ["operations-tag", tag]
     let showTag = layoutSelectors.isShown(isShownKey, docExpansion === "full" || docExpansion === "list")
 
     return (
@@ -61,11 +62,14 @@ export default class OperationTag extends React.Component {
         <h4
           onClick={() => layoutActions.show(isShownKey, !showTag)}
           className={!tagDescription ? "opblock-tag no-desc" : "opblock-tag" }
-          id={isShownKey.join("-")}>
+          id={isShownKey.map(v => escapeDeepLinkPath(v)).join("-")}
+          data-tag={tag}
+          data-is-open={showTag}
+          >
           <DeepLink
             enabled={isDeepLinkingEnabled}
             isShown={showTag}
-            path={tag}
+            path={createDeepLinkPath(tag)}
             text={tag} />
           { !tagDescription ? <small></small> :
             <small>

--- a/src/core/components/operation-tag.jsx
+++ b/src/core/components/operation-tag.jsx
@@ -52,7 +52,6 @@ export default class OperationTag extends React.Component {
     let tagExternalDocsDescription = tagObj.getIn(["tagDetails", "externalDocs", "description"])
     let tagExternalDocsUrl = tagObj.getIn(["tagDetails", "externalDocs", "url"])
 
-    // let isShownKey = ["operations-tag", createDeepLinkPath(tag)]
     let isShownKey = ["operations-tag", tag]
     let showTag = layoutSelectors.isShown(isShownKey, docExpansion === "full" || docExpansion === "list")
 

--- a/test/e2e-cypress/tests/features/deep-linking.js
+++ b/test/e2e-cypress/tests/features/deep-linking.js
@@ -3,7 +3,7 @@ describe("Deep linking feature", () => {
     const swagger2BaseUrl = "/?deepLinking=true&url=/documents/features/deep-linking.swagger.yaml"
 
     describe("regular Operation", () => {
-      BaseDeeplinkTestFactory({
+      OperationDeeplinkTestFactory({
         baseUrl: swagger2BaseUrl,
         elementToGet: ".opblock-get",
         correctElementId: "operations-myTag-myOperation",
@@ -16,7 +16,7 @@ describe("Deep linking feature", () => {
       const elementToGet = ".opblock-post"
       const correctFragment = "#/my%20Tag/my%20Operation"
       
-      BaseDeeplinkTestFactory({
+      OperationDeeplinkTestFactory({
         baseUrl: swagger2BaseUrl,
         elementToGet,
         correctElementId: "operations-my_Tag-my_Operation",
@@ -42,7 +42,7 @@ describe("Deep linking feature", () => {
     })
 
     describe("Operation with underscores in tag+id", () => {
-      BaseDeeplinkTestFactory({
+      OperationDeeplinkTestFactory({
         baseUrl: swagger2BaseUrl,
         elementToGet: ".opblock-patch",
         correctElementId: "operations-underscore_Tag-underscore_Operation",
@@ -52,7 +52,7 @@ describe("Deep linking feature", () => {
     })
 
     describe("Operation with UTF-16 characters", () => {
-      BaseDeeplinkTestFactory({
+      OperationDeeplinkTestFactory({
         baseUrl: swagger2BaseUrl,
         elementToGet: ".opblock-head",
         correctElementId: "operations-шеллы-пошел",
@@ -62,7 +62,7 @@ describe("Deep linking feature", () => {
     })
 
     describe("Operation with no operationId", () => {
-      BaseDeeplinkTestFactory({
+      OperationDeeplinkTestFactory({
         baseUrl: swagger2BaseUrl,
         elementToGet: ".opblock-put",
         correctElementId: "operations-tagTwo-put_noOperationId",
@@ -72,7 +72,7 @@ describe("Deep linking feature", () => {
     })
 
     describe("regular Tag", () => {
-      BaseDeeplinkTestFactory({
+      TagDeeplinkTestFactory({
         isTagCase: true,
         baseUrl: swagger2BaseUrl,
         elementToGet: `.opblock-tag[data-tag="myTag"][data-is-open="true"]`,
@@ -83,7 +83,7 @@ describe("Deep linking feature", () => {
     })
 
     describe("Tag with whitespace", () => {
-      BaseDeeplinkTestFactory({
+      TagDeeplinkTestFactory({
         isTagCase: true,
         baseUrl: swagger2BaseUrl,
         elementToGet: `.opblock-tag[data-tag="my Tag"][data-is-open="true"]`,
@@ -97,7 +97,7 @@ describe("Deep linking feature", () => {
     const openAPI3BaseUrl = "/?deepLinking=true&url=/documents/features/deep-linking.openapi.yaml"
 
     describe("regular Operation", () => {
-      BaseDeeplinkTestFactory({
+      OperationDeeplinkTestFactory({
         baseUrl: openAPI3BaseUrl,
         elementToGet: ".opblock-get",
         correctElementId: "operations-myTag-myOperation",
@@ -110,7 +110,7 @@ describe("Deep linking feature", () => {
       const elementToGet = ".opblock-post"
       const correctFragment = "#/my%20Tag/my%20Operation"
       
-      BaseDeeplinkTestFactory({
+      OperationDeeplinkTestFactory({
         baseUrl: openAPI3BaseUrl,
         elementToGet: ".opblock-post",
         correctElementId: "operations-my_Tag-my_Operation",
@@ -137,7 +137,7 @@ describe("Deep linking feature", () => {
     })
 
     describe("Operation with underscores in tag+id", () => {
-      BaseDeeplinkTestFactory({
+      OperationDeeplinkTestFactory({
         baseUrl: openAPI3BaseUrl,
         elementToGet: ".opblock-patch",
         correctElementId: "operations-underscore_Tag-underscore_Operation",
@@ -147,7 +147,7 @@ describe("Deep linking feature", () => {
     })
 
     describe("Operation with UTF-16 characters", () => {
-      BaseDeeplinkTestFactory({
+      OperationDeeplinkTestFactory({
         baseUrl: openAPI3BaseUrl,
         elementToGet: ".opblock-head",
         correctElementId: "operations-шеллы-пошел",
@@ -157,7 +157,7 @@ describe("Deep linking feature", () => {
     })
 
     describe("Operation with no operationId", () => {
-      BaseDeeplinkTestFactory({
+      OperationDeeplinkTestFactory({
         baseUrl: openAPI3BaseUrl,
         elementToGet: ".opblock-put",
         correctElementId: "operations-tagTwo-put_noOperationId",
@@ -165,10 +165,32 @@ describe("Deep linking feature", () => {
         correctHref: "#/tagTwo/put_noOperationId"
       })
     })
+
+    describe("regular Tag", () => {
+      TagDeeplinkTestFactory({
+        isTagCase: true,
+        baseUrl: openAPI3BaseUrl,
+        elementToGet: `.opblock-tag[data-tag="myTag"][data-is-open="true"]`,
+        correctElementId: "operations-tag-myTag",
+        correctFragment: "#/myTag",
+        correctHref: "#/myTag"
+      })
+    })
+
+    describe("Tag with whitespace", () => {
+      TagDeeplinkTestFactory({
+        isTagCase: true,
+        baseUrl: openAPI3BaseUrl,
+        elementToGet: `.opblock-tag[data-tag="my Tag"][data-is-open="true"]`,
+        correctElementId: "operations-tag-my_Tag",
+        correctFragment: "#/my%20Tag",
+        correctHref: "#/my%20Tag"
+      })
+    })
   })
 })
 
-function OperationDeeplinkTestFactory({ baseUrl, elementToGet, correctElementId, correctFragment, correctHref, isTagCase = false }) {  
+function OperationDeeplinkTestFactory({ baseUrl, elementToGet, correctElementId, correctFragment, correctHref }) {  
   it("should generate a correct element ID", () => {
     cy.visit(baseUrl)
       .get(elementToGet)
@@ -193,7 +215,7 @@ function OperationDeeplinkTestFactory({ baseUrl, elementToGet, correctElementId,
       .should("have.deep.property", "location.hash", correctFragment)
   })
 
-  it("should expand the content when reloaded", () => {
+  it("should expand the operation when reloaded", () => {
     cy.visit(`${baseUrl}${correctFragment}`)
       .get(`${elementToGet}.is-open`)
       .should("exist")
@@ -243,7 +265,7 @@ function TagDeeplinkTestFactory({ baseUrl, elementToGet, correctElementId, corre
       .should("have.attr", "href", correctHref)
   })
 
-  it("should expand the content when reloaded", () => {
+  it("should expand the tag when reloaded", () => {
     cy.visit(`${baseUrl}${correctFragment}`)
       .get(`${elementToGet}[data-is-open="true"]`)
       .should("exist")

--- a/test/e2e-cypress/tests/features/deep-linking.js
+++ b/test/e2e-cypress/tests/features/deep-linking.js
@@ -71,16 +71,25 @@ describe("Deep linking feature", () => {
       })
     })
 
-    describe("regular Operation with `docExpansion: none` enabled", function() {
-      it("should expand a tag", () => {
-        cy.visit(`${swagger2BaseUrl}&docExpansion=none#/myTag`)
-          .get(`.opblock-tag-section.is-open`)
-          .should("have.length", 1)
+    describe("regular Tag", () => {
+      BaseDeeplinkTestFactory({
+        isTagCase: true,
+        baseUrl: swagger2BaseUrl,
+        elementToGet: `.opblock-tag[data-tag="myTag"][data-is-open="true"]`,
+        correctElementId: "operations-tag-myTag",
+        correctFragment: "#/myTag",
+        correctHref: "#/myTag"
       })
-      it("should expand an operation", () => {
-        cy.visit(`${swagger2BaseUrl}&docExpansion=none#/myTag/myOperation`)
-          .get(`.opblock.is-open`)
-          .should("have.length", 1)
+    })
+
+    describe("Tag with whitespace", () => {
+      BaseDeeplinkTestFactory({
+        isTagCase: true,
+        baseUrl: swagger2BaseUrl,
+        elementToGet: `.opblock-tag[data-tag="my Tag"][data-is-open="true"]`,
+        correctElementId: "operations-tag-my_Tag",
+        correctFragment: "#/my%20Tag",
+        correctHref: "#/my%20Tag"
       })
     })
   })
@@ -156,23 +165,10 @@ describe("Deep linking feature", () => {
         correctHref: "#/tagTwo/put_noOperationId"
       })
     })
-
-    describe("regular Operation with `docExpansion: none` enabled", function () {
-      it("should expand a tag", () => {
-        cy.visit(`${openAPI3BaseUrl}&docExpansion=none#/myTag`)
-          .get(`.opblock-tag-section.is-open`)
-          .should("have.length", 1)
-      })
-      it("should expand an operation", () => {
-        cy.visit(`${openAPI3BaseUrl}&docExpansion=none#/myTag/myOperation`)
-          .get(`.opblock.is-open`)
-          .should("have.length", 1)
-      })
-    })
   })
 })
 
-function BaseDeeplinkTestFactory({ baseUrl, elementToGet, correctElementId, correctFragment, correctHref }) {
+function OperationDeeplinkTestFactory({ baseUrl, elementToGet, correctElementId, correctFragment, correctHref, isTagCase = false }) {  
   it("should generate a correct element ID", () => {
     cy.visit(baseUrl)
       .get(elementToGet)
@@ -197,7 +193,7 @@ function BaseDeeplinkTestFactory({ baseUrl, elementToGet, correctElementId, corr
       .should("have.deep.property", "location.hash", correctFragment)
   })
 
-  it("should expand the operation when reloaded", () => {
+  it("should expand the content when reloaded", () => {
     cy.visit(`${baseUrl}${correctFragment}`)
       .get(`${elementToGet}.is-open`)
       .should("exist")
@@ -209,5 +205,61 @@ function BaseDeeplinkTestFactory({ baseUrl, elementToGet, correctElementId, corr
       .should("exist")
       .window()
       .should("have.deep.property", "location.hash", correctFragment)
+  })
+
+  it("should expand a tag with docExpansion disabled", () => {
+    cy.visit(`${baseUrl}&docExpansion=none${correctFragment}`)
+      .get(`.opblock-tag-section.is-open`)
+      .should("have.length", 1)
+  })
+
+  it("should expand an operation with docExpansion disabled", () => {
+    cy.visit(`${baseUrl}&docExpansion=none${correctFragment}`)
+      .get(`.opblock.is-open`)
+      .should("have.length", 1)
+  })
+}
+
+function TagDeeplinkTestFactory({ baseUrl, elementToGet, correctElementId, correctFragment, correctHref, isTagCase = false }) {
+  it("should generate a correct element ID", () => {
+    cy.visit(baseUrl)
+      .get(elementToGet)
+      .should("have.id", correctElementId)
+  })
+
+  it("should add the correct element fragment to the URL when expanded", () => {
+    cy.visit(baseUrl)
+      .get(elementToGet)
+      .click()
+      .click() // tags need two clicks because they're expanded by default
+      .window()
+      .should("have.deep.property", "location.hash", correctFragment)
+  })
+
+  it("should provide an anchor link that has the correct fragment as href", () => {
+    cy.visit(baseUrl)
+      .get(elementToGet)
+      .find("a")
+      .should("have.attr", "href", correctHref)
+  })
+
+  it("should expand the content when reloaded", () => {
+    cy.visit(`${baseUrl}${correctFragment}`)
+      .get(`${elementToGet}[data-is-open="true"]`)
+      .should("exist")
+  })
+
+  it("should retain the correct fragment when reloaded", () => {
+    cy.visit(`${baseUrl}${correctFragment}`)
+      .reload()
+      .should("exist")
+      .window()
+      .should("have.deep.property", "location.hash", correctFragment)
+  })
+
+  it("should expand a tag with docExpansion disabled", () => {
+    cy.visit(`${baseUrl}&docExpansion=none${correctFragment}`)
+      .get(`.opblock-tag-section.is-open`)
+      .should("have.length", 1)
   })
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

This PR updates `operation-tag.jsx` to bring tag deep linking in line with the operation-level implementation's escaping and spacing.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes #5047.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I added many new automated tests, plus manually tested against the deep linking definitions and the repro definition provided in #5047.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.