### PR TITLE
Back-port "fix: anchor tag safety" to 2.x

### DIFF
--- a/src/main/template/main.handlebars
+++ b/src/main/template/main.handlebars
@@ -6,11 +6,11 @@
   <p>{{{sanitize externalDocs.description}}}</p>
   <a href="{{{escape externalDocs.url}}}" target="_blank">{{{escape externalDocs.url}}}</a>
   {{/if}}
-  {{#if info.termsOfServiceUrl}}<div class="info_tos"><a target="_blank" href="{{{escape info.termsOfServiceUrl}}}" data-sw-translate>Terms of service</a></div>{{/if}}
+  {{#if info.termsOfServiceUrl}}<div class="info_tos"><a target="_blank" rel="noopener noreferrer" href="{{{escape info.termsOfServiceUrl}}}" data-sw-translate>Terms of service</a></div>{{/if}}
   {{#if info.contact.name}}<div><div class='info_name' style="display: inline" data-sw-translate>Created by </div> {{{escape info.contact.name}}}</div>{{/if}}
-  {{#if info.contact.url}}<div class='info_url' data-sw-translate>See more at <a href="{{{escape info.contact.url}}}">{{{escape info.contact.url}}}</a></div>{{/if}}
+  {{#if info.contact.url}}<div class='info_url' data-sw-translate>See more at <a target="_blank" rel="noopener noreferrer" href="{{{escape info.contact.url}}}">{{{escape info.contact.url}}}</a></div>{{/if}}
   {{#if info.contact.email}}<div class='info_email'><a target="_parent" href="mailto:{{{escape info.contact.email}}}?subject={{{escape info.title}}}" data-sw-translate>Contact the developer</a></div>{{/if}}
-  {{#if info.license}}<div class='info_license'><a target="_blank" href='{{{escape info.license.url}}}'>{{{escape info.license.name}}}</a></div>{{/if}}
+  {{#if info.license}}<div class='info_license'><a target="_blank" rel="noopener noreferrer" href='{{{escape info.license.url}}}'>{{{escape info.license.name}}}</a></div>{{/if}}
   {{/if}}
 </div>
 <div class='container' id='resources_container'>
@@ -24,7 +24,7 @@
   , <span style="font-variant: small-caps" data-sw-translate>api version</span>: {{{escape info.version}}}
     {{/if}}]
     {{#if validatorUrl}}
-    <span style="float:right"><a target="_blank" href="{{{escape validatorUrl}}}/debug?url={{{escape url}}}"><img id="validator" src="{{{escape validatorUrl}}}?url={{{escape url}}}"></a>
+    <span style="float:right"><a target="_blank" rel="noopener noreferrer" href="{{{escape validatorUrl}}}/debug?url={{{escape url}}}"><img id="validator" src="{{{escape validatorUrl}}}?url={{{escape url}}}"></a>
     </span>
     {{/if}}
     </h4>

--- a/src/main/template/templates.js
+++ b/src/main/template/templates.js
@@ -141,13 +141,13 @@ templates['main'] = template({"1":function(container,depth0,helpers,partials,dat
     + ((stack1 = (helpers.sanitize || (depth0 && depth0.sanitize) || alias2).call(alias1,((stack1 = (depth0 != null ? depth0.externalDocs : depth0)) != null ? stack1.description : stack1),{"name":"sanitize","hash":{},"data":data})) != null ? stack1 : "")
     + "</p>\n  <a href=\""
     + ((stack1 = (helpers.escape || (depth0 && depth0.escape) || alias2).call(alias1,((stack1 = (depth0 != null ? depth0.externalDocs : depth0)) != null ? stack1.url : stack1),{"name":"escape","hash":{},"data":data})) != null ? stack1 : "")
-    + "\" target=\"_blank\">"
+    + "\" target=\"_blank\" rel=\"noopener noreferrer\">"
     + ((stack1 = (helpers.escape || (depth0 && depth0.escape) || alias2).call(alias1,((stack1 = (depth0 != null ? depth0.externalDocs : depth0)) != null ? stack1.url : stack1),{"name":"escape","hash":{},"data":data})) != null ? stack1 : "")
     + "</a>\n";
 },"4":function(container,depth0,helpers,partials,data) {
     var stack1;
 
-  return "<div class=\"info_tos\"><a target=\"_blank\" href=\""
+  return "<div class=\"info_tos\"><a target=\"_blank\" rel=\"noopener noreferrer\" href=\""
     + ((stack1 = (helpers.escape || (depth0 && depth0.escape) || helpers.helperMissing).call(depth0 != null ? depth0 : {},((stack1 = (depth0 != null ? depth0.info : depth0)) != null ? stack1.termsOfServiceUrl : stack1),{"name":"escape","hash":{},"data":data})) != null ? stack1 : "")
     + "\" data-sw-translate>Terms of service</a></div>";
 },"6":function(container,depth0,helpers,partials,data) {
@@ -159,7 +159,7 @@ templates['main'] = template({"1":function(container,depth0,helpers,partials,dat
 },"8":function(container,depth0,helpers,partials,data) {
     var stack1, alias1=depth0 != null ? depth0 : {}, alias2=helpers.helperMissing;
 
-  return "<div class='info_url' data-sw-translate>See more at <a href=\""
+  return "<div class='info_url' data-sw-translate>See more at <a target=\"_blank\" rel=\"noopener noreferrer\" href=\""
     + ((stack1 = (helpers.escape || (depth0 && depth0.escape) || alias2).call(alias1,((stack1 = ((stack1 = (depth0 != null ? depth0.info : depth0)) != null ? stack1.contact : stack1)) != null ? stack1.url : stack1),{"name":"escape","hash":{},"data":data})) != null ? stack1 : "")
     + "\">"
     + ((stack1 = (helpers.escape || (depth0 && depth0.escape) || alias2).call(alias1,((stack1 = ((stack1 = (depth0 != null ? depth0.info : depth0)) != null ? stack1.contact : stack1)) != null ? stack1.url : stack1),{"name":"escape","hash":{},"data":data})) != null ? stack1 : "")
@@ -175,7 +175,7 @@ templates['main'] = template({"1":function(container,depth0,helpers,partials,dat
 },"12":function(container,depth0,helpers,partials,data) {
     var stack1, alias1=depth0 != null ? depth0 : {}, alias2=helpers.helperMissing;
 
-  return "<div class='info_license'><a target=\"_blank\" href='"
+  return "<div class='info_license'><a target=\"_blank\" rel=\"noopener noreferrer\" href='"
     + ((stack1 = (helpers.escape || (depth0 && depth0.escape) || alias2).call(alias1,((stack1 = ((stack1 = (depth0 != null ? depth0.info : depth0)) != null ? stack1.license : stack1)) != null ? stack1.url : stack1),{"name":"escape","hash":{},"data":data})) != null ? stack1 : "")
     + "'>"
     + ((stack1 = (helpers.escape || (depth0 && depth0.escape) || alias2).call(alias1,((stack1 = ((stack1 = (depth0 != null ? depth0.info : depth0)) != null ? stack1.license : stack1)) != null ? stack1.name : stack1),{"name":"escape","hash":{},"data":data})) != null ? stack1 : "")
@@ -189,7 +189,7 @@ templates['main'] = template({"1":function(container,depth0,helpers,partials,dat
 },"16":function(container,depth0,helpers,partials,data) {
     var stack1, alias1=depth0 != null ? depth0 : {}, alias2=helpers.helperMissing;
 
-  return "    <span style=\"float:right\"><a target=\"_blank\" href=\""
+  return "    <span style=\"float:right\"><a target=\"_blank\" rel=\"noopener noreferrer\" href=\""
     + ((stack1 = (helpers.escape || (depth0 && depth0.escape) || alias2).call(alias1,(depth0 != null ? depth0.validatorUrl : depth0),{"name":"escape","hash":{},"data":data})) != null ? stack1 : "")
     + "/debug?url="
     + ((stack1 = (helpers.escape || (depth0 && depth0.escape) || alias2).call(alias1,(depth0 != null ? depth0.url : depth0),{"name":"escape","hash":{},"data":data})) != null ? stack1 : "")


### PR DESCRIPTION
Setting target="_blank" on anchor tags is unsafe unless used in conjunction with rel="noopener".

This is a back-port of dd3afdc45656b (#4789) to fix the problem in version 2.x.

@shockey @JonathanParrilla  PTAL

### Description

I ran `grep -r target src/main/template` to find all places where we are creating links to external URLs and then fixed these places by adding `rel="noopener noreferrer"` attribute.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

In LoopBack, we are depending on swagger-ui version 2.x (see https://github.com/strongloop/loopback-component-explorer). We tried to upgrade to 3.x, but found that such upgrade requires too much effort, and thus decided to stick with 2.x.

Now we are seeing a security vulnerability reported for our module. I believe we are not affected by the vulnerability, because the possibly-malicious URLs are fully under control of the person running swagger-ui, but it still look bad that security checkers are reporting a vulnerability.

Can we back-port the fix from 3.x to 2.x please?

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I tried to run `npm test`, unfortunately it failed with a cryptic error:

```
> swagger-ui@2.2.10 pretest /Users/bajtos/src/swagger-ui
> npm run jshint


> swagger-ui@2.2.10 prejshint /Users/bajtos/src/swagger-ui
> gulp

fs.js:27
const { Math, Object, Reflect } = primordials;
                                  ^

ReferenceError: primordials is not defined
    at fs.js:27:35
    at req_ (/Users/bajtos/src/swagger-ui/node_modules/natives/index.js:143:24)
    at Object.req [as require] (/Users/bajtos/src/swagger-ui/node_modules/natives/index.js:55:10)
    at Object.<anonymous> (/Users/bajtos/src/swagger-ui/node_modules/vinyl-fs/node_modules/graceful-fs/fs.js:1:37)
    at Module._compile (internal/modules/cjs/loader.js:759:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:770:10)
    at Module.load (internal/modules/cjs/loader.js:628:32)
    at Function.Module._load (internal/modules/cjs/loader.js:555:12)
    at Module.require (internal/modules/cjs/loader.js:666:19)
    at require (internal/modules/cjs/helpers.js:16:16)
```

I also try to run `mocha` directly, unfortunately that failed too in the test `should have "Swagger UI" in title` with no diagnostic messages :(

Could you please advise how can/should I test this change?

### Screenshots (if appropriate):

n/a

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.