### PR TITLE
bug: expected PropType in Model ImmutablePureComponent should be a map, instead of OrderedMap

### DIFF
--- a/docs/development/setting-up.md
+++ b/docs/development/setting-up.md
@@ -4,10 +4,22 @@ Swagger UI includes a development server that provides hot module reloading and 
 
 ### Prerequisites
 
-- Node.js `6.0.0` or greater
-- npm `3.0.0` or greater
 - git, any version
+- NPM 6.x
 
+Generally, we recommend following guidelines from [Node.js Releases](https://nodejs.org/en/about/releases/) to only use Active LTS or Maintenance LTS releases.
+
+Current Node.js Active LTS:
+- Node.js 12.x
+- NPM 6.x
+
+Current Node.js Maintenance LTS:
+- Node.js 10.x
+- NPM 6.x
+
+Unsupported Node.js LTS that should still work:
+- Node.js 8.13.0 or greater
+- NPM 6.x
 
 ### Steps
 

--- a/src/core/components/model.jsx
+++ b/src/core/components/model.jsx
@@ -5,7 +5,7 @@ import PropTypes from "prop-types"
 
 export default class Model extends ImmutablePureComponent {
   static propTypes = {
-    schema: ImPropTypes.orderedMap.isRequired,
+    schema: ImPropTypes.map.isRequired,
     getComponent: PropTypes.func.isRequired,
     getConfigs: PropTypes.func.isRequired,
     specSelectors: PropTypes.object.isRequired,

--- a/src/core/components/object-model.jsx
+++ b/src/core/components/object-model.jsx
@@ -114,7 +114,7 @@ export default class ObjectModel extends Component {
               }
               {
                 // empty row befor extensions...
-                !showExtensions ? null : <tr>&nbsp;</tr>
+                !showExtensions ? null : <tr><td>&nbsp;</td></tr>
               }
               {
                 !showExtensions ? null :


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Changed  from `schema: ImPropTypes.orderedMap.isRequired,` to `schema: ImPropTypes.map.isRequired`


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->
Prior to this change, there exists a console error
```
Warning: Failed prop type: Invalid prop `schema` of type `Immutable.Map` supplied to `Model`, expected `OrderedMap`.
    in Model (created by ModelWrapper)
    in ModelWrapper (created by Models)
    in span (created by ModelCollapse)
    in ModelCollapse (created by Models)
    in div (created by Models)
    in div (created by NoMargin)
    in NoMargin (created by Collapse)
    in Collapse (created by Models)
    in section (created by Models)
    in Models (created by _class)
    [...more output omitted...]
```


### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Run Swagger UI in development mode
2. In the default Petstore definition, expand the ApiResponse model
3. Observe that a PropType error has been emitted in your browser's console...


### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
