### PR TITLE
housekeeping: prevent log warning for missing getComponent in production #5919

### DIFF
--- a/src/core/json-schema-components.jsx
+++ b/src/core/json-schema-components.jsx
@@ -50,8 +50,13 @@ export class JsonSchemaForm extends Component {
       schema = schema.toJS()
 
     let { type, format="" } = schema
-
-    let Comp = (format ? getComponent(`JsonSchema_${type}_${format}`) : getComponent(`JsonSchema_${type}`)) || getComponent("JsonSchema_string")
+    // In the json schema rendering code, we optimistically query our system for a number of components.
+    // If the component doesn't exist, we optionally suppress these warnings.
+    let getComponentSilently = (name) => getComponent(name, false, { failSilently: true })
+    let Comp = (format ? 
+      getComponentSilently(`JsonSchema_${type}_${format}`) :
+      getComponentSilently(`JsonSchema_${type}`)) ||
+      getComponentSilently("JsonSchema_string")
     return <Comp { ...this.props } errors={errors} fn={fn} getComponent={getComponent} value={value} onChange={onChange} schema={schema} disabled={disabled}/>
   }
 

--- a/src/core/plugins/view/root-injects.jsx
+++ b/src/core/plugins/view/root-injects.jsx
@@ -100,16 +100,20 @@ const wrapRender = (component) => {
   return target
 }
 
-
-export const getComponent = (getSystem, getStore, getComponents, componentName, container) => {
+export const getComponent = (getSystem, getStore, getComponents, componentName, container, config = {}) => {
 
   if(typeof componentName !== "string")
     throw new TypeError("Need a string, to fetch a component. Was given a " + typeof componentName)
 
+    // getComponent has a config object as a third, optional parameter
+    // using the config object requires the presence of the second parameter, container
+    // e.g. getComponent("JsonSchema_string_whatever", false, { failSilently: true })
   let component = getComponents(componentName)
 
   if(!component) {
-    getSystem().log.warn("Could not find component", componentName)
+    if (!config.failSilently) {
+      getSystem().log.warn("Could not find component:", componentName)
+    }
     return null
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
squash commits from review in PR #5919


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->
have a clean commit history


### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A. already tested from PR #5919 


### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
