### PR TITLE
improvement: expose docExpansion setting as a prop in swagger-ui-react

### DIFF
--- a/flavors/swagger-ui-react/README.md
+++ b/flavors/swagger-ui-react/README.md
@@ -65,7 +65,7 @@ or a Promise that resolves to a request object.
 A function that accepts a response object, and returns either a response object
 or a Promise that resolves to a response object.
 
-#### `initalDocExpansion`: PropTypes.oneOf(['list', 'full', 'none'])
+#### `docExpansion`: PropTypes.oneOf(['list', 'full', 'none'])
 
 Controls the default expansion setting for the operations and tags. It can be 'list' (expands only the tags), 'full' (expands the tags and operations) or 'none' (expands nothing). The default value is 'list'.
 
@@ -74,6 +74,7 @@ Controls the default expansion setting for the operations and tags. It can be 'l
 ## Limitations
 
 * Not all configuration bindings are available.
+* Some props are only applied on mount, and cannot be updated reliably.
 * OAuth redirection handling is not supported.
 * Topbar/Standalone mode is not supported.
 * Custom plugins are not supported.

--- a/flavors/swagger-ui-react/README.md
+++ b/flavors/swagger-ui-react/README.md
@@ -69,7 +69,7 @@ or a Promise that resolves to a response object.
 
 Controls the default expansion setting for the operations and tags. It can be 'list' (expands only the tags), 'full' (expands the tags and operations) or 'none' (expands nothing). The default value is 'list'.
 
-⚠️ This prop is only applied once on mount. Changes to this prop's value will not be propagated to the underlying Swagger UI instance. 
+⚠️ This prop is currently only applied once, on mount. Changes to this prop's value will not be propagated to the underlying Swagger UI instance. A future version of this module will remove this limitation, and the change will not be considered a breaking change.
 
 ## Limitations
 

--- a/flavors/swagger-ui-react/README.md
+++ b/flavors/swagger-ui-react/README.md
@@ -69,7 +69,7 @@ or a Promise that resolves to a response object.
 
 Controls the default expansion setting for the operations and tags. It can be 'list' (expands only the tags), 'full' (expands the tags and operations) or 'none' (expands nothing). The default value is 'list'.
 
-⚠️ This prop is only applied on mount, subsequent changes to this prop will not be applied. 
+⚠️ This prop is only applied once on mount. Changes to this prop's value will not be propagated to the underlying Swagger UI instance. 
 
 ## Limitations
 

--- a/flavors/swagger-ui-react/README.md
+++ b/flavors/swagger-ui-react/README.md
@@ -65,6 +65,12 @@ or a Promise that resolves to a request object.
 A function that accepts a response object, and returns either a response object
 or a Promise that resolves to a response object.
 
+#### `initalDocExpansion`: PropTypes.oneOf(['list', 'full', 'none'])
+
+Controls the default expansion setting for the operations and tags. It can be 'list' (expands only the tags), 'full' (expands the tags and operations) or 'none' (expands nothing). The default value is 'list'.
+
+⚠️ This prop is only applied on mount, subsequent changes to this prop will not be applied. 
+
 ## Limitations
 
 * Not all configuration bindings are available.

--- a/flavors/swagger-ui-react/index.js
+++ b/flavors/swagger-ui-react/index.js
@@ -16,6 +16,7 @@ export default class SwaggerUI extends React.Component {
       requestInterceptor: this.requestInterceptor,
       responseInterceptor: this.responseInterceptor,
       onComplete: this.onComplete,
+      docExpansion: this.props.initalDocExpansion,
     })
 
     this.system = ui
@@ -80,4 +81,5 @@ SwaggerUI.propTypes = {
   requestInterceptor: PropTypes.func,
   responseInterceptor: PropTypes.func,
   onComplete: PropTypes.func,
+  initalDocExpansion: PropTypes.oneOf(['list', 'full', 'none']),
 }

--- a/flavors/swagger-ui-react/index.js
+++ b/flavors/swagger-ui-react/index.js
@@ -16,7 +16,7 @@ export default class SwaggerUI extends React.Component {
       requestInterceptor: this.requestInterceptor,
       responseInterceptor: this.responseInterceptor,
       onComplete: this.onComplete,
-      docExpansion: this.props.initalDocExpansion,
+      docExpansion: this.props.docExpansion,
     })
 
     this.system = ui
@@ -81,5 +81,5 @@ SwaggerUI.propTypes = {
   requestInterceptor: PropTypes.func,
   responseInterceptor: PropTypes.func,
   onComplete: PropTypes.func,
-  initalDocExpansion: PropTypes.oneOf(['list', 'full', 'none']),
+  docExpansion: PropTypes.oneOf(['list', 'full', 'none']),
 }


### PR DESCRIPTION
### Description
Adds a `initialDocExpansion` prop to swagger-ui-react which acts a value for swagger-ui's docExpansion configuration setting.

### Motivation and Context
I needed to be able to set docExpansion to "full" so that my APIs swagger-ui-react was fully expanded by default. This allows that through an `initialDocExpansion` prop. I've added the "initial" prefix to re-enforce that this prop is only applied on mount.

### How Has This Been Tested?
Manually added the same changes to the transpiled JS in the swagger-ui-react npm package. Correct behaviour observed.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.
> The new prop is not marked as required, if omitted `swagger-ui`'s default value (`list`) will kick in (as per current behaviour).

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [x] My changes require a change to the project documentation.
- [x] If yes to above: I have updated the documentation accordingly.
> Just the `swagger-ui-react` readme.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
> There is no testing in place for `swagger-ui-react` yet.