### PR TITLE
This PR allows additional configuration to be use in swagger-ui-react

### DIFF
--- a/flavors/swagger-ui-react/README.md
+++ b/flavors/swagger-ui-react/README.md
@@ -31,9 +31,11 @@ export default App = () => <SwaggerUI url="https://petstore.swagger.io/v2/swagge
 
 These props map to [Swagger UI configuration options](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md) of the same name.
 
+Not all the configuration options are described here. See [Swagger UI configuration options](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md) for the full set.
+
 #### `spec`: PropTypes.object
 
-An OpenAPI document respresented as a JavaScript object, JSON string, or YAML string for Swagger UI to display.
+An OpenAPI document represented as a JavaScript object, JSON string, or YAML string for Swagger UI to display.
 
 ⚠️ Don't use this in conjunction with `url` - unpredictable behavior may occur.
 
@@ -73,7 +75,7 @@ Controls the default expansion setting for the operations and tags. It can be 'l
 
 ## Limitations
 
-* Not all configuration bindings are available.
+* Not all configuration bindings have been tested.
 * Some props are only applied on mount, and cannot be updated reliably.
 * OAuth redirection handling is not supported.
 * Topbar/Standalone mode is not supported.

--- a/flavors/swagger-ui-react/index.js
+++ b/flavors/swagger-ui-react/index.js
@@ -20,7 +20,7 @@ export default class SwaggerUI extends React.Component {
       requestInterceptor: this.requestInterceptor,
       responseInterceptor: this.responseInterceptor,
       onComplete: this.onComplete,
-      ...this.otherProps
+      ...otherProps
     })
 
     this.system = ui

--- a/flavors/swagger-ui-react/index.js
+++ b/flavors/swagger-ui-react/index.js
@@ -10,13 +10,17 @@ export default class SwaggerUI extends React.Component {
   }
   
   componentDidMount() {
+    const {
+      requestInterceptor,
+      responseInterceptor,
+      onComplete,
+      ...otherProps
+    } = this.props;
     const ui = swaggerUIConstructor({
-      spec: this.props.spec,
-      url: this.props.url,
       requestInterceptor: this.requestInterceptor,
       responseInterceptor: this.responseInterceptor,
       onComplete: this.onComplete,
-      docExpansion: this.props.docExpansion,
+      ...this.otherProps
     })
 
     this.system = ui


### PR DESCRIPTION
Only a few [Swagger UI configuration options](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md) are available in swagger-ui-react.

This PR makes them all available

### Description
Previously only individual configuration options were mapped from swagger-ui-react to swagger-ui. This PR fixes that.



### Motivation and Context
I needed to set the `supportedSubmitMethods` configuration option when using swagger-ui with react.


### How Has This Been Tested?
I ran `npm run test` from the root


### Screenshots (if appropriate):
🤷‍♂️


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x ] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [x] My changes require a change to the project documentation.
- [x] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.