### PR TITLE
improvement: showCommonExtensions support for OAS3 parameters

### DIFF
--- a/src/core/components/parameter-row.jsx
+++ b/src/core/components/parameter-row.jsx
@@ -220,7 +220,7 @@ export default class ParameterRow extends Component {
     let itemType = schema.getIn(["items", "type"])
 
     let value = paramWithMeta ? paramWithMeta.get("value") : ""
-    let commonExt = showCommonExtensions ? getCommonExtensions(param) : null
+    let commonExt = showCommonExtensions ? getCommonExtensions(schema) : null
     let extensions = showExtensions ? getExtensions(param) : null
 
     let paramItems // undefined


### PR DESCRIPTION
### Description
Swagger UI has the [`showCommonExtensions`](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md#user-content-showcommonextensions) option that displays the `maximum`, `minimum`, `maxLength`, `minLength`, and `pattern` attributes for primitive parameters in OAS2 definitions. This PR makes this work for OAS3 parameters as well.

### Motivation and Context
Fixes #5016.

### How Has This Been Tested?
Manually.

### Screenshots (if appropriate):
Here, Swagger UI is configured with `showCommonExtensions: true`.

![Swagger UI showing parameter minimum, maximum, minLength, maxLength, and pattern](https://user-images.githubusercontent.com/8576823/76010222-9a926180-5f23-11ea-823d-9e3068829760.png)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
