### PR TITLE
Json request/response to set default values for json primitives base on schema definition

### DIFF
--- a/src/core/plugins/samples/fn.js
+++ b/src/core/plugins/samples/fn.js
@@ -20,6 +20,10 @@ const primitives = {
 
 const primitive = (schema) => {
   schema = objectify(schema)
+  if (schema.hasOwnProperty("default")) { // Need to accept empty string values as present
+    return schema["default"]
+  }
+
   let { type, format } = schema
 
   let fn = primitives[`${type}_${format}`] || primitives[type]


### PR DESCRIPTION
As a user I would like to be able to have the 'default' value provided by my OpenAPI definition for primitive fields (string, integer, etc) be presented in the request and response payloads in the swagger ui.

### Description
This change makes it so that when getting a sample from schema for a json content type the 'primitive' function will check for a 'default' value set in the schema and use that if it is present.

Only a single file was changed, src/core/plugins/samples/fn.js
The 'primitive' function now checks if the schema object that was passed into has a 'default' property set and if use returns the value from the 'default' property instead of auto generating a value.

### Motivation and Context
This change is meant to help users when learning an api to get a better idea of what default values will come back in the response and to help users when 'trying out' requests to avoid sending bad data, e.g. 'string' for string fields when a good default value is present in the OpenAPI definition.

### How Has This Been Tested?
I manually tested with the attached sample.yaml file
[sample.yaml.zip](https://github.com/swagger-api/swagger-ui/files/4258536/sample.yaml.zip)

I checked that for string and integer primitives the default value was presented in the request and response payload previews. Also that when clicking it 'try it out' and 'execute' that the expected defaults were present and sent.

Tested on OS X Catalina 10.15.3
Safari Version 13.0.5 (15608.5.11)

### My PR contains... 
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
