### PR TITLE
Added markdown for header descriptions as per specifications

### DIFF
--- a/src/core/components/headers.jsx
+++ b/src/core/components/headers.jsx
@@ -5,16 +5,16 @@ import Im from "immutable"
 const propStyle = { color: "#999", fontStyle: "italic" }
 
 export default class Headers extends React.Component {
-
   static propTypes = {
     headers: PropTypes.object.isRequired,
     getComponent: PropTypes.func.isRequired
   };
 
   render() {
-
     let { headers, getComponent } = this.props
+
     const Property = getComponent("Property")
+    const Markdown = getComponent("Markdown")
 
     if ( !headers || !headers.size )
       return null
@@ -36,12 +36,16 @@ export default class Headers extends React.Component {
               if(!Im.Map.isMap(header)) {
                 return null
               }
+
+              const description = header.get( "description" );
               const type = header.getIn(["schema"]) ? header.getIn(["schema", "type"]) : header.getIn(["type"])
               const schemaExample = header.getIn(["schema", "example"])
 
               return (<tr key={ key }>
                 <td className="header-col">{ key }</td>
-                <td className="header-col">{ header.get( "description" ) }</td>
+                <td className="header-col">{
+                  !description ? null : <Markdown source={ description } />
+                }</td>
                 <td className="header-col">{ type } { schemaExample ? <Property propKey={ "Example" } propVal={ schemaExample } propStyle={ propStyle } /> : null }</td>
               </tr>)
             }).toArray()


### PR DESCRIPTION
### Description
Markdown support for Response Headers was not implemented as per the specifications

https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#header-object
which subclasses:
https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#parameterObject

https://swagger.io/specification/#headerObject
which subclasses
https://swagger.io/specification/#parameterObject

### Motivation and Context
I wanted to use markdown to create a link from a response header to the `/#component/schemas` object that the header contained

### How Has This Been Tested?
The change was very simple and I implemented and built the code following examples in other modules where the `Markdown` component is used.

## Checklist
### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
