### PR TITLE
housekeeping: prevent log warning for missing getComponent in production

### DIFF
--- a/src/core/json-schema-components.jsx
+++ b/src/core/json-schema-components.jsx
@@ -52,7 +52,8 @@ export class JsonSchemaForm extends Component {
     let { type, format="" } = schema
     // In the json schema rendering code, we optimistically query our system for a number of components.
     // If the component doesn't exist, we optionally suppress these warnings.
-    let Comp = (format ? getComponent(`JsonSchema_${type}_${format}`, false, { failSilently: true }) : getComponent(`JsonSchema_${type}`, false, { failSilently: true })) || getComponent("JsonSchema_string", false, { failSilently: true })
+    let getComponentSilently = (name) => getComponent(name, false, { failSilently: true })
+    let Comp = (format ? getComponentSilently(`JsonSchema_${type}_${format}`) : getComponentSilently(`JsonSchema_${type}`)) || getComponentSilently("JsonSchema_string")
     return <Comp { ...this.props } errors={errors} fn={fn} getComponent={getComponent} value={value} onChange={onChange} schema={schema} disabled={disabled}/>
   }
 

--- a/src/core/json-schema-components.jsx
+++ b/src/core/json-schema-components.jsx
@@ -50,8 +50,9 @@ export class JsonSchemaForm extends Component {
       schema = schema.toJS()
 
     let { type, format="" } = schema
-
-    let Comp = (format ? getComponent(`JsonSchema_${type}_${format}`) : getComponent(`JsonSchema_${type}`)) || getComponent("JsonSchema_string")
+    // In the json schema rendering code, we optimistically query our system for a number of components.
+    // If the component doesn't exist, we optionally suppress these warnings.
+    let Comp = (format ? getComponent(`JsonSchema_${type}_${format}`, false, { failSilently: true }) : getComponent(`JsonSchema_${type}`, false, { failSilently: true })) || getComponent("JsonSchema_string", false, { failSilently: true })
     return <Comp { ...this.props } errors={errors} fn={fn} getComponent={getComponent} value={value} onChange={onChange} schema={schema} disabled={disabled}/>
   }
 

--- a/src/core/plugins/view/root-injects.jsx
+++ b/src/core/plugins/view/root-injects.jsx
@@ -113,7 +113,7 @@ export const getComponent = (getSystem, getStore, getComponents, componentName, 
 
   if(!component) {
     if (!config.failSilently) {
-      getSystem().log.warn("Could not find component:", componentName, " | config:", config)
+      getSystem().log.warn("Could not find component:", componentName)
     }
     return null
   }

--- a/src/core/plugins/view/root-injects.jsx
+++ b/src/core/plugins/view/root-injects.jsx
@@ -101,7 +101,7 @@ const wrapRender = (component) => {
 }
 
 
-export const getComponent = (getSystem, getStore, getComponents, componentName, container, config) => {
+export const getComponent = (getSystem, getStore, getComponents, componentName, container, config = {}) => {
 
   if(typeof componentName !== "string")
     throw new TypeError("Need a string, to fetch a component. Was given a " + typeof componentName)

--- a/src/core/plugins/view/root-injects.jsx
+++ b/src/core/plugins/view/root-injects.jsx
@@ -101,18 +101,19 @@ const wrapRender = (component) => {
 }
 
 
-export const getComponent = (getSystem, getStore, getComponents, componentName, container) => {
+export const getComponent = (getSystem, getStore, getComponents, componentName, container, config) => {
 
   if(typeof componentName !== "string")
     throw new TypeError("Need a string, to fetch a component. Was given a " + typeof componentName)
 
+    // getComponent has a config object as a third, optional parameter
+    // using the config object requires the presence of the second parameter, container
+    // e.g. getComponent("JsonSchema_string_whatever", false, { failSilently: true })
   let component = getComponents(componentName)
 
   if(!component) {
-    if (process.env.NODE_ENV !== "production") {
-      // In the json schema rendering code, we optimistically query our system for a number of components.
-      // If the component doesn't exist, these warnings get thrown (in non-production mode).
-      getSystem().log.warn("Could not find component", componentName)
+    if (!(config && config.failSilently)) {
+      getSystem().log.warn("Could not find component:", componentName, " | config:", config)
     }
     return null
   }

--- a/src/core/plugins/view/root-injects.jsx
+++ b/src/core/plugins/view/root-injects.jsx
@@ -109,7 +109,11 @@ export const getComponent = (getSystem, getStore, getComponents, componentName, 
   let component = getComponents(componentName)
 
   if(!component) {
-    getSystem().log.warn("Could not find component", componentName)
+    if (process.env.NODE_ENV !== "production") {
+      // In the json schema rendering code, we optimistically query our system for a number of components.
+      // If the component doesn't exist, these warnings get thrown (in non-production mode).
+      getSystem().log.warn("Could not find component", componentName)
+    }
     return null
   }
 

--- a/src/core/plugins/view/root-injects.jsx
+++ b/src/core/plugins/view/root-injects.jsx
@@ -112,7 +112,7 @@ export const getComponent = (getSystem, getStore, getComponents, componentName, 
   let component = getComponents(componentName)
 
   if(!component) {
-    if (!(config && config.failSilently)) {
+    if (!config.failSilently) {
       getSystem().log.warn("Could not find component:", componentName, " | config:", config)
     }
     return null


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
~Add a `process.env.NODE_ENV` check before logging a warning of a missing getComponent~
New: getComponent has a config object as a third, optional parameter
using the config object requires the presence of the second parameter, container
e.g. getComponent("JsonSchema_string_whatever", false, { failSilently: true })

JsonSchemaForm specifically now optionally suppresses the warning.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->
extending #2931, where this is generally a safe warning and nothing needs to be done by the user. so we should silence the warning in production mode. 


### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tested manually using different NODE_ENV + CRA
dev mode, easiest to identify with query parameter, e.g. http://localhost:3200/?docExpansion=full


### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
