### PR TITLE
copy whole directory with swagger definitions

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -30,7 +30,9 @@ fi
 replace_in_index myApiKeyXXXX123456789 $API_KEY
 
 if [[ -f $SWAGGER_JSON ]]; then
-  cp -s $SWAGGER_JSON $NGINX_ROOT
+  cp -s $(dirname $SWAGGER_JSON)/*.yml $NGINX_ROOT
+  cp -s $(dirname $SWAGGER_JSON)/*.yaml $NGINX_ROOT
+  cp -s $(dirname $SWAGGER_JSON)/*.json $NGINX_ROOT
   REL_PATH="./$(basename $SWAGGER_JSON)"
   sed -i "s|https://petstore.swagger.io/v2/swagger.json|$REL_PATH|g" $INDEX_FILE
   sed -i "s|http://example.com/api|$REL_PATH|g" $INDEX_FILE

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -30,9 +30,7 @@ fi
 replace_in_index myApiKeyXXXX123456789 $API_KEY
 
 if [[ -f $SWAGGER_JSON ]]; then
-  cp -s $(dirname $SWAGGER_JSON)/*.yml $NGINX_ROOT
-  cp -s $(dirname $SWAGGER_JSON)/*.yaml $NGINX_ROOT
-  cp -s $(dirname $SWAGGER_JSON)/*.json $NGINX_ROOT
+  ln -s $(dirname $SWAGGER_JSON)/* $NGINX_ROOT
   REL_PATH="./$(basename $SWAGGER_JSON)"
   sed -i "s|https://petstore.swagger.io/v2/swagger.json|$REL_PATH|g" $INDEX_FILE
   sed -i "s|http://example.com/api|$REL_PATH|g" $INDEX_FILE


### PR DESCRIPTION
### Description
It's not possible to use docker image of swagger-ui when you want to have references in other file (check #5008 for more context)


### Motivation and Context
Fixes #5008 


### How Has This Been Tested?
I've tried out patched version locally and it worked. One caveat of using `SWAGGER_JSON` since now will be that files will be aliased to nginx folder. It might be dangerous for people who put swagger definition in root of the source code as it will expose whole source code with swagger-ui. 

Might be a better solution to introduce new argument like `SWAGGER_DEFINITION` and clearly state about aliasing. Old behavior will be preserved with `SWAGGER_JSON`. 

## Checklist

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x ] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [x ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [ ] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [x] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
