### PR TITLE
housekeeping: fail React flavor release if a step fails

### DIFF
--- a/flavors/swagger-ui-react/release/run.sh
+++ b/flavors/swagger-ui-react/release/run.sh
@@ -1,5 +1,8 @@
 # Deploy `swagger-ui-react` to npm.
 
+# https://www.peterbe.com/plog/set-ex
+set -ex
+
 # Parameter Expansion: http://stackoverflow.com/questions/6393551/what-is-the-meaning-of-0-in-a-bash-script
 cd "${0%/*}"
 

--- a/flavors/swagger-ui-react/release/run.sh
+++ b/flavors/swagger-ui-react/release/run.sh
@@ -6,7 +6,7 @@ set -ex
 # Parameter Expansion: http://stackoverflow.com/questions/6393551/what-is-the-meaning-of-0-in-a-bash-script
 cd "${0%/*}"
 
-mkdir ../dist
+mkdir -p ../dist
 
 # Copy UI's dist files to our directory
 cp ../../../dist/swagger-ui.js ../dist


### PR DESCRIPTION
[`swagger-ui-react@3.23.1`](https://unpkg.com/swagger-ui-react@3.23.1/) is broken because `index.js` is empty:

<img width="1088" alt="image" src="https://user-images.githubusercontent.com/680248/61168240-b4a0af00-a510-11e9-91ea-ef614a6d90d6.png">


This is because Babel failed in the release job ([`oss-swagger-ui-release-react#10`](https://jenkins.swagger.io/view/OSS%20-%20JavaScript%20Releases/job/oss-swagger-ui-release-react/10/console)), but the job continued to run, release, and succeed:

<img width="1139" alt="image" src="https://user-images.githubusercontent.com/680248/61168255-dd28a900-a510-11e9-91ba-cdec4bd3302b.png">

### This PR prevents this from happening again, by using `set -e` to exit the release script with a non-zero code if any step in the script fails.

It also starts using `mkdir -p` so that "already exists" errors from that command don't cause the job to fail.