### PR TITLE
fix: Swagger 2.0 `Response.examples`, again

### DIFF
--- a/src/core/components/response.jsx
+++ b/src/core/components/response.jsx
@@ -136,10 +136,18 @@ export default class Response extends React.Component {
         })
       }
     } else {
-      sampleResponse = schema ? getSampleSchema(schema.toJS(), activeContentType, {
-        includeReadOnly: true,
-        includeWriteOnly: true // writeOnly has no filtering effect in swagger 2.0
-       }) : null
+      if(response.getIn(["examples", activeContentType])) {
+        sampleResponse = response.getIn(["examples", activeContentType])
+      } else {
+        sampleResponse = schema ? getSampleSchema(
+          schema.toJS(), 
+          activeContentType, 
+          {
+            includeReadOnly: true,
+            includeWriteOnly: true // writeOnly has no filtering effect in swagger 2.0
+          }
+        ) : null
+      }
     }
 
     let example = getExampleComponent( sampleResponse, HighlightCode )

--- a/src/core/components/response.jsx
+++ b/src/core/components/response.jsx
@@ -10,7 +10,7 @@ const getExampleComponent = ( sampleResponse, HighlightCode ) => {
     sampleResponse !== undefined &&
     sampleResponse !== null
   ) { return <div>
-      <HighlightCode className="example" value={ sampleResponse } />
+      <HighlightCode className="example" value={ stringify(sampleResponse) } />
     </div>
   }
   return null
@@ -138,6 +138,7 @@ export default class Response extends React.Component {
     } else {
       if(response.getIn(["examples", activeContentType])) {
         sampleResponse = response.getIn(["examples", activeContentType])
+        debugger
       } else {
         sampleResponse = schema ? getSampleSchema(
           schema.toJS(), 

--- a/test/e2e-cypress/static/documents/bugs/5458.yaml
+++ b/test/e2e-cypress/static/documents/bugs/5458.yaml
@@ -1,0 +1,37 @@
+swagger: "2.0"
+info:
+  title: test
+  version: 1.0.0
+paths:
+  /foo1:
+    get:
+      summary: Response without a schema
+      produces:
+        - application/json
+      responses:
+        200:
+          description: Successful response
+          examples:
+            application/json:
+              foo: custom value
+  /foo2:
+    get:
+      summary: Response with schema
+      produces:
+        - application/json
+      responses:
+        200:
+          description: Successful response
+          schema:
+            $ref: '#/definitions/Foo'
+          examples:
+            application/json:
+              foo: custom value
+
+definitions:
+  Foo:
+    type: object
+    properties:
+      foo:
+        type: string
+        example: bar

--- a/test/e2e-cypress/tests/bugs/5458.js
+++ b/test/e2e-cypress/tests/bugs/5458.js
@@ -1,0 +1,18 @@
+// http://github.com/swagger-api/swagger-ui/issues/5458
+
+describe("#5458: Swagger 2.0 `Response.examples` mappings", () => {
+  it("should render a custom example when a schema is not defined", () => {
+    cy.visit("/?url=/documents/bugs/5458.yaml")
+      .get("#operations-default-get_foo1")
+      .click()
+      .get(".model-example .highlight-code")
+      .contains("custom value")
+  })
+  it("should render a custom example when a schema is defined", () => {
+    cy.visit("/?url=/documents/bugs/5458.yaml")
+      .get("#operations-default-get_foo2")
+      .click()
+      .get(".model-example .highlight-code")
+      .contains("custom value")
+  })
+})

--- a/test/e2e-cypress/tests/bugs/5458.js
+++ b/test/e2e-cypress/tests/bugs/5458.js
@@ -1,18 +1,22 @@
 // http://github.com/swagger-api/swagger-ui/issues/5458
 
+const expectedValue = `{
+  "foo": "custom value"
+}`
+
 describe("#5458: Swagger 2.0 `Response.examples` mappings", () => {
   it("should render a custom example when a schema is not defined", () => {
     cy.visit("/?url=/documents/bugs/5458.yaml")
       .get("#operations-default-get_foo1")
       .click()
       .get(".model-example .highlight-code")
-      .contains("custom value")
+      .contains(expectedValue)
   })
   it("should render a custom example when a schema is defined", () => {
     cy.visit("/?url=/documents/bugs/5458.yaml")
       .get("#operations-default-get_foo2")
       .click()
       .get(".model-example .highlight-code")
-      .contains("custom value")
+      .contains(expectedValue)
   })
 })


### PR DESCRIPTION
Fixes #5458, avoids a mistake I made in 9749a4785.