### PR TITLE
housekeeping: make release note generator more flexible

### DIFF
--- a/release/get-changelog.sh
+++ b/release/get-changelog.sh
@@ -1,4 +1,5 @@
-echo '**Interface changes**: ???'
-echo ''
-echo '**Changelog**:'
-./node_modules/.bin/conventional-changelog -p angular | tail -n +3
+echo "_No release summary included._\n\n#### Changelog\n"
+
+PREV_RELEASE_REF=$(git log --pretty=oneline | grep ' release: ' | head -n 2 | tail -n 1 | cut -f 1 -d " ")
+
+git log --pretty=oneline $PREV_RELEASE_REF..HEAD | awk '{ $1=""; print}' | sed -e 's/^[ \t]*//' | sed 's/^feat/0,feat/' | sed 's/^improve/1,improve/' | sed 's/^fix/2,fix/'| sort | sed 's/^[0-2],//' | sed 's/^/* /'


### PR DESCRIPTION
I've been using a new style for release notes, this reflects that.

The new changelog generator now sorts items as we like them, and pulls in stray commits that may not be to the Angular convention's liking, but we may still want present.