### PR TITLE
housekeeping: allow overriding `swagger-ui-react` version

### DIFF
--- a/flavors/swagger-ui-react/release/create-manifest.js
+++ b/flavors/swagger-ui-react/release/create-manifest.js
@@ -2,4 +2,8 @@ var jsonMerger = require("json-merger")
 var fs = require("fs")
 var result = jsonMerger.mergeFiles(["../../../package.json", "template.json"])
 
+if(process.env.REACT_FLAVOR_VERSION_IDENTIFIER) {
+  result.version = process.env.REACT_FLAVOR_VERSION_IDENTIFIER
+}
+
 process.stdout.write(JSON.stringify(result, null, 2))


### PR DESCRIPTION
...by setting the `REACT_FLAVOR_VERSION_IDENTIFIER` env var