### PR TITLE
fix: <Select disabled> for `type: string` + `enum` schemas

### DIFF
--- a/src/core/json-schema-components.jsx
+++ b/src/core/json-schema-components.jsx
@@ -78,6 +78,7 @@ export class JsonSchema_string extends Component {
                       allowedValues={ enumValue }
                       value={ value }
                       allowEmptyValue={ !required }
+                      disabled={disabled}
                       onChange={ this.onEnumChange }/>)
     }
 

--- a/test/e2e-cypress/tests/bugs/5452.js
+++ b/test/e2e-cypress/tests/bugs/5452.js
@@ -8,6 +8,8 @@ describe("#5452: <Select /> crashing in Parameters", function() {
       cy.visit("http://localhost:3230/?url=/documents/bugs/5452/openapi.yaml")
         .get("#operations-default-get_endpoint")
         .click()
+        .get(".try-out__btn")
+        .click()
         .get(".parameters > tbody > tr > .parameters-col_description > select")
         .select("")
         .get(".parameters > tbody > tr > .parameters-col_description > select")
@@ -21,6 +23,8 @@ describe("#5452: <Select /> crashing in Parameters", function() {
     it("should not result in a render error", function() {
       cy.visit("http://localhost:3230/?url=/documents/bugs/5452/swagger.yaml")
         .get("#operations-default-get_endpoint")
+        .click()
+        .get(".try-out__btn")
         .click()
         .get(".parameters > tbody > tr > .parameters-col_description > select")
         .select("")

--- a/test/mocha/components/json-schema-form.jsx
+++ b/test/mocha/components/json-schema-form.jsx
@@ -40,6 +40,27 @@ describe("<JsonSchemaForm/>", function(){
       expect(wrapper.find("select option").eq(2).text()).toEqual("two")
     })
 
+    it("should render a string enum as disabled when JsonSchemaForm is disabled", function(){
+
+      let props = {
+        getComponent: getComponentStub,
+        value: "",
+        onChange: () => {},
+        keyName: "",
+        fn: {},
+        schema: {
+          type: "string",
+          enum: ["one", "two"]
+        },
+        disabled: true
+      }
+
+      let wrapper = render(<JsonSchemaForm {...props}/>)
+
+      expect(wrapper.find("select").attr("disabled")).toEqual("disabled")
+    })
+
+
     it("should render the correct options for a required string enum parameter", function(){
 
       let props = {


### PR DESCRIPTION
Fixes #5568.