### PR TITLE
Bugfix: fix for mutated request incase Promise is returned

### DIFF
--- a/src/core/plugins/spec/actions.js
+++ b/src/core/plugins/spec/actions.js
@@ -419,10 +419,14 @@ export const executeRequest = (req) =>
     let requestInterceptorWrapper = function(r) {
       let mutatedRequest = requestInterceptor.apply(this, [r])
 
-      Promise.resolve(mutatedRequest).then(resolvedMutatedRequest => {
-        let parsedMutatedRequest = Object.assign({}, resolvedMutatedRequest)
-        specActions.setMutatedRequest(req.pathName, req.method, parsedMutatedRequest)
-      })
+      if (mutatedRequest !== undefined) {
+        Promise.resolve(mutatedRequest).then(resolvedMutatedRequest => {
+          let parsedMutatedRequest = Object.assign({}, resolvedMutatedRequest)
+          specActions.setMutatedRequest(req.pathName, req.method, parsedMutatedRequest)
+        })
+      } else {
+        specActions.setMutatedRequest(req.pathName, req.method, {})
+      }
       return mutatedRequest
     }
 

--- a/src/core/plugins/spec/actions.js
+++ b/src/core/plugins/spec/actions.js
@@ -418,8 +418,11 @@ export const executeRequest = (req) =>
 
     let requestInterceptorWrapper = function(r) {
       let mutatedRequest = requestInterceptor.apply(this, [r])
-      let parsedMutatedRequest = Object.assign({}, mutatedRequest)
-      specActions.setMutatedRequest(req.pathName, req.method, parsedMutatedRequest)
+
+      Promise.resolve(mutatedRequest).then(resolvedMutatedRequest => {
+        let parsedMutatedRequest = Object.assign({}, resolvedMutatedRequest)
+        specActions.setMutatedRequest(req.pathName, req.method, parsedMutatedRequest)
+      })
       return mutatedRequest
     }
 


### PR DESCRIPTION
currently if requestInterceptor returns Promise then url is not displayed on swagger ui page it displays only:
`CURL -X "undefined"`

### Description
<!--- Describe your changes in detail -->



### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->



### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->



### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
