### PR TITLE
Add optional `id` prop to Operation component to allow overriding

### DIFF
--- a/src/core/components/operation.jsx
+++ b/src/core/components/operation.jsx
@@ -64,6 +64,7 @@ export default class Operation extends PureComponent {
     let {
       deprecated,
       isShown,
+      id,
       path,
       method,
       op,
@@ -86,6 +87,7 @@ export default class Operation extends PureComponent {
     let parameters = getList(operation, ["parameters"])
     let operationScheme = specSelectors.operationScheme(path, method)
     let isShownKey = ["operations", tag, operationId]
+    id = id || escapeDeepLinkPath(isShownKey.join("-"))
     let extensions = getExtensions(operation)
 
     const Responses = getComponent("responses")
@@ -111,7 +113,7 @@ export default class Operation extends PureComponent {
     let onChangeKey = [ path, method ] // Used to add values to _this_ operation ( indexed by path and method )
 
     return (
-        <div className={deprecated ? "opblock opblock-deprecated" : isShown ? `opblock opblock-${method} is-open` : `opblock opblock-${method}`} id={escapeDeepLinkPath(isShownKey.join("-"))} >
+        <div className={deprecated ? "opblock opblock-deprecated" : isShown ? `opblock opblock-${method} is-open` : `opblock opblock-${method}`} id={id} >
         <OperationSummary operationProps={operationProps} toggleShown={toggleShown} getComponent={getComponent} authActions={authActions} authSelectors={authSelectors} specPath={specPath} />
           <Collapse isOpened={isShown}>
             <div className="opblock-body">

--- a/src/core/components/operation.jsx
+++ b/src/core/components/operation.jsx
@@ -14,6 +14,7 @@ export default class Operation extends PureComponent {
     response: PropTypes.instanceOf(Iterable),
     request: PropTypes.instanceOf(Iterable),
 
+    id: PropTypes.string,
     toggleShown: PropTypes.func.isRequired,
     onTryoutClick: PropTypes.func.isRequired,
     onCancelClick: PropTypes.func.isRequired,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This is being requested to be able add custom DOM `id` to Operation component
Main motivation relates to automated tests that use `id` in X-Paths

### Description
<!--- Describe your changes in detail -->
In Operation component `src/core/components/operation.jsx`...
– Added prop to Operation component `id`, which is optional
– If `id` is passed, it used; if not legacy format is maintained based on `isShownKey`

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
DOM `id`s are used in automated testing; being tied directly to isShownKey is too restrictive.

<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
This was tested on build running locally (`npm run dev`).
When no `id` prop exists, feature works as expected.
When `id:{"customId"} was passed, the `id` on the element was checked

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->



### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
