### PR TITLE
Direct link to models

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "hot-e2e-selenium-server": "webpack-dev-server --config webpack/dev-e2e.babel.js --content-base test/e2e-selenium/static",
     "e2e-cypress": "run-p -r hot-e2e-cypress-server mock-api test-e2e-cypress",
     "dev-test-e2e-cypress-open": "cypress open",
-    "dev-e2e-cypress": "run-p -r hot-e2e-cypress-server mock-api dev-e2e-cypress-open",
+    "dev-e2e-cypress": "run-p -r hot-e2e-cypress-server mock-api dev-test-e2e-cypress-open",
     "e2e-selenium": "run-p -r hot-e2e-selenium-server mock-api test-e2e-selenium",
     "open-static": "node -e \"require('open')('http://localhost:3002')\"",
     "security-audit": "run-s -sc security-audit:all security-audit:prod",

--- a/src/core/components/model-container.jsx
+++ b/src/core/components/model-container.jsx
@@ -1,0 +1,100 @@
+import React, { Component } from "react"
+import Im, { Map } from "immutable"
+import PropTypes from "prop-types"
+
+export default class ModelContainer extends Component {
+  static propTypes = {
+    name: PropTypes.string,
+    specSelectors: PropTypes.object,
+    layoutSelectors: PropTypes.object,
+    specActions: PropTypes.object.isRequired,
+    getComponent: PropTypes.func,
+    getConfigs: PropTypes.func.isRequired,
+    layoutActions: PropTypes.object
+  }
+
+  getSingleModelForRender(name, specSelectors, layoutSelectors, specActions,
+                          getComponent, getConfigs, layoutActions) {
+
+    const getSchemaBasePath = () => {
+      const isOAS3 = specSelectors.isOAS3()
+      return isOAS3 ? ["components", "schemas"] : ["definitions"]
+    }
+
+    const getCollapsedContent = () => {
+      return " "
+    }
+
+    const handleToggle = (name, isExpanded) => {
+      layoutActions.show(["models", name], isExpanded)
+      if(isExpanded) {
+        specActions.requestResolvedSubtree([...getSchemaBasePath(), name])
+      }
+    }
+
+    const ModelWrapper = getComponent("ModelWrapper")
+    const ModelCollapse = getComponent("ModelCollapse")
+    const JumpToPath = getComponent("JumpToPath")
+    let { defaultModelsExpandDepth } = getConfigs()
+    const fullPath = [...getSchemaBasePath(), name]
+
+    const schemaValue = specSelectors.specResolvedSubtree(fullPath)
+    const rawSchemaValue = specSelectors.specJson().getIn(fullPath)
+
+    const schema = Map.isMap(schemaValue) ? schemaValue : Im.Map()
+    const rawSchema = Map.isMap(rawSchemaValue) ? rawSchemaValue : Im.Map()
+
+    const displayName = schema.get("title") || rawSchema.get("title") || name
+    const isShown = layoutSelectors.isShown( ["models", name], false )
+
+    if( isShown && (schema.size === 0 && rawSchema.size > 0) ) {
+      // Firing an action in a container render is not great,
+      // but it works for now.
+      specActions.requestResolvedSubtree([...getSchemaBasePath(), name])
+    }
+
+    const expanded = defaultModelsExpandDepth > 0 && isShown
+
+    const specPath = Im.List([...getSchemaBasePath(), name])
+
+    const content = <ModelWrapper name={ name }
+                                  expandDepth={ defaultModelsExpandDepth }
+                                  schema={ schema || Im.Map() }
+                                  displayName={displayName}
+                                  specPath={specPath}
+                                  getComponent={ getComponent }
+                                  specSelectors={ specSelectors }
+                                  getConfigs = {getConfigs}
+                                  layoutSelectors = {layoutSelectors}
+                                  layoutActions = {layoutActions}/>
+
+    const title = <span className="model-box">
+              <span className="model model-title">
+                {displayName}
+              </span>
+            </span>
+
+    return <div id={ `model-${name}` } className="model-container" data-name={name} data-is-open={ expanded }>
+      <span className="models-jump-to-path"><JumpToPath specPath={specPath} /></span>
+      <ModelCollapse
+        classes="model-box"
+        collapsedContent={getCollapsedContent(name)}
+        onToggle={handleToggle}
+        title={title}
+        displayName={displayName}
+        modelName={name}
+        hideSelfOnExpand={true}
+        expanded={ expanded }
+      >{content}</ModelCollapse>
+    </div>
+  }
+
+  render(){
+    let {name, specSelectors, layoutSelectors, specActions,
+      getComponent, getConfigs, layoutActions} = this.props
+
+    return this.getSingleModelForRender(name, specSelectors, layoutSelectors, specActions,
+      getComponent, getConfigs, layoutActions
+    )
+  }
+}

