### PR TITLE
improvement: operation path + summary overflow styling

### DIFF
--- a/dev-helpers/doc.yaml
+++ b/dev-helpers/doc.yaml
@@ -1,0 +1,9 @@
+openapi: "3.0.0"
+
+paths:
+ /pet/with/a/really/long/made/up/path/that/keeps/going/and/going/and/when/will/it/ever/stop/nobody/knows/:
+    post:
+      tags:
+        - pet
+      summary: M:Microsoft.SomeNamespace.Some.Really.Long.Namespace.SomeController.MethodName(System.String,System.String,System.String,System.String,Newtonsoft.Json.Linq.JToken) 
+      description: ''

--- a/dev-helpers/doc.yaml
+++ b/dev-helpers/doc.yaml
@@ -1,9 +1,0 @@
-openapi: "3.0.0"
-
-paths:
- /pet/with/a/really/long/made/up/path/that/keeps/going/and/going/and/when/will/it/ever/stop/nobody/knows/:
-    post:
-      tags:
-        - pet
-      summary: M:Microsoft.SomeNamespace.Some.Really.Long.Namespace.SomeController.MethodName(System.String,System.String,System.String,System.String,Newtonsoft.Json.Linq.JToken) 
-      description: ''

--- a/src/core/components/operation-summary-path.jsx
+++ b/src/core/components/operation-summary-path.jsx
@@ -37,13 +37,15 @@ export default class OperationSummaryPath extends PureComponent{
     const DeepLink = getComponent( "DeepLink" )
 
     return(
-      <span className={ deprecated ? "opblock-summary-path__deprecated" : "opblock-summary-path" } onCopyCapture={this.onCopyCapture}>
-              <DeepLink
-                  enabled={isDeepLinkingEnabled}
-                  isShown={isShown}
-                  path={createDeepLinkPath(`${tag}/${operationId}`)}
-                  text={path.replace(/\//g, "\u200b/")} />
-              </span>
+      <span className={ deprecated ? "opblock-summary-path__deprecated" : "opblock-summary-path" } 
+        onCopyCapture={this.onCopyCapture}
+        data-path={path}>
+        <DeepLink
+            enabled={isDeepLinkingEnabled}
+            isShown={isShown}
+            path={createDeepLinkPath(`${tag}/${operationId}`)}
+            text={path.replace(/\//g, "\u200b/")} />
+      </span>
 
     )
   }

--- a/src/core/components/operation-summary-path.jsx
+++ b/src/core/components/operation-summary-path.jsx
@@ -12,6 +12,12 @@ export default class OperationSummaryPath extends PureComponent{
     getComponent: PropTypes.func.isRequired,
   }
 
+  onCopyCapture = (e) => {
+    // strips injected zero-width spaces (`\u200b`) from copied content
+    e.clipboardData.setData("text/plain", this.props.operationProps.get("path"))
+    e.preventDefault()
+  }
+
   render(){
     let {
       getComponent,
@@ -31,12 +37,12 @@ export default class OperationSummaryPath extends PureComponent{
     const DeepLink = getComponent( "DeepLink" )
 
     return(
-      <span className={ deprecated ? "opblock-summary-path__deprecated" : "opblock-summary-path" } >
+      <span className={ deprecated ? "opblock-summary-path__deprecated" : "opblock-summary-path" } onCopyCapture={this.onCopyCapture}>
               <DeepLink
                   enabled={isDeepLinkingEnabled}
                   isShown={isShown}
                   path={createDeepLinkPath(`${tag}/${operationId}`)}
-                  text={path} />
+                  text={path.replace(/\//g, "\u200b/")} />
               </span>
 
     )

--- a/src/style/_layout.scss
+++ b/src/style/_layout.scss
@@ -245,10 +245,9 @@
 
 
         display: flex;
-        flex: 0 3 auto;
         align-items: center;
 
-        word-break: break-all;
+        word-break: break-word;
 
         padding: 0 10px;
 
@@ -270,7 +269,9 @@
     {
         font-size: 13px;
 
-        flex: 1;
+        flex: 1 1 auto;
+
+        word-break: break-word;
 
         @include text_body();
     }

--- a/test/e2e-cypress/tests/bugs/4867.js
+++ b/test/e2e-cypress/tests/bugs/4867.js
@@ -7,8 +7,8 @@ describe("#4867: callback parameter rendering", () => {
       .contains("Callbacks")
       .click()
 
-      .get(".callbacks-container")
-      .contains("http://$request.query.url")
+      .get(".callbacks-container .opblock-summary-path")
+      .should("have.attr", "data-path", "http://$request.query.url")
       .click()
 
       .get(".parameters-container")


### PR DESCRIPTION
Fixes https://github.com/swagger-api/swagger-ui/issues/5171.

- Balances the flex characteristics of the path and summary elements
- Adds kind word wrapping that preserves words if possible
- Injects zero-width spaces into paths for better line breaks; intercepts copy events to remove the ZWSPs from paths