### PR TITLE
Fix: #5669 online validator badge

### DIFF
--- a/docs/development/setting-up.md
+++ b/docs/development/setting-up.md
@@ -4,10 +4,22 @@ Swagger UI includes a development server that provides hot module reloading and 
 
 ### Prerequisites
 
-- Node.js `6.0.0` or greater
-- npm `3.0.0` or greater
 - git, any version
+- NPM 6.x
 
+Generally, we recommend following guidelines from [Node.js Releases](https://nodejs.org/en/about/releases/) to only use Active LTS or Maintenance LTS releases.
+
+Current Node.js Active LTS:
+- Node.js 12.x
+- NPM 6.x
+
+Current Node.js Maintenance LTS:
+- Node.js 10.x
+- NPM 6.x
+
+Unsupported Node.js LTS that should still work:
+- Node.js 8.13.0 or greater
+- NPM 6.x
 
 ### Steps
 

--- a/src/core/plugins/oas3/wrap-components/online-validator-badge.js
+++ b/src/core/plugins/oas3/wrap-components/online-validator-badge.js
@@ -1,5 +1,24 @@
 import { OAS3ComponentWrapFactory } from "../helpers"
+import OnlineValidatorBadge from "core/components/online-validator-badge"
 
 // We're disabling the Online Validator Badge until the online validator
 // can handle OAS3 specs.
-export default OAS3ComponentWrapFactory(() => null)
+// export default OAS3ComponentWrapFactory(() => null)
+// OAS3 spec is now supported. Return OnlineValidatorBadge.
+// export default OAS3ComponentWrapFactory(OnlineValidatorBadge)
+
+
+const VALIDATOR_CAN_HANDLE_OAS3_SPECS = true
+
+export const handleFlag = (wrapped) => {
+  if (VALIDATOR_CAN_HANDLE_OAS3_SPECS) {
+    return (
+      wrapped(OnlineValidatorBadge)
+    )
+  }
+  return (
+    // renders but console error: setState(...): Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op. Please check the code for the ValidatorImage component.
+    wrapped(() => null)
+  )
+}
+export default handleFlag(OAS3ComponentWrapFactory)

--- a/src/core/plugins/oas3/wrap-components/online-validator-badge.js
+++ b/src/core/plugins/oas3/wrap-components/online-validator-badge.js
@@ -1,24 +1,5 @@
 import { OAS3ComponentWrapFactory } from "../helpers"
 import OnlineValidatorBadge from "core/components/online-validator-badge"
 
-// We're disabling the Online Validator Badge until the online validator
-// can handle OAS3 specs.
-// export default OAS3ComponentWrapFactory(() => null)
-// OAS3 spec is now supported. Return OnlineValidatorBadge.
-// export default OAS3ComponentWrapFactory(OnlineValidatorBadge)
-
-
-const VALIDATOR_CAN_HANDLE_OAS3_SPECS = true
-
-export const handleFlag = (wrapped) => {
-  if (VALIDATOR_CAN_HANDLE_OAS3_SPECS) {
-    return (
-      wrapped(OnlineValidatorBadge)
-    )
-  }
-  return (
-    // renders but console error: setState(...): Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op. Please check the code for the ValidatorImage component.
-    wrapped(() => null)
-  )
-}
-export default handleFlag(OAS3ComponentWrapFactory)
+// OAS3 spec is now supported by the online validator.
+export default OAS3ComponentWrapFactory(OnlineValidatorBadge)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
The `online-validator-badge.js` now returns `OnlineValidatorBadge` instead of `null`. 


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->
- The 3.0 wrapper for `OnlineValidatorBadge` previously returned `null`. This was done because the external online validator tool previously did not support OAS3 specs.
- Instead of "unwrapping" as a possible solution, this fix maintains the 3.0 wrapper for `OnlineValidatorBadge`, in case the wrapper is needed again in the future.
- This fix is independent of the external online validator tool. It is simply a display fix (to always be visible).


### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On local, I had to manually input the url into the topBar, as provided by a comment in the ticket (https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/examples/v3.0/petstore.yaml).

Pre-fix, the green validator badge was not be visible.
post- fix, the green validator badge should be visible.

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
