### PR TITLE
Feature/oauth2 form customisation

### DIFF
--- a/dev-helpers/index.html
+++ b/dev-helpers/index.html
@@ -63,7 +63,12 @@
         appName: "your-app-name",
         scopeSeparator: " ",
         additionalQueryStringParams: {},
-        usePkceWithAuthorizationCodeGrant: false
+        usePkceWithAuthorizationCodeGrant: false,
+        defaultScope: ["openid"],
+        hideClientSecret: false,
+        hideClientId: false,
+        hideScope: false,
+        hideInfo: false
       })
     }
   </script>

--- a/docker/configurator/oauth.js
+++ b/docker/configurator/oauth.js
@@ -30,6 +30,26 @@ const oauthBlockSchema = {
   OAUTH_USE_PKCE: {
     type: "boolean",
     name: "usePkceWithAuthorizationCodeGrant"
+  },
+  OAUTH_DEFAULT_SCOPE: {
+    type: "array",
+    name: "defaultScope"
+  },
+  OAUTH_HIDE_CLIENT_ID: {
+    type: "boolean",
+    name: "hideClientId"
+  },
+  OAUTH_HIDE_CLIENT_SECRET: {
+    type: "boolean",
+    name: "hideClientSecret"
+  },
+  OAUTH_HIDE_SCOPE: {
+    type: "boolean",
+    name: "hideScope"
+  },
+  OAUTH_HIDE_INFO: {
+    type: "boolean",
+    name: "hideInfo"
   }
 }
 

