### PR TITLE
fix: move `@babel/runtime-corejs2` to production dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1322,9 +1322,9 @@
       }
     },
     "@babel/runtime-corejs2": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.5.4.tgz",
-      "integrity": "sha512-sHv74OzyZ18d6tjHU0HmlVES3+l+lydkOMTiKsJSTGWcTBpIMfXLEgduahlJrQjknW9RCQAqLIEdLOHjBmq/hg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.5.5.tgz",
+      "integrity": "sha512-FYATQVR00NSNi7mUfpPDp7E8RYMXDuO8gaix7u/w3GekfUinKgX1AcTxs7SoiEmoEW9mbpjrwqWSW6zCmw5h8A==",
       "dev": true,
       "requires": {
         "core-js": "^2.6.5",
@@ -1338,9 +1338,9 @@
           "dev": true
         },
         "regenerator-runtime": {
-          "version": "0.13.2",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
-          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==",
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "start": "npm-run-all --parallel serve-static open-static"
   },
   "dependencies": {
+    "@babel/runtime-corejs2": "^7.5.5",
     "@braintree/sanitize-url": "^2.0.2",
     "@kyleshockey/js-yaml": "^1.0.1",
     "@kyleshockey/object-assign-deep": "^0.4.2",
@@ -91,7 +92,6 @@
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
     "@babel/register": "^7.4.4",
-    "@babel/runtime-corejs2": "^7.0.0",
     "@release-it/conventional-changelog": "^1.1.0",
     "autoprefixer": "^8.4.1",
     "babel-eslint": "^9.0.0",


### PR DESCRIPTION
Addresses #5505.