### PR TITLE
fix: accept string-represented values in required array runtime validation

### DIFF
--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -523,7 +523,7 @@ export const validateParam = (param, value, { isOAS3 = false, bypassRequiredChec
     // These checks should evaluate to true if there is a parameter
     let stringCheck = type === "string" && value
     let arrayCheck = type === "array" && Array.isArray(value) && value.length
-    let listCheck = type === "array" && Im.List.isList(value) && value.count()
+    let arrayListCheck = type === "array" && Im.List.isList(value) && value.count()
     let fileCheck = type === "file" && value instanceof win.File
     let booleanCheck = type === "boolean" && (value || value === false)
     let numberCheck = type === "number" && (value || value === 0)
@@ -543,7 +543,7 @@ export const validateParam = (param, value, { isOAS3 = false, bypassRequiredChec
     // }
 
     const allChecks = [
-      stringCheck, arrayCheck, listCheck, fileCheck, booleanCheck,
+      stringCheck, arrayCheck, arrayListCheck, fileCheck, booleanCheck,
       numberCheck, integerCheck, objectCheck, objectStringCheck,
     ]
 
@@ -605,7 +605,7 @@ export const validateParam = (param, value, { isOAS3 = false, bypassRequiredChec
     } else if ( type === "array" ) {
       let itemType
 
-      if ( !listCheck || !value.count() ) { return errors }
+      if ( !arrayListCheck || !value.count() ) { return errors }
 
       itemType = paramDetails.getIn(["items", "type"])
 

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -524,6 +524,7 @@ export const validateParam = (param, value, { isOAS3 = false, bypassRequiredChec
     let stringCheck = type === "string" && value
     let arrayCheck = type === "array" && Array.isArray(value) && value.length
     let arrayListCheck = type === "array" && Im.List.isList(value) && value.count()
+    let arrayStringCheck = type === "array" && typeof value === "string" && value
     let fileCheck = type === "file" && value instanceof win.File
     let booleanCheck = type === "boolean" && (value || value === false)
     let numberCheck = type === "number" && (value || value === 0)
@@ -543,8 +544,8 @@ export const validateParam = (param, value, { isOAS3 = false, bypassRequiredChec
     // }
 
     const allChecks = [
-      stringCheck, arrayCheck, arrayListCheck, fileCheck, booleanCheck,
-      numberCheck, integerCheck, objectCheck, objectStringCheck,
+      stringCheck, arrayCheck, arrayListCheck, arrayStringCheck, fileCheck, 
+      booleanCheck, numberCheck, integerCheck, objectCheck, objectStringCheck,
     ]
 
     const passedAnyCheck = allChecks.some(v => !!v)

--- a/test/mocha/core/utils.js
+++ b/test/mocha/core/utils.js
@@ -602,6 +602,14 @@ describe("utils", function() {
       }
       value = []
       assertValidateParam(param, value, ["Required field is not provided"])
+
+      // invalid (empty) array, represented as a string
+      param = {
+        required: true,
+        type: "array"
+      }
+      value = ""
+      assertValidateParam(param, value, ["Required field is not provided"])
       
       // invalid (not an array)
       param = {
@@ -628,6 +636,14 @@ describe("utils", function() {
         type: "array"
       }
       value = [1]
+      assertValidateParam(param, value, [])
+
+      // valid array, with no 'type' for items, represented as a string
+      param = {
+        required: true,
+        type: "array"
+      }
+      value = "[1]"
       assertValidateParam(param, value, [])
       
       // valid array, items match type


### PR DESCRIPTION
Fixes #5606 