### PR TITLE
feat: Show minimum and maximum in parameter query

### DIFF
--- a/src/core/components/parameter-row.jsx
+++ b/src/core/components/parameter-row.jsx
@@ -225,6 +225,8 @@ export default class ParameterRow extends Component {
 
     let paramItems // undefined
     let paramEnum // undefined
+    let paramMinimumValue // undefined
+    let paramMaximumValue // undefined
     let paramDefaultValue // undefined
     let paramExample // undefined
     let isDisplayParamEnum = false
@@ -246,6 +248,14 @@ export default class ParameterRow extends Component {
 
     // Default and Example Value for readonly doc
     if ( param !== undefined ) {
+      paramMinimumValue = schema.get("minimum")
+      if (paramMinimumValue === undefined) {
+        paramMinimumValue = param.get("minimum")
+      }
+      paramMaximumValue = schema.get("maximum")
+      if (paramMaximumValue === undefined) {
+        paramMaximumValue = param.get("maximum")
+      }
       paramDefaultValue = schema.get("default")
       if (paramDefaultValue === undefined) {
         paramDefaultValue = param.get("default")
@@ -284,6 +294,16 @@ export default class ParameterRow extends Component {
                 "<i>Available values</i> : " + paramEnum.map(function(item) {
                     return item
                   }).toArray().join(", ")}/>
+            : null
+          }
+
+          { (bodyParam || !isExecute) && paramMinimumValue !== undefined ?
+            <Markdown className="parameter__minimum" source={"<i>Minimum value</i> : " + paramMinimumValue}/>
+            : null
+          }
+
+          { (bodyParam || !isExecute) && paramMaximumValue !== undefined ?
+            <Markdown className="parameter__maximum" source={"<i>Maximum value</i> : " + paramMaximumValue}/>
             : null
           }
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Hi there. query parameter does not show minimum/maximum value, but it makes the doc ambiguous. So I would like swagger-ui to show minimum and maximum value

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

refs #5016


### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->



### Screenshots (if appropriate):


![Screen Shot 2019-10-30 at 14 50 58](https://user-images.githubusercontent.com/7419215/67832341-b379a900-fb24-11e9-9bbf-4772411f5144.png)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
