### PR TITLE
housekeeping: address inconsistently truncated Standalone Plugin responses within Cypress tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test-e2e-selenium": "sleep 3 && nightwatch test/e2e-selenium/scenarios/ --config test/e2e-selenium/nightwatch.json",
     "e2e-initial-render": "nightwatch test/e2e-selenium/scenarios/ --config test/e2e-selenium/nightwatch.json --group initial-render",
     "mock-api": "json-server --watch test/e2e-selenium/db.json --port 3204",
-    "hot-e2e-cypress-server": "webpack-dev-server --port 3230 --content-base test/e2e-cypress/static --host 0.0.0.0 --config webpack-hot-dev-server.config.js --inline --hot --progress",
+    "hot-e2e-cypress-server": "webpack-dev-server --port 3230 --content-base test/e2e-cypress/static --host 0.0.0.0 --config webpack-hot-dev-server.config.js",
     "hot-e2e-selenium-server": "webpack-dev-server --port 3230 --content-base test/e2e-selenium/helpers --host 0.0.0.0 --config webpack-hot-dev-server.config.js --inline --hot --progress",
     "e2e-cypress": "run-p -r hot-e2e-cypress-server mock-api test-e2e-cypress",
     "e2e-selenium": "run-p -r hot-e2e-selenium-server mock-api test-e2e-selenium",

--- a/test/e2e-cypress/support/index.js
+++ b/test/e2e-cypress/support/index.js
@@ -25,3 +25,11 @@ import "./commands"
 Cypress.on("window:before:load", win => {
   win.fetch = null
 })
+
+Cypress.on('uncaught:exception', (err, runnable) => {
+  console.log(err)
+  util.inspect(err)
+  console.log(JSON.stringify(err, null, 2))
+  
+  throw err
+})

--- a/test/e2e-cypress/support/index.js
+++ b/test/e2e-cypress/support/index.js
@@ -1,3 +1,5 @@
+import fs from "fs"
+
 // ***********************************************************
 // This example support/index.js is processed and
 // loaded automatically before your test files.
@@ -28,8 +30,8 @@ Cypress.on("window:before:load", win => {
 
 Cypress.on("uncaught:exception", (err, runnable) => {
   console.log(err)
-  util.inspect(err)
   console.log(JSON.stringify(err, null, 2))
-  
+  fs.writeFileSync(require("path").normalize(__dirname, "./error.log"), JSON.stringify(err, null, 2))
+
   throw err
 })

--- a/test/e2e-cypress/support/index.js
+++ b/test/e2e-cypress/support/index.js
@@ -26,7 +26,7 @@ Cypress.on("window:before:load", win => {
   win.fetch = null
 })
 
-Cypress.on('uncaught:exception', (err, runnable) => {
+Cypress.on("uncaught:exception", (err, runnable) => {
   console.log(err)
   util.inspect(err)
   console.log(JSON.stringify(err, null, 2))

--- a/webpack-hot-dev-server.config.js
+++ b/webpack-hot-dev-server.config.js
@@ -65,7 +65,6 @@ module.exports = require("./make-webpack-config")(rules, {
     port: 3200,
     publicPath: "/",
     noInfo: true,
-    hot: true,
     disableHostCheck: true, // for development within VMs
     stats: {
       colors: true


### PR DESCRIPTION
problem: sometimes, the JavaScript file for the Standalone plugin gets truncated, which breaks Cypress in mysterious ways:

![image](https://user-images.githubusercontent.com/680248/60784373-45901880-a114-11e9-800b-81fc9a4c72d0.png)

I only know that it's the Standalone plugin because this happened on my local machine _once_ a week ago and took notes on the failure. Hasn't happened outside of CI since.