### PR TITLE
fix: empty ModelExample rendering in a Response w/o `content` 

### DIFF
--- a/src/core/components/response.jsx
+++ b/src/core/components/response.jsx
@@ -109,7 +109,7 @@ export default class Response extends React.Component {
 
     // Goal: find a schema value for `schema`
     if(isOAS3) {
-      const oas3SchemaForContentType = activeMediaType.get("schema", Map({}))
+      const oas3SchemaForContentType = activeMediaType.get("schema")
 
       schema = oas3SchemaForContentType ? inferSchema(oas3SchemaForContentType.toJS()) : null
       specPathWithPossibleSchema = oas3SchemaForContentType ? List(["content", this.state.responseContentType, "schema"]) : specPath

--- a/test/e2e-cypress/static/documents/bugs/5453.yaml
+++ b/test/e2e-cypress/static/documents/bugs/5453.yaml
@@ -1,0 +1,10 @@
+openapi: 3.0.2
+info:
+  title: Response without a schema
+  version: 1.0.0
+paths:
+  /foo:
+    get:
+      responses:
+        '200':
+          description: OK

--- a/test/e2e-cypress/tests/bugs/5453.js
+++ b/test/e2e-cypress/tests/bugs/5453.js
@@ -1,0 +1,11 @@
+// http://github.com/swagger-api/swagger-ui/issues/5453
+
+  describe("#5453: Responses w/o `content` should not render ModelExample", () => {
+   it("should not render a ModelExample section", () => {
+     cy.visit("/?url=/documents/bugs/5453.yaml")
+       .get("#operations-default-get_foo")
+       .click()
+       .get(".responses-inner")
+       .should("not.have.descendants", ".model-example")
+   })
+ })


### PR DESCRIPTION
fixes #5453.