### PR TITLE
Allowing authorizationUrl to have a pre-defined response_type

### DIFF
--- a/src/core/oauth2-authorize.js
+++ b/src/core/oauth2-authorize.js
@@ -6,9 +6,7 @@ export default function authorize ( { auth, authActions, errActions, configs, au
   let flow = schema.get("flow")
   let query = []
   let authorizationUrl = schema.get("authorizationUrl")
-  let responseTypeFound = authorizationUrl ?
-    authorizationUrl.indexOf('?response_type=') > 0 || authorizationUrl.indexOf('&response_type') > 0 :
-    false;
+  let responseTypeFound = authorizationUrl ? authorizationUrl.indexOf("?response_type=") > 0 || authorizationUrl.indexOf("&response_type") > 0 : false
 
   switch (flow) {
     case "password":

--- a/src/core/oauth2-authorize.js
+++ b/src/core/oauth2-authorize.js
@@ -5,6 +5,10 @@ export default function authorize ( { auth, authActions, errActions, configs, au
   let { schema, scopes, name, clientId } = auth
   let flow = schema.get("flow")
   let query = []
+  let authorizationUrl = schema.get("authorizationUrl")
+  let responseTypeFound = authorizationUrl ?
+    authorizationUrl.indexOf('?response_type=') > 0 || authorizationUrl.indexOf('&response_type') > 0 :
+    false;
 
   switch (flow) {
     case "password":
@@ -16,11 +20,15 @@ export default function authorize ( { auth, authActions, errActions, configs, au
       return
 
     case "accessCode":
-      query.push("response_type=code")
+      if (!responseTypeFound) {
+        query.push("response_type=code")
+      }
       break
 
     case "implicit":
-      query.push("response_type=token")
+      if (!responseTypeFound) {
+        query.push("response_type=token")
+      }
       break
 
     case "clientCredentials":
@@ -30,7 +38,9 @@ export default function authorize ( { auth, authActions, errActions, configs, au
 
     case "authorizationCode":
       // OAS3
-      query.push("response_type=code")
+      if (!responseTypeFound) {
+        query.push("response_type=code")
+      }
       break
   }
 
@@ -74,7 +84,6 @@ export default function authorize ( { auth, authActions, errActions, configs, au
     }
   }
 
-  let authorizationUrl = schema.get("authorizationUrl")
   let url = [authorizationUrl, query.join("&")].join(authorizationUrl.indexOf("?") === -1 ? "?" : "&")
 
   // pass action authorizeOauth2 and authentication data through window


### PR DESCRIPTION
This change would allow the user to include their own pre-defined response_type in the authorizationUrl, so that they aren't forced to use the response_type that is defined by swagger-ui based on the flow.
