### PR TITLE
Dropdown improvements

### DIFF
--- a/src/core/components/layout-utils/drop-down.jsx
+++ b/src/core/components/layout-utils/drop-down.jsx
@@ -31,9 +31,6 @@ export default class DropDown extends PureComponent {
     this.setChildRefCollection = {}
 
     React.Children.forEach(this.props.children, (child, i) => {
-      if(child.props.value === props.value) {
-        selectedKey = i
-      }
       this.setChildRefCollection[i] = (instance) => { 
         return this.childRefCollection[i] = instance
       }
@@ -71,6 +68,8 @@ export default class DropDown extends PureComponent {
       }
     })
   }
+
+  initialSelect = (selectedKey) => this.setState({ selectedKey })
 
   setFocus = () => this.buttonRef.focus()
 
@@ -116,9 +115,9 @@ export default class DropDown extends PureComponent {
     )
 
     if (!this.buttonRef.contains(e.target) && !clickedChild) {
-        this.setState({
-          expanded: false
-        })
+      this.setState({
+        expanded: false
+      })
     }
   }
 
@@ -207,6 +206,8 @@ export default class DropDown extends PureComponent {
     const ref = this.setChildRef(i, child.ref)
 
     return React.cloneElement(child, {
+      selected: child.props.value === this.props.value,
+      initialSelect: this.initialSelect,
       ref,
       optionKey: i,
       onKeyPress: this.onKeyPressChild,
@@ -285,6 +286,21 @@ export class DropDownItem extends Component {
     if(onSelect) { 
       onSelect(optionKey)
     }
+  }
+
+  selectKey = () => {
+    const { selected, initialSelect, optionKey } = this.props
+    if (selected) {
+      initialSelect(optionKey)
+    }
+  }
+
+  componentDidUpdate = () => {
+    this.selectKey()
+  }
+
+  componentDidMount = () => {
+    this.selectKey()
   }
 
   onKeyPress = (e) => {

--- a/src/core/components/layout-utils/drop-down.jsx
+++ b/src/core/components/layout-utils/drop-down.jsx
@@ -89,7 +89,10 @@ export default class DropDown extends PureComponent {
     const hasSelected = key || key === 0 
 
     if(hasSelected && this.props.onChange) {
-      this.props.onChange(this.childRefCollection[key].getValue())
+      this.props.onChange({
+        ...this.props,
+        value: this.childRefCollection[key].getValue()
+      })
     }
 
     this.setState((state) => { 
@@ -127,6 +130,7 @@ export default class DropDown extends PureComponent {
     }
     this.openDropdown()
   }
+  
 
   onClickChild = (key) => this.closeDropdown(key)
 

--- a/src/core/components/layout-utils/drop-down.jsx
+++ b/src/core/components/layout-utils/drop-down.jsx
@@ -264,6 +264,8 @@ export class DropDownItem extends Component {
     mod: PropTypes.string,
     value: PropTypes.string,
     optionKey: PropTypes.any,
+    selected: PropTypes.bool,
+    initialSelect: PropTypes.func,
     onSelect: PropTypes.func,
     onKeyPress: PropTypes.func,
     children: PropTypes.node.isRequired

--- a/src/core/components/schemes.jsx
+++ b/src/core/components/schemes.jsx
@@ -28,7 +28,7 @@ export default class Schemes extends React.Component {
     }
   }
 
-  onChange = ( value ) => {
+  onChange = ({value}) => {
     this.setScheme( value )
   }
 


### PR DESCRIPTION
Dropdown bug fix and small enhancement
 
### Description


Update dropdown to:
- pass props into onChange function to accommodate parts of swagger-ui that need to access the attributes they passed in.
- to select default selectedKey in onComponentUpdate (fixes issue when values available on first render)


### Motivation and Context
Replacing selects with the custom one shed light on issues.



### How Has This Been Tested?
Manually



### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
