### PR TITLE
Dialog accessibility: adds accessible name and closes on escape keypress

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ To help with the migration, here are the currently known issues with 3.X. This l
 - Support for `collectionFormat` is partial.
 - l10n (translations) is not implemented.
 - Relative path support for external files is not implemented.
+- Multiple instances of the Swagger UI may cause accessibility issues due to duplicated ID refs
 
 ## Security contact
 

--- a/src/core/components/auth/authorization-popup.jsx
+++ b/src/core/components/auth/authorization-popup.jsx
@@ -8,6 +8,13 @@ export default class AuthorizationPopup extends React.Component {
     authActions.showDefinitions(false)
   }
 
+  onKeyDown = (e) => {
+    if (e.key === "Escape") {
+      e.stopPropagation()
+      this.close()
+    }
+  }
+
   render() {
     let { authSelectors, authActions, getComponent, errSelectors, specSelectors, fn: { AST = {} } } = this.props
     let definitions = authSelectors.shownDefinitions()
@@ -16,13 +23,18 @@ export default class AuthorizationPopup extends React.Component {
     return (
       <div className="dialog-ux">
         <div className="backdrop-ux"></div>
-        <div className="modal-ux">
+        <div className="modal-ux"
+          aria-labelledby="modal-ux-title"
+          aria-modal="true"
+          role="dialog"
+          onKeyDown={ this.onKeyDown }>
           <div className="modal-dialog-ux">
             <div className="modal-ux-inner">
               <div className="modal-ux-header">
-                <h3>Available authorizations</h3>
+                <h3 id="modal-ux-title">Available authorizations</h3>
                 <button type="button" className="close-modal" onClick={ this.close }>
-                  <svg width="20" height="20">
+                  <svg width="20" height="20" aria-labelledby="modal-ux-close" role="img">
+                    <title id="modal-ux-close">close</title>
                     <use href="#close" xlinkHref="#close" />
                   </svg>
                 </button>

--- a/test/components/auth/authorization-popup.jsx
+++ b/test/components/auth/authorization-popup.jsx
@@ -1,0 +1,67 @@
+
+/* eslint-env mocha */
+import React from "react"
+import expect, { createSpy } from "expect"
+import { shallow } from "enzyme"
+import AuthorizationPopup from "components/auth/authorization-popup"
+import Auths from "components/auth/auths"
+
+describe("<AuthorizationPopup/>", function(){
+  // Given
+  const getMockedProps = () => ({
+    fn: { AST: {} },
+    authActions: {
+      showDefinitions: createSpy()
+    },
+    authSelectors: {
+      shownDefinitions: () => ({
+        valueSeq: () => [1, 2, 3]
+      })
+    },
+    errSelectors: null,
+    getComponent: () => "div",
+    specSelectors: null
+  })
+
+  it("renders Auth components", function(){
+    // When
+    const wrapper = shallow(<AuthorizationPopup {...getMockedProps()}/>)
+
+    // Then
+    const authContainer = wrapper.find(".modal-ux-content")
+    expect(authContainer.getNode().props.children.length).toEqual(3)
+  })
+
+  it("closes the modal on click", function() {
+    // When
+    const props = getMockedProps()
+    const wrapper = shallow(<AuthorizationPopup {...props}/>)
+
+    // Then
+    wrapper.find(".close-modal").simulate("click")
+    expect(props.authActions.showDefinitions).toHaveBeenCalledWith(false)
+  })
+
+  it("closes the modal on escape key", function() {
+    // When
+    const props = getMockedProps()
+    const wrapper = shallow(<AuthorizationPopup {...props}/>)
+
+    // Then
+    wrapper.find(".modal-ux").simulate("keydown", { key: "Escape", stopPropagation: () => {} })
+    expect(props.authActions.showDefinitions).toHaveBeenCalledWith(false)
+  })
+
+  it("does not close the modal with other keys", function() {
+    // When
+    const props = getMockedProps()
+    const wrapper = shallow(<AuthorizationPopup {...props}/>)
+
+    // Then
+    const modalUX = wrapper.find(".modal-ux")
+    modalUX.simulate("keydown", { key: "Enter", stopPropagation: () => {} })
+    modalUX.simulate("keydown", { key: " ", stopPropagation: () => {} })
+    modalUX.simulate("keydown", { key: "q", stopPropagation: () => {} })
+    expect(props.authActions.showDefinitions).toNotHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Addresses #5248 (num. 18 on the list)

### Description
This PR adds the following:
- Adds dialog role and aria-modal
- Uses dialog title as the accessible name
- Adds accessible name to the close button
- Handles escape key press within the dialog

Note: this PR does not address the focus issues with the dialog (blocking focus outside of it, and handling focus on open/close).

### Motivation and Context
- Adding the role and accessible name means that assistive tech users are notified that they are entering a dialog, and what the name of the dialog is
- The close button is now labelled. Earlier it only announced "button"
- Keyboard users may press escape to close the dialog from anywhere within it


### How Has This Been Tested?
Manually tested on Firefox/NVDA, Chrome/NVDA, Chrome/JAWS, and Edge/Narrator

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
(there were no existing tests for the authorization-popup that I could find, but I would be happy to add tests if that would improve the PR)