### PR TITLE
Handle relative urls for oauth authorization

### DIFF
--- a/src/core/components/auth/oauth2.jsx
+++ b/src/core/components/auth/oauth2.jsx
@@ -11,6 +11,7 @@ export default class Oauth2 extends React.Component {
     authSelectors: PropTypes.object.isRequired,
     authActions: PropTypes.object.isRequired,
     errSelectors: PropTypes.object.isRequired,
+    oas3Selectors: PropTypes.object.isRequired,
     specSelectors: PropTypes.object.isRequired,
     errActions: PropTypes.object.isRequired,
     getConfigs: PropTypes.any
@@ -47,12 +48,19 @@ export default class Oauth2 extends React.Component {
   }
 
   authorize =() => {
-    let { authActions, errActions, getConfigs, authSelectors } = this.props
+    let { authActions, errActions, getConfigs, authSelectors, oas3Selectors } = this.props
     let configs = getConfigs()
     let authConfigs = authSelectors.getConfigs()
 
     errActions.clear({authId: name,type: "auth", source: "auth"})
-    oauth2Authorize({auth: this.state, authActions, errActions, configs, authConfigs })
+    oauth2Authorize({
+      auth: this.state,
+      currentServer: oas3Selectors.serverEffectiveValue(oas3Selectors.selectedServer()),
+      authActions,
+      errActions,
+      configs,
+      authConfigs
+    })
   }
 
   onScopeChange =(e) => {

--- a/src/core/oauth2-authorize.js
+++ b/src/core/oauth2-authorize.js
@@ -76,11 +76,17 @@ export default function authorize ( { auth, authActions, errActions, configs, au
   }
 
   const authorizationUrl = schema.get("authorizationUrl")
-  let sanitizedAuthorizationUrl = parseUrl(
-    sanitizeUrl(authorizationUrl),
-    currentServer,
-    true
-  ).toString()
+  let sanitizedAuthorizationUrl
+  if (currentServer) {
+    // OpenAPI 3
+    sanitizedAuthorizationUrl = parseUrl(
+      sanitizeUrl(authorizationUrl),
+      currentServer,
+      true
+    ).toString()
+  } else {
+    sanitizedAuthorizationUrl = sanitizeUrl(authorizationUrl)
+  }
   let url = [sanitizedAuthorizationUrl, query.join("&")].join(authorizationUrl.indexOf("?") === -1 ? "?" : "&")
 
   // pass action authorizeOauth2 and authentication data through window

--- a/src/core/oauth2-authorize.js
+++ b/src/core/oauth2-authorize.js
@@ -1,7 +1,8 @@
+import parseUrl from "url-parse"
 import win from "core/window"
 import { btoa, sanitizeUrl } from "core/utils"
 
-export default function authorize ( { auth, authActions, errActions, configs, authConfigs={} } ) {
+export default function authorize ( { auth, authActions, errActions, configs, authConfigs={}, currentServer } ) {
   let { schema, scopes, name, clientId } = auth
   let flow = schema.get("flow")
   let query = []
@@ -75,7 +76,11 @@ export default function authorize ( { auth, authActions, errActions, configs, au
   }
 
   const authorizationUrl = schema.get("authorizationUrl")
-  const sanitizedAuthorizationUrl = sanitizeUrl(authorizationUrl)
+  let sanitizedAuthorizationUrl = parseUrl(
+    sanitizeUrl(authorizationUrl),
+    currentServer,
+    true
+  ).toString()
   let url = [sanitizedAuthorizationUrl, query.join("&")].join(authorizationUrl.indexOf("?") === -1 ? "?" : "&")
 
   // pass action authorizeOauth2 and authentication data through window

--- a/src/core/plugins/auth/actions.js
+++ b/src/core/plugins/auth/actions.js
@@ -155,7 +155,8 @@ export const authorizeRequest = ( data ) => ( { fn, getConfigs, authActions, err
   let parsedUrl
 
   if (specSelectors.isOAS3()) {
-    parsedUrl = parseUrl(url, oas3Selectors.selectedServer(), true)
+    let finalServerUrl = oas3Selectors.serverEffectiveValue(oas3Selectors.selectedServer())
+    parsedUrl = parseUrl(url, finalServerUrl, true)
   } else {
     parsedUrl = parseUrl(url, specSelectors.url(), true)
   }

--- a/test/core/oauth2-authorize.js
+++ b/test/core/oauth2-authorize.js
@@ -8,14 +8,14 @@ describe("oauth2", function () {
 
   let mockSchema = {
     flow: "accessCode",
-    authorizationUrl: "https://testAuthorizationUrl"
+    authorizationUrl: "https://testauthorizationurl"
   }
 
   let authConfig = {
-    auth: { schema: { get: (key)=> mockSchema[key] } }, 
-    authActions: {}, 
-    errActions: {}, 
-    configs: { oauth2RedirectUrl: "" }, 
+    auth: { schema: { get: (key)=> mockSchema[key] } },
+    authActions: {},
+    errActions: {},
+    configs: { oauth2RedirectUrl: "" },
     authConfigs: {}
   }
 
@@ -25,15 +25,34 @@ describe("oauth2", function () {
       win.open = createSpy()
       oauth2Authorize(authConfig)
       expect(win.open.calls.length).toEqual(1)
-      expect(win.open.calls[0].arguments[0]).toMatch("https://testAuthorizationUrl?response_type=code&redirect_uri=&state=")
+      expect(win.open.calls[0].arguments[0]).toMatch("https://testauthorizationurl?response_type=code&redirect_uri=&state=")
+    })
+
+    it("should build authorize url relative", function() {
+      let relativeMockSchema = {
+        flow: "accessCode",
+        authorizationUrl: "/testauthorizationurl"
+      }
+      let relativeAuthConfig = {
+        auth: { schema: { get: (key)=> relativeMockSchema[key] } },
+        authActions: {},
+        errActions: {},
+        configs: { oauth2RedirectUrl: "" },
+        authConfigs: {},
+        currentServer: "https://currentserver"
+      }
+      win.open = createSpy()
+      oauth2Authorize(relativeAuthConfig)
+      expect(win.open.calls.length).toEqual(1)
+      expect(win.open.calls[0].arguments[0]).toMatch("https://currentserver/testauthorizationurl?response_type=code&redirect_uri=&state=")
     })
 
     it("should append query parameters to authorizeUrl with query parameters", function() {
       win.open = createSpy()
-      mockSchema.authorizationUrl = "https://testAuthorizationUrl?param=1"
+      mockSchema.authorizationUrl = "https://testauthorizationurl?param=1"
       oauth2Authorize(authConfig)
       expect(win.open.calls.length).toEqual(1)
-      expect(win.open.calls[0].arguments[0]).toMatch("https://testAuthorizationUrl?param=1&response_type=code&redirect_uri=&state=")
+      expect(win.open.calls[0].arguments[0]).toMatch("https://testauthorizationurl?param=1&response_type=code&redirect_uri=&state=")
     })
   })
 })

--- a/test/core/plugins/auth/actions.js
+++ b/test/core/plugins/auth/actions.js
@@ -53,7 +53,8 @@ describe("auth plugin - actions", () => {
             getConfigs: () => ({})
           },
           oas3Selectors: {
-            selectedServer: () => server
+            selectedServer: () => server,
+            serverEffectiveValue: () => server
           },
           specSelectors: {
             isOAS3: () => oas3,
@@ -127,7 +128,9 @@ describe("auth plugin - actions", () => {
           })
         },
         oas3Selectors: {
-          selectedServer: () => "http://google.com"
+          selectedServer: () => "http://google.com",
+          serverEffectiveValue: (server) => server
+
         },
         specSelectors: {
           isOAS3: () => true,


### PR DESCRIPTION
Closes #5243 and #3992

The full URL is computed based on the current selected server
if a relative URL is used as authorizationUrl or tokenUrl

### Description

Ensure we support relative `authorizationUrl` and `tokenUrl` (relative to the server endpoint) with OAuth.

I'm not sure if this can break backward compatibility, just let me know if you need any change :)

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Unit tests
- Manually on my personal projects/swagger UI definition
- With variable in servers urls


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