--- a/docs/usage/oauth2.md
+++ b/docs/usage/oauth2.md
@@ -10,7 +10,7 @@ appName | `OAUTH_APP_NAME` |application name, displayed in authorization popup. 
 scopeSeparator | `OAUTH_SCOPE_SEPARATOR` |scope separator for passing scopes, encoded before calling, default value is a space (encoded value `%20`). MUST be a string
 additionalQueryStringParams | `OAUTH_ADDITIONAL_PARAMS` |Additional query parameters added to `authorizationUrl` and `tokenUrl`. MUST be an object
 useBasicAuthenticationWithAccessCodeGrant | _Unavailable_ |Only activated for the `accessCode` flow.  During the `authorization_code` request to the `tokenUrl`, pass the [Client Password](https://tools.ietf.org/html/rfc6749#section-2.3.1) using the HTTP Basic Authentication scheme (`Authorization` header with `Basic base64encode(client_id + client_secret)`).  The default is `false`
-usePkceWithAuthorizationCodeGrant | `OAUTH_USE_PKCE` | Only applies to `authorizatonCode` flows. [Proof Key for Code Exchange](https://tools.ietf.org/html/rfc7636) brings enhanced security for OAuth public clients. The default is `false`
+usePkceWithAuthorizationCodeGrant | `OAUTH_USE_PKCE` | Only applies to `authorizatonCode` (or `accessCode`) flows. [Proof Key for Code Exchange](https://tools.ietf.org/html/rfc7636) brings enhanced security for OAuth public clients. The default is `false`
 
 ```javascript
 const ui = SwaggerUI({...})

--- a/docs/usage/oauth2.md
+++ b/docs/usage/oauth2.md
@@ -11,7 +11,11 @@ scopeSeparator | `OAUTH_SCOPE_SEPARATOR` |scope separator for passing scopes, en
 additionalQueryStringParams | `OAUTH_ADDITIONAL_PARAMS` |Additional query parameters added to `authorizationUrl` and `tokenUrl`. MUST be an object
 useBasicAuthenticationWithAccessCodeGrant | _Unavailable_ |Only activated for the `accessCode` flow.  During the `authorization_code` request to the `tokenUrl`, pass the [Client Password](https://tools.ietf.org/html/rfc6749#section-2.3.1) using the HTTP Basic Authentication scheme (`Authorization` header with `Basic base64encode(client_id + client_secret)`).  The default is `false`
 usePkceWithAuthorizationCodeGrant | `OAUTH_USE_PKCE` | Only applies to `authorizatonCode` (or `accessCode`) flows. [Proof Key for Code Exchange](https://tools.ietf.org/html/rfc7636) brings enhanced security for OAuth public clients. The default is `false`
-
+defaultScope | `OAUTH_DEFAULT_SCOPE` | Pre-check scope if found in the security definition, default: `['openid']`. MUST be an array
+hideClientId | `OAUTH_HIDE_CLIENT_ID` | Hide the "client id" field, default `false`. MUST be a boolean
+hideClientSecret | `OAUTH_HIDE_CLIENT_SECRET` | Hide the "client secret" field, default `false`. MUST be a boolean
+hideScope | `OAUTH_HIDE_SCOPE` | Hide the "scope" selector, default `false`. MUST be a boolean
+hideInfo | `OAUTH_HIDE_INFO` | Hide the "OAuth2 information" paragraph, default `false`. MUST be a boolean
 ```javascript
 const ui = SwaggerUI({...})
 
@@ -23,6 +27,11 @@ ui.initOAuth({
     appName: "your-app-name",
     scopeSeparator: " ",
     additionalQueryStringParams: {test: "hello"},
-    usePkceWithAuthorizationCodeGrant: true
+    usePkceWithAuthorizationCodeGrant: true,
+    defaultScope: ["openid"],
+    hideClientSecret: false,
+    hideClientId: false,
+    hideScope: false,
+    hideInfo: false
   })
 ```

--- a/src/core/components/auth/oauth2.jsx
+++ b/src/core/components/auth/oauth2.jsx
@@ -208,10 +208,10 @@ export default class Oauth2 extends React.Component {
           </Row>
         }
 
-        {
-          !isAuthorized && scopes && scopes.size &&
+        { !isAuthorized && scopes && scopes.size &&
           !this.state.hideScope ? <div className="scopes">
             <h2>Scopes:</h2>
+            { this.state.scopes = this.state.defaultScope }
             { scopes.map((description, name) => {
               return (
                 <Row key={ name }>
@@ -219,7 +219,7 @@ export default class Oauth2 extends React.Component {
                     <Input data-value={ name }
                           id={`${name}-${flow}-checkbox-${this.state.name}`}
                            disabled={ isAuthorized }
-                           checked={ this.state.defaultScope.includes(name)}
+                           defaultChecked={this.state.defaultScope.includes(name)}
                            type="checkbox"
                            onChange={ this.onScopeChange }/>
                          <label htmlFor={`${name}-${flow}-checkbox-${this.state.name}`}>

--- a/src/core/components/auth/oauth2.jsx
+++ b/src/core/components/auth/oauth2.jsx
@@ -25,6 +25,11 @@ export default class Oauth2 extends React.Component {
     let clientId = auth && auth.get("clientId") || authConfigs.clientId || ""
     let clientSecret = auth && auth.get("clientSecret") || authConfigs.clientSecret || ""
     let passwordType = auth && auth.get("passwordType") || "basic"
+    let defaultScope = auth && auth.get("defaultScope") || authConfigs.defaultScope || ["openid"]
+    let hideClientId = auth && auth.get("hideClientId") || authConfigs.hideClientId
+    let hideClientSecret = auth && auth.get("hideClientSecret") || authConfigs.hideClientSecret
+    let hideScope = auth && auth.get("hideScope") || authConfigs.hideScope
+    let hideInfo = auth && auth.get("hideInfo") || authConfigs.hideInfo
 
     this.state = {
       appName: authConfigs.appName,
@@ -35,7 +40,12 @@ export default class Oauth2 extends React.Component {
       clientSecret: clientSecret,
       username: username,
       password: "",
-      passwordType: passwordType
+      passwordType: passwordType,
+      defaultScope: defaultScope,
+      hideClientId: hideClientId,
+      hideClientSecret: hideClientSecret,
+      hideScope: hideScope,
+      hideInfo: hideInfo
     }
   }
 
@@ -121,10 +131,9 @@ export default class Oauth2 extends React.Component {
         { description && <Markdown source={ schema.get("description") } /> }
 
         { isAuthorized && <h6>Authorized</h6> }
-
-        { ( flow === IMPLICIT || flow === ACCESS_CODE ) && <p>Authorization URL: <code>{ schema.get("authorizationUrl") }</code></p> }
-        { ( flow === PASSWORD || flow === ACCESS_CODE || flow === APPLICATION ) && <p>Token URL:<code> { schema.get("tokenUrl") }</code></p> }
-        <p className="flow">Flow: <code>{ schema.get("flow") }</code></p>
+        { !this.state.hideInfo && ( flow === IMPLICIT || flow === ACCESS_CODE ) && <p>Authorization URL: <code>{ schema.get("authorizationUrl") }</code></p> }
+        { !this.state.hideInfo && ( flow === PASSWORD || flow === ACCESS_CODE || flow === APPLICATION ) && <p>Token URL:<code> { schema.get("tokenUrl") }</code></p> }
+        { !this.state.hideInfo && <p className="flow">Flow: <code>{ schema.get("flow") }</code></p> }
 
         {
           flow !== PASSWORD ? null
@@ -166,7 +175,7 @@ export default class Oauth2 extends React.Component {
         }
         {
           ( flow === APPLICATION || flow === IMPLICIT || flow === ACCESS_CODE || flow === PASSWORD ) &&
-          ( !isAuthorized || isAuthorized && this.state.clientId) && <Row>
+          !this.state.hideClientId && !isAuthorized && <Row>
             <label htmlFor="client_id">client_id:</label>
             {
               isAuthorized ? <code> ****** </code>
@@ -183,24 +192,25 @@ export default class Oauth2 extends React.Component {
         }
 
         {
-          ( (flow === APPLICATION || flow === ACCESS_CODE || flow === PASSWORD) && <Row>
+          (flow === APPLICATION || flow === ACCESS_CODE || flow === PASSWORD) &&
+          !this.state.hideClientSecret && !isAuthorized && <Row>
             <label htmlFor="client_secret">client_secret:</label>
             {
-              isAuthorized ? <code> ****** </code>
-                           : <Col tablet={10} desktop={10}>
-                               <InitializedInput id="client_secret"
-                                      initialValue={ this.state.clientSecret }
-                                      type="password"
-                                      data-name="clientSecret"
-                                      onChange={ this.onInputChange }/>
-                             </Col>
+              <Col tablet={10} desktop={10}>
+                <InitializedInput id="client_secret"
+                      initialValue={ this.state.clientSecret }
+                      type="password"
+                      data-name="clientSecret"
+                      onChange={ this.onInputChange }/>
+              </Col>
             }
 
           </Row>
-        )}
+        }
 
         {
-          !isAuthorized && scopes && scopes.size ? <div className="scopes">
+          !isAuthorized && scopes && scopes.size &&
+          !this.state.hideScope ? <div className="scopes">
             <h2>Scopes:</h2>
             { scopes.map((description, name) => {
               return (
@@ -209,6 +219,7 @@ export default class Oauth2 extends React.Component {
                     <Input data-value={ name }
                           id={`${name}-${flow}-checkbox-${this.state.name}`}
                            disabled={ isAuthorized }
+                           checked={ this.state.defaultScope.includes(name)}
                            type="checkbox"
                            onChange={ this.onScopeChange }/>
                          <label htmlFor={`${name}-${flow}-checkbox-${this.state.name}`}>

--- a/src/core/oauth2-authorize.js
+++ b/src/core/oauth2-authorize.js
@@ -66,7 +66,7 @@ export default function authorize ( { auth, authActions, errActions, configs, au
     query.push("realm=" + encodeURIComponent(authConfigs.realm))
   }
 
-  if (flow === "authorizationCode" && authConfigs.usePkceWithAuthorizationCodeGrant) {
+  if ((flow === "authorizationCode" || flow === "accessCode") && authConfigs.usePkceWithAuthorizationCodeGrant) {
       const codeVerifier = generateCodeVerifier()
       const codeChallenge = createCodeChallenge(codeVerifier)
 

--- a/test/mocha/docker/oauth.js
+++ b/test/mocha/docker/oauth.js
@@ -23,7 +23,12 @@ describe("docker: env translator - oauth block", function() {
       OAUTH_APP_NAME: ``,
       OAUTH_SCOPE_SEPARATOR: "",
       OAUTH_ADDITIONAL_PARAMS: ``,
-      OAUTH_USE_PKCE: false
+      OAUTH_USE_PKCE: false,
+      OAUTH_DEFAULT_SCOPE: `[]`,
+      OAUTH_HIDE_CLIENT_ID: false,
+      OAUTH_HIDE_CLIENT_SECRET: false,
+      OAUTH_HIDE_SCOPE: false,
+      OAUTH_HIDE_INFO: false
     }
 
     expect(oauthBlockBuilder(input)).toEqual(dedent(`
@@ -35,6 +40,11 @@ describe("docker: env translator - oauth block", function() {
       scopeSeparator: "",
       additionalQueryStringParams: undefined,
       usePkceWithAuthorizationCodeGrant: false,
+      defaultScope: [],
+      hideClientId: false,
+      hideClientSecret: false,
+      hideScope: false,
+      hideInfo: false,
     })`))
   })
 
@@ -46,7 +56,12 @@ describe("docker: env translator - oauth block", function() {
       OAUTH_APP_NAME: `myAppName`,
       OAUTH_SCOPE_SEPARATOR: "%21",
       OAUTH_ADDITIONAL_PARAMS: `{ "a": 1234, "b": "stuff" }`,
-      OAUTH_USE_PKCE: true
+      OAUTH_USE_PKCE: true,
+      OAUTH_DEFAULT_SCOPE: `["openid", "profile"]`,
+      OAUTH_HIDE_CLIENT_ID: true,
+      OAUTH_HIDE_CLIENT_SECRET: true,
+      OAUTH_HIDE_SCOPE: true,
+      OAUTH_HIDE_INFO: true,
     }
 
     expect(oauthBlockBuilder(input)).toEqual(dedent(`
@@ -58,6 +73,11 @@ describe("docker: env translator - oauth block", function() {
       scopeSeparator: "%21",
       additionalQueryStringParams: { "a": 1234, "b": "stuff" },
       usePkceWithAuthorizationCodeGrant: true,
+      defaultScope: ["openid", "profile"],
+      hideClientId: true,
+      hideClientSecret: true,
+      hideScope: true,
+      hideInfo: true,
     })`))
   })
 })


### PR DESCRIPTION
Add the ability to customize the OAuth2 authentication form

### Description
Add configuration keys to ui.initOAuth to hide some fields and to define pre-checked scope.

```javascsript
ui.initOAuth({
  "clientId": "xxxxxx", 
  "usePkceWithAuthorizationCodeGrant": true, 
  "defaultScope": ["openid", "groups", "profile"], 
  "hideClientSecret": true, 
  "hideClientId": true, 
  "hideScope": false, 
  "hideInfo": true
})
```

This PR also enable the PKCE compatibility with OAS2

### Motivation and Context
In a AuthorizationCode flow with PKCE context, we don't want to display the client_secret field because it can confuse the user (because generally, when PKCE is activated, the client secret must be empty).

So i've implemented the possibility to show/hide some form fields and to pre-select scope (usefull if hidden or if a scope is mandatory like "openid" in the case of a OIDC authentication).

### How Has This Been Tested?
Test was done with all possible value of the the new configuration keys
It doesn't affect any other part of Swagger-UI code.

### Screenshots (if appropriate):
N/A


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [x] My changes require a change to the project documentation.
- [x] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
