### PR TITLE
docs: update prerequisites for development

### DIFF
--- a/docs/development/setting-up.md
+++ b/docs/development/setting-up.md
@@ -4,10 +4,22 @@ Swagger UI includes a development server that provides hot module reloading and 
 
 ### Prerequisites
 
-- Node.js `6.0.0` or greater
-- npm `3.0.0` or greater
 - git, any version
+- NPM 6.x
 
+Generally, we recommend following guidelines from [Node.js Releases](https://nodejs.org/en/about/releases/) to only use Active LTS or Maintenance LTS releases.
+
+Current Node.js Active LTS:
+- Node.js 12.x
+- NPM 6.x
+
+Current Node.js Maintenance LTS:
+- Node.js 10.x
+- NPM 6.x
+
+Unsupported Node.js LTS that should still work:
+- Node.js 8.13.0 or greater
+- NPM 6.x
 
 ### Steps
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


### Description
<!--- Describe your changes in detail -->
Update prerequisites to recommend using latest version of Node.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->
Consistency of documentation between swagger-ui and swagger-editor.
Refs: [Required Fix for swagger-editor](https://github.com/swagger-api/swagger-editor/pull/2118)

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I can confirm that node v6.17.1 still does work locally (MacOS Catalina), despite the documentation change.
v8.17.0, v10.10.0, v12.16.1, and v13.9.0 also still work


### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [x] My changes require a change to the project documentation.
- [x] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
