### PR TITLE
fix: use `null` as a notSetValue for examplesForMediaType

### DIFF
--- a/src/core/plugins/oas3/components/request-body.jsx
+++ b/src/core/plugins/oas3/components/request-body.jsx
@@ -67,7 +67,7 @@ const RequestBody = ({
 
   const mediaTypeValue = requestBodyContent.get(contentType, OrderedMap())
   const schemaForMediaType = mediaTypeValue.get("schema", OrderedMap())
-  const examplesForMediaType = mediaTypeValue.get("examples", OrderedMap())
+  const examplesForMediaType = mediaTypeValue.get("examples", null)
 
   const handleExamplesSelect = (key /*, { isSyntheticChange } */) => {
     updateActiveExamplesKey(key)

--- a/test/e2e-cypress/static/documents/bugs/5455.yaml
+++ b/test/e2e-cypress/static/documents/bugs/5455.yaml
@@ -1,0 +1,25 @@
+openapi: 3.0.2
+info:
+  title: test
+  version: 1.0.0
+paths:
+  /foo:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Foo'
+      responses:
+        201:
+          description: Created
+
+components:
+  schemas:
+    Foo:
+      type: object
+      properties:
+        foo:
+          type: string
+          example: bar

--- a/test/e2e-cypress/tests/bugs/5455.js
+++ b/test/e2e-cypress/tests/bugs/5455.js
@@ -1,0 +1,11 @@
+// http://github.com/swagger-api/swagger-ui/issues/5455
+
+describe("#5455: Request bodies w/o `examples` should not render a dropdown", () => {
+  it("should not render a <select> element", () => {
+    cy.visit("/?url=/documents/bugs/5455.yaml")
+      .get("#operations-default-post_foo")
+      .click()
+      .get(".opblock-section-request-body > .opblock-description-wrapper")
+      .should("not.have.descendants", "select")
+  })
+})


### PR DESCRIPTION
fixes #5455