--- a/src/core/components/models.jsx
+++ b/src/core/components/models.jsx
@@ -1,5 +1,4 @@
 import React, { Component } from "react"
-import Im, { Map } from "immutable"
 import PropTypes from "prop-types"
 
 export default class Models extends Component {
@@ -12,37 +11,17 @@ export default class Models extends Component {
     getConfigs: PropTypes.func.isRequired
   }
 
-  getSchemaBasePath = () => {
-    const isOAS3 = this.props.specSelectors.isOAS3()
-    return isOAS3 ? ["components", "schemas"] : ["definitions"]
-  }
-
-  getCollapsedContent = () => {
-    return " "
-  }
-
-  handleToggle = (name, isExpanded) => {
-    const { layoutActions } = this.props
-    layoutActions.show(["models", name], isExpanded)
-    if(isExpanded) {
-      this.props.specActions.requestResolvedSubtree([...this.getSchemaBasePath(), name])
-    }
-  }
-
   render(){
-    let { specSelectors, getComponent, layoutSelectors, layoutActions, getConfigs } = this.props
+    let { specSelectors, getComponent, layoutSelectors, specActions, layoutActions, getConfigs } = this.props
     let definitions = specSelectors.definitions()
     let { docExpansion, defaultModelsExpandDepth } = getConfigs()
     if (!definitions.size || defaultModelsExpandDepth < 0) return null
 
     let showModels = layoutSelectors.isShown("models", defaultModelsExpandDepth > 0 && docExpansion !== "none")
-    const specPathBase = this.getSchemaBasePath()
     const isOAS3 = specSelectors.isOAS3()
 
-    const ModelWrapper = getComponent("ModelWrapper")
     const Collapse = getComponent("Collapse")
-    const ModelCollapse = getComponent("ModelCollapse")
-    const JumpToPath = getComponent("JumpToPath")
+    const ModelContainer = getComponent("ModelContainer")
 
     return <section className={ showModels ? "models is-open" : "models"}>
       <h4 onClick={() => layoutActions.show("models", !showModels)}>
@@ -53,58 +32,21 @@ export default class Models extends Component {
       </h4>
       <Collapse isOpened={showModels}>
         {
-          definitions.entrySeq().map(([name])=>{
-
-            const fullPath = [...specPathBase, name]
-
-            const schemaValue = specSelectors.specResolvedSubtree(fullPath)
-            const rawSchemaValue = specSelectors.specJson().getIn(fullPath)
-
-            const schema = Map.isMap(schemaValue) ? schemaValue : Im.Map()
-            const rawSchema = Map.isMap(rawSchemaValue) ? rawSchemaValue : Im.Map()
-
-            const displayName = schema.get("title") || rawSchema.get("title") || name
-            const isShown = layoutSelectors.isShown( ["models", name], false )
-
-            if( isShown && (schema.size === 0 && rawSchema.size > 0) ) {
-              // Firing an action in a container render is not great,
-              // but it works for now.
-              this.props.specActions.requestResolvedSubtree([...this.getSchemaBasePath(), name])
-            }
-
-            const specPath = Im.List([...specPathBase, name])
-
-            const content = <ModelWrapper name={ name }
-              expandDepth={ defaultModelsExpandDepth }
-              schema={ schema || Im.Map() }
-              displayName={displayName}
-              specPath={specPath}
-              getComponent={ getComponent }
-              specSelectors={ specSelectors }
-              getConfigs = {getConfigs}
-              layoutSelectors = {layoutSelectors}
-              layoutActions = {layoutActions}/>
-
-            const title = <span className="model-box">
-              <span className="model model-title">
-                {displayName}
-              </span>
-            </span>
-
-            return <div id={ `model-${name}` } className="model-container" key={ `models-section-${name}` }>
-              <span className="models-jump-to-path"><JumpToPath specPath={specPath} /></span>
-              <ModelCollapse
-                classes="model-box"
-                collapsedContent={this.getCollapsedContent(name)}
-                onToggle={this.handleToggle}
-                title={title}
-                displayName={displayName}
-                modelName={name}
-                hideSelfOnExpand={true}
-                expanded={ defaultModelsExpandDepth > 0 && isShown }
-                >{content}</ModelCollapse>
-              </div>
-          }).toArray()
+          definitions.entrySeq()
+            .map(([name])=> {
+              return (
+                <ModelContainer key={ `models-section-${name}`}
+                  name={name}
+                  specSelectors={specSelectors}
+                  layoutSelectors={layoutSelectors}
+                  specActions={specActions}
+                  getComponent={getComponent}
+                  getConfigs={getConfigs}
+                  layoutActions={layoutActions}
+                />
+              )
+          })
+            .toArray()
         }
       </Collapse>
     </section>

--- a/src/core/plugins/deep-linking/index.js
+++ b/src/core/plugins/deep-linking/index.js
@@ -2,7 +2,7 @@ import layout from "./layout"
 import OperationWrapper from "./operation-wrapper"
 import OperationTagWrapper from "./operation-tag-wrapper"
 import ModelsWrapper from "./models-wrapper"
-import ModelCollapseWrapper from "./model-collapse-wrapper"
+import ModelContainerWrapper from "./model-container-wrapper"
 
 export default function() {
   return [layout, {
@@ -22,7 +22,7 @@ export default function() {
       operation: OperationWrapper,
       OperationTag: OperationTagWrapper,
       Models: ModelsWrapper,
-      ModelCollapse: ModelCollapseWrapper,
+      ModelContainer: ModelContainerWrapper,
     },
   }]
 }

--- a/src/core/plugins/deep-linking/index.js
+++ b/src/core/plugins/deep-linking/index.js
@@ -1,6 +1,8 @@
 import layout from "./layout"
 import OperationWrapper from "./operation-wrapper"
 import OperationTagWrapper from "./operation-tag-wrapper"
+import ModelsWrapper from "./models-wrapper"
+import ModelCollapseWrapper from "./model-collapse-wrapper"
 
 export default function() {
   return [layout, {
@@ -19,6 +21,8 @@ export default function() {
     wrapComponents: {
       operation: OperationWrapper,
       OperationTag: OperationTagWrapper,
+      Models: ModelsWrapper,
+      ModelCollapse: ModelCollapseWrapper,
     },
   }]
 }

--- a/src/core/plugins/deep-linking/layout.js
+++ b/src/core/plugins/deep-linking/layout.js
@@ -93,6 +93,12 @@ export const parseDeepLinkHash = (rawHash) => ({ layoutActions, layoutSelectors,
       layoutActions.show(tagIsShownKey, true)
     }
 
+    if(type === "models" && tagId) {
+      // we're going to show a model, so we need to expand the models as well
+      const tagIsShownKey = layoutSelectors.isShownKeyFromUrlHashArray([type])
+      layoutActions.show(tagIsShownKey, true)
+    }
+
     // If an `_` is present, trigger the legacy escaping behavior to be safe
     // TODO: remove this in v4.0, it is deprecated
     if (tagId.indexOf("_") > -1 || maybeOperationId.indexOf("_") > -1) {
@@ -173,22 +179,30 @@ export default {
           return state.get("scrollToKey")
         },
         isShownKeyFromUrlHashArray(state, urlHashArray) {
-          const [tag, operationId] = urlHashArray
+          const [firstPart, secondPart] = urlHashArray
           // We only put operations in the URL
-          if(operationId) {
-            return ["operations", tag, operationId]
-          } else if (tag) {
-            return ["operations-tag", tag]
+          if(firstPart === "models" && secondPart) {
+            return [firstPart, secondPart]
+          } else if (firstPart === "models") {
+            return [firstPart]
+          } else if(secondPart) {
+            return ["operations", firstPart, secondPart]
+          } else if (firstPart) {
+            return ["operations-tag", firstPart]
           }
           return []
         },
         urlHashArrayFromIsShownKey(state, isShownKey) {
-          let [type, tag, operationId] = isShownKey
+          let [type, firstPart, secondPart] = isShownKey
           // We only put operations in the URL
-          if(type == "operations") {
-            return [tag, operationId]
+          if(type === "models" && firstPart) {
+            return [type, firstPart]
+          } else if (type === "models") {
+            return [type]
+          } else if(type == "operations") {
+            return [firstPart, secondPart]
           } else if (type == "operations-tag") {
-            return [tag]
+            return [firstPart]
           }
           return []
         },

--- a/src/core/plugins/deep-linking/model-collapse-wrapper.jsx
+++ b/src/core/plugins/deep-linking/model-collapse-wrapper.jsx
@@ -1,0 +1,25 @@
+import React from "react"
+import { PropTypes } from "prop-types"
+
+const Wrapper = (Ori, system) => class ModelCollapseWrapper extends React.Component {
+
+  static propTypes = {
+    modelName: PropTypes.object.isRequired,
+  }
+
+  onLoad = (ref) => {
+    const { modelName } = this.props
+    const isShownKey = ["models", modelName]
+    system.layoutActions.readyToScroll(isShownKey, ref)
+  }
+
+  render() {
+    return (
+      <span ref={this.onLoad}>
+        <Ori {...this.props} />
+      </span>
+    )
+  }
+}
+
+export default Wrapper

--- a/src/core/plugins/deep-linking/model-container-wrapper.jsx
+++ b/src/core/plugins/deep-linking/model-container-wrapper.jsx
@@ -1,23 +1,23 @@
 import React from "react"
 import { PropTypes } from "prop-types"
 
-const Wrapper = (Ori, system) => class ModelCollapseWrapper extends React.Component {
+const Wrapper = (Ori, system) => class ModelContainerWrapper extends React.Component {
 
   static propTypes = {
-    modelName: PropTypes.object.isRequired,
+    name: PropTypes.object.isRequired,
   }
 
   onLoad = (ref) => {
-    const { modelName } = this.props
-    const isShownKey = ["models", modelName]
+    const { name } = this.props
+    const isShownKey = ["models", name]
     system.layoutActions.readyToScroll(isShownKey, ref)
   }
 
   render() {
     return (
-      <span ref={this.onLoad}>
+      <div ref={this.onLoad}>
         <Ori {...this.props} />
-      </span>
+      </div>
     )
   }
 }

--- a/src/core/plugins/deep-linking/models-wrapper.jsx
+++ b/src/core/plugins/deep-linking/models-wrapper.jsx
@@ -1,0 +1,19 @@
+import React from "react"
+
+const Wrapper = (Ori, system) => class ModelsWrapper extends React.Component {
+
+  onLoad = (ref) => {
+    const isShownKey = ["models"]
+    system.layoutActions.readyToScroll(isShownKey, ref)
+  }
+
+  render() {
+    return (
+      <span ref={this.onLoad}>
+        <Ori {...this.props} />
+      </span>
+    )
+  }
+}
+
+export default Wrapper

--- a/src/core/presets/base.js
+++ b/src/core/presets/base.js
@@ -66,6 +66,7 @@ import ParamBody from "core/components/param-body"
 import Curl from "core/components/curl"
 import Schemes from "core/components/schemes"
 import SchemesContainer from "core/containers/schemes"
+import ModelContainer from "core/components/model-container"
 import ModelCollapse from "core/components/model-collapse"
 import ModelExample from "core/components/model-example"
 import ModelWrapper from "core/components/model-wrapper"
@@ -135,6 +136,7 @@ export default function() {
       SchemesContainer,
       modelExample: ModelExample,
       ModelWrapper,
+      ModelContainer,
       ModelCollapse,
       Model,
       Models,

--- a/src/style/_models.scss
+++ b/src/style/_models.scss
@@ -109,12 +109,19 @@ section.models
 
     &.is-open
     {
-        padding: 0 0 20px;
         h4
         {
             margin: 0 0 5px 0;
 
             border-bottom: 1px solid rgba($section-models-isopen-h4-border-bottom-color, .3);
+        }
+        &> div > *:first-child
+        {
+          margin-top: 20px;
+        }
+        &> div > *:last-child
+        {
+          margin-bottom: 20px;
         }
     }
     h4
@@ -176,16 +183,6 @@ section.models
         &:hover
         {
             background: rgba($section-models-model-container-background-color,.07);
-        }
-
-        &:first-of-type
-        {
-            margin: 20px;
-        }
-
-        &:last-of-type
-        {
-            margin: 0 20px;
         }
 
         .models-jump-to-path {

--- a/test/e2e-cypress/static/documents/features/deep-linking.openapi.yaml
+++ b/test/e2e-cypress/static/documents/features/deep-linking.openapi.yaml
@@ -56,3 +56,15 @@ paths:
             application/json:
               schema:
                 type: object
+components:
+  schemas:
+    MyModel:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: MyModel

--- a/test/e2e-cypress/static/documents/features/deep-linking.swagger.yaml
+++ b/test/e2e-cypress/static/documents/features/deep-linking.swagger.yaml
@@ -32,3 +32,14 @@ paths:
   /noOperationId:
     put:
       tags: ["tagTwo"]
+definitions:
+  MyModel:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+    xml:
+      name: MyModel

--- a/test/e2e-cypress/tests/features/deep-linking.js
+++ b/test/e2e-cypress/tests/features/deep-linking.js
@@ -92,6 +92,17 @@ describe("Deep linking feature", () => {
         correctHref: "#/my%20Tag"
       })
     })
+
+    describe("regular Model ", () => {
+      ModelDeeplinkTestFactory({
+        isTagCase: false,
+        baseUrl: swagger2BaseUrl,
+        elementToGet: `.model-container[data-name="MyModel"]`,
+        correctElementId: "model-MyModel",
+        correctFragment: "#/models/MyModel",
+        correctHref: "#/models/MyModel"
+      })
+    })
   })
   describe("in OpenAPI 3", () => {
     const openAPI3BaseUrl = "/?deepLinking=true&url=/documents/features/deep-linking.openapi.yaml"
@@ -187,10 +198,21 @@ describe("Deep linking feature", () => {
         correctHref: "#/my%20Tag"
       })
     })
+
+    describe("regular Model ", () => {
+      ModelDeeplinkTestFactory({
+        isTagCase: false,
+        baseUrl: openAPI3BaseUrl,
+        elementToGet: `.model-container[data-name="MyModel"]`,
+        correctElementId: "model-MyModel",
+        correctFragment: "#/models/MyModel",
+        correctHref: "#/models/MyModel"
+      })
+    })
   })
 })
 
-function OperationDeeplinkTestFactory({ baseUrl, elementToGet, correctElementId, correctFragment, correctHref }) {  
+function OperationDeeplinkTestFactory({ baseUrl, elementToGet, correctElementId, correctFragment, correctHref }) {
   it("should generate a correct element ID", () => {
     cy.visit(baseUrl)
       .get(elementToGet)
@@ -282,6 +304,59 @@ function TagDeeplinkTestFactory({ baseUrl, elementToGet, correctElementId, corre
   it("should expand a tag with docExpansion disabled", () => {
     cy.visit(`${baseUrl}&docExpansion=none${correctFragment}`)
       .get(`.opblock-tag-section.is-open`)
+      .should("have.length", 1)
+  })
+}
+
+function ModelDeeplinkTestFactory({ baseUrl, elementToGet, correctElementId, correctFragment, correctHref }) {
+  it("should generate a correct element ID", () => {
+    cy.visit(baseUrl)
+      .get(elementToGet)
+      .should("have.id", correctElementId)
+  })
+
+  it("should add the correct element fragment to the URL when expanded", () => {
+    cy.visit(baseUrl)
+      .get(elementToGet + ">.model-box")// only the collapsible part is clickable
+      .click()
+      .window()
+      .should("have.deep.property", "location.hash", correctFragment)
+  })
+
+  // todo implement anchor
+  // it("should provide an anchor link that has the correct fragment as href", () => {
+  //   cy.visit(baseUrl)
+  //     .get(elementToGet)
+  //     .find("a")
+  //     .should("have.attr", "href", correctHref)
+  //     .click()
+  //     .window()
+  //     .should("have.deep.property", "location.hash", correctFragment)
+  // })
+
+  it("should expand the operation when reloaded", () => {
+    cy.visit(`${baseUrl}${correctFragment}`)
+      .get(`${elementToGet}[data-is-open="true"]`)
+      .should("exist")
+  })
+
+  it("should retain the correct fragment when reloaded", () => {
+    cy.visit(`${baseUrl}${correctFragment}`)
+      .reload()
+      .should("exist")
+      .window()
+      .should("have.deep.property", "location.hash", correctFragment)
+  })
+
+  it("should expand the models section with docExpansion disabled", () => {
+    cy.visit(`${baseUrl}&docExpansion=none${correctFragment}`)
+      .get(`.models.is-open`)
+      .should("have.length", 1)
+  })
+
+  it("should expand a model with docExpansion disabled", () => {
+    cy.visit(`${baseUrl}&docExpansion=none${correctFragment}`)
+      .get(`${elementToGet}[data-is-open="true"]`)
       .should("have.length", 1)
   })
 }

--- a/test/e2e-selenium/pages/main.js
+++ b/test/e2e-selenium/pages/main.js
@@ -491,40 +491,40 @@ module.exports = {
           selector: ".swagger-ui .models h4"
         },
         orderModel: {
-          selector: "section.models div.model-container:nth-child(1)"
+          selector: "section.models div#model-Order"
         },
         orderModelCallapse: {
-          selector: "section.models div.model-container:nth-child(1) span.model-toggle"
+          selector: "section.models div#model-Order span.model-toggle"
         },
         categoryModel: {
-          selector: "section.models div.model-container:nth-child(2)"
+          selector: "section.models div#model-Category"
         },
         categoryModelCallapse: {
-          selector: "section.models div.model-container:nth-child(2) span.model-toggle"
+          selector: "section.models div#model-Category span.model-toggle"
         },
         userModel: {
-          selector: "section.models div.model-container:nth-child(3)"
+          selector: "section.models div#model-User"
         },
         userModelCallapse: {
-          selector: "section.models div.model-container:nth-child(3) span.model-toggle"
+          selector: "section.models div#model-User span.model-toggle"
         },
         tagModel: {
-          selector: "section.models div.model-container:nth-child(4)"
+          selector: "section.models div#model-Tag"
         },
         tagModelCallapse: {
-          selector: "section.models div.model-container:nth-child(4) span.model-toggle"
+          selector: "section.models div#model-Tag span.model-toggle"
         },
         petModel: {
-          selector: "section.models div.model-container:nth-child(5)"
+          selector: "section.models div#model-Pet"
         },
         petModelCallapse: {
-          selector: "section.models div.model-container:nth-child(5) span.model-toggle"
+          selector: "section.models div#model-Pet span.model-toggle"
         },
         apiResponseModel: {
-          selector: "section.models div.model-container:nth-child(6)"
+          selector: "section.models div#model-ApiResponse"
         },
         apiResponseModelCallapse: {
-          selector: "section.models div.model-container:nth-child(6) span.model-toggle"
+          selector: "section.models div#model-ApiResponse span.model-toggle"
         },
       }
     }

--- a/test/mocha/components/model-container.jsx
+++ b/test/mocha/components/model-container.jsx
@@ -3,14 +3,14 @@ import React from "react"
 import expect, { createSpy } from "expect"
 import { shallow } from "enzyme"
 import { fromJS, Map } from "immutable"
-import Models from "components/models"
-import ModelCollpase from "components/model-collapse"
+import ModelContainer from "components/model-container"
+import ModelCollapse from "components/model-collapse"
 import ModelComponent from "components/model-wrapper"
 
-describe("<Models/>", function(){
+describe("<ModelContainer/>", function(){
   // Given
   let components = {
-    Collapse: ModelCollpase,
+    ModelCollapse: ModelCollapse,
     ModelWrapper: ModelComponent
   }
   let props = {
@@ -32,8 +32,8 @@ describe("<Models/>", function(){
       isShown: createSpy()
     },
     layoutActions: {},
+    specActions: {},
     getConfigs: () => ({
-      docExpansion: "list",
       defaultModelsExpandDepth: 0
     })
   }
@@ -41,14 +41,11 @@ describe("<Models/>", function(){
 
   it("passes defaultModelsExpandDepth to ModelWrapper", function(){
     // When
-    let wrapper = shallow(<Models {...props}/>)
+    let wrapper = shallow(<ModelContainer {...props}/>)
 
     // Then should render tabs
     expect(wrapper.find("ModelCollapse").length).toEqual(1)
     expect(wrapper.find("ModelWrapper").length).toBeGreaterThan(0)
-    wrapper.find("ModelComponent").forEach((modelWrapper) => {
-      expect(modelWrapper.props().expandDepth).toBe(0)
-    })
+    expect(wrapper.find("ModelWrapper").props().expandDepth).toBe(0)
   })
-
 })


### PR DESCRIPTION
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

This PR would cover a part of the feature request #1369 (Deep linking for models).

The part it aims to cover is the ability to directly link to models in the URL.

The goal with this feature would be the following:
* given that DeepLinking is turned on,
* when the user specifies a model in the URL,
* then the UI should open that model and scroll to it

### Description
(This PR seems to be the newer version of #5237)
<!--- Describe your changes in detail -->
Extend the functionality of the deep-linking plugin:
* The models section is expanded and scrolled to with `#/models`
* The specific model is expanded and scrolled to with `#/models/ModelName`

Necessary refactors to make the above possible:
* extract new component for model-container
* change how the styling is done for the models section

Bugs fixed:
* the `dev-e2e-cypress` script was calling the wrong script to start the cypress server
* the spacing between the first and second item in the models section was different (bigger) than the spacing between the rest of the items.

Known bugs:
* when a model is open, collapsing and expanding the models section will put the last open model in the path instead of just the models path without the specific model

### Help needed!
It would be nice if someone with actual knowledge about ReactJs and SwaggerUi and DeepLinking could help out :)

**Is this PR introducing breaking changes?**

Please help me to decide if this PR is introducing breaking changes or not!

I think these might be considered as breaking changes:
- wrapped the models section and it's individual models in wrapper components, so the DOM structure changed.
- extracted a new React component inbetween Models.jsx and ModelCollapse.jsx. The new component's name is ModelContainer.jsx. This theoretically did not change the DOM structure.
- modified the styling in _models.scss to accomodate the wrapped component, so the styling mechanism is changed.

[DONE] **How to fix the scrolling to the specific model?**

The problem is that the `zenscroll` library cannot get the position of the `ModelCollapse` component right, so it does not scroll to the right place. I couldn't figure out how to fix this yet, any help is appreciated. 

One random idea I had is to somehow include the `div` with the `model-${name}` id in the `ModelCollapse` component, because that element's position seems to be working well for positioning (`offsetTop` gives back an appropriate number), but this seems to be something that might become a breaking change, so I'm somewhat reluctant to go this way.

UPDATE: I implemented this idea in the second commit and it made the scrolling possible.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually & added e2e tests.

<!--- ### Screenshots (if appropriate): -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [x] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
