### PR TITLE
Accept presets and defaultModelsExpandDepth props in swagger-ui-react component 

### DIFF
--- a/flavors/swagger-ui-react/index.js
+++ b/flavors/swagger-ui-react/index.js
@@ -1,18 +1,19 @@
 import React from "react"
 import PropTypes from "prop-types"
-import swaggerUIConstructor from "./swagger-ui"
-
+import swaggerUIConstructor, {presets} from "./swagger-ui"
 export default class SwaggerUI extends React.Component {
   constructor (props) {
     super(props)
     this.SwaggerUIComponent = null
     this.system = null
   }
-  
+
   componentDidMount() {
     const ui = swaggerUIConstructor({
       spec: this.props.spec,
       url: this.props.url,
+      defaultModelsExpandDepth: this.props.defaultModelsExpandDepth,
+      presets: [presets.apis,...this.props.presets],
       requestInterceptor: this.requestInterceptor,
       responseInterceptor: this.responseInterceptor,
       onComplete: this.onComplete,
@@ -71,6 +72,11 @@ export default class SwaggerUI extends React.Component {
     }
   }
 }
+SwaggerUI.defaultProps = {
+  docExpansion: "list",
+  defaultModelsExpandDepth: 1,
+  presets: []
+}
 
 SwaggerUI.propTypes = {
   spec: PropTypes.oneOf([
@@ -78,8 +84,10 @@ SwaggerUI.propTypes = {
     PropTypes.object,
   ]),
   url: PropTypes.string,
+  defaultModelsExpandDepth: PropTypes.number,
   requestInterceptor: PropTypes.func,
   responseInterceptor: PropTypes.func,
   onComplete: PropTypes.func,
   docExpansion: PropTypes.oneOf(['list', 'full', 'none']),
+  presets: PropTypes.arrayOf(PropTypes.func),
 }


### PR DESCRIPTION
Improve the swagger-ui-react component configuration flexibility,
### Description
This PR adds improvements to swagger-ui-react flavor, Allowing users to pass `defaultModelsExpandDepth` and `presets` parameters via React component properties. Other change is, adding default props for `docExpansion`, `defaultModelsExpandDepth` and `preset` parameters. Without the default props.

### Motivation and Context

When using `swagger-ui-react` package with React 16.x , We wanted to remove the `authorizeBtn` from plugins, But it seems swagger-ui-react component doesn't accept presets nor plugins parameters.
Found this similar issue https://github.com/swagger-api/swagger-ui/issues/5367 already raised.

And also I have added default props to newly added properties + the docExpansin property added from this https://github.com/swagger-api/swagger-ui/pull/5242 PR. Without that, if the user didn't pass that prop, Swagger UI `constructorConfig` get `undefined` values ( even after the deep linking defaults + opts )  

### How Has This Been Tested?

Locally test the changes and run the `npm test` from `swagger-ui` local copy with the changes.


### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [x] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
