### PR TITLE
bug: remove clearValidation from onTryoutClick (#5070)

### DIFF
--- a/src/core/components/execute.jsx
+++ b/src/core/components/execute.jsx
@@ -22,6 +22,12 @@ export default class Execute extends Component {
         this.props.onExecute()
       }
       specActions.execute( { operation, path, method } )
+    } else {
+      // deferred by 40ms, to give element class change time to settle.
+      specActions.clearValidateParams( [path, method] )
+      setTimeout(() => {
+        specActions.validateParams([path, method])
+      }, 40)
     }
   }
 

--- a/src/core/containers/OperationContainer.jsx
+++ b/src/core/containers/OperationContainer.jsx
@@ -118,9 +118,7 @@ export default class OperationContainer extends PureComponent {
   }
 
   onTryoutClick =() => {
-    let { specActions, path, method } = this.props
     this.setState({tryItOutEnabled: !this.state.tryItOutEnabled})
-    specActions.clearValidateParams([path, method])
   }
 
   onExecute = () => {

--- a/test/e2e-cypress/tests/bugs/5070.js
+++ b/test/e2e-cypress/tests/bugs/5070.js
@@ -1,0 +1,32 @@
+describe("#5070: Required field not highlighted on click of Execute button (second time)", () => {
+  it("should not clear error class=invalid on input field (Swagger)", () => {
+    cy
+      .visit("/?url=/documents/petstore.swagger.yaml")
+      .get("#operations-pet-getPetById")
+      .click()
+      // Expand Try It Out
+      .get(".try-out__btn")
+      .click()
+      // Execute without user input
+      .get(".execute.opblock-control__btn")
+      .click()
+      .get(".parameters-col_description input")
+      .should($el => {
+        expect($el).to.have.length(1)
+        const className = $el[0].className
+        expect(className).to.match(/invalid/i)
+      })
+      // Cancel Try It Out
+      .get(".cancel")
+      .click()
+      // Expand Try It Out (Again)
+      .get(".try-out__btn")
+      .click()
+      .get(".parameters-col_description input")
+      .should($el => {
+        expect($el).to.have.length(1)
+        const className = $el[0].className
+        expect(className).to.match(/invalid/i)
+      })
+  })
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Remove clearValidation function from onClick of Try It Out. As a result, the red error field will remain red.

In addition, the input box will now also re-bounce on subsequent onClick of "Execute"


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->
From #5070, Clicking on Try It Out button also calls a function that clears the validation errors that might be present. It can be confusing to the user that the error appears to have gone away when the red validation fields disappears. However, the error is actually still present, and Execute will not fire off an actual request (this part is ok and expected)


### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
new cypress test included in this PR


### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
