### PR TITLE
fix: curl entries array support within multipart/form-data (#3838)

### DIFF
--- a/src/core/curlify.js
+++ b/src/core/curlify.js
@@ -1,5 +1,19 @@
 import win from "./window"
 
+/**
+ * if duplicate key name existed from FormData entries,
+ * we mutated the key name by appending a hashIdx
+ * @param {String} k - possibly mutated key name
+ * @return {String} - src key name
+ */
+const extractKey = (k) => {
+  const hashIdx = "_**[]"
+  if (k.indexOf(hashIdx) < 0) {
+    return k
+  }
+  return k.split(hashIdx)[0].trim()
+}
+
 export default function curl( request ){
   let curlified = []
   let type = ""
@@ -21,11 +35,12 @@ export default function curl( request ){
 
     if(type === "multipart/form-data" && request.get("method") === "POST") {
       for( let [ k,v ] of request.get("body").entrySeq()) {
+        let extractedKey = extractKey(k)
         curlified.push( "-F" )
         if (v instanceof win.File) {
-          curlified.push( `"${k}=@${v.name}${v.type ? `;type=${v.type}` : ""}"` )
+          curlified.push(`"${extractedKey}=@${v.name}${v.type ? `;type=${v.type}` : ""}"` )
         } else {
-          curlified.push( `"${k}=${v}"` )
+          curlified.push(`"${extractedKey}=${v}"` )
         }
       }
     } else {

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -67,17 +67,64 @@ export function arrayify (thing) {
   return normalizeArray(thing)
 }
 
-export function fromJSOrdered (js) {
-  if(isImmutable(js))
+export function fromJSOrdered(js) {
+  if (isImmutable(js)) {
     return js // Can't do much here
-
-  if (js instanceof win.File)
+  }
+  if (js instanceof win.File) {
     return js
+  }
+  if (!isObject(js)) {
+    return js
+  }
+  if (Array.isArray(js)) {
+    return Im.Seq(js).map(fromJSOrdered).toList()
+  }
+  if (js.entries) {
+    // handle multipart/form-data
+    const objWithHashedKeys = createObjWithHashedKeys(js)
+    return Im.OrderedMap(objWithHashedKeys).map(fromJSOrdered)
+  }
+  return Im.OrderedMap(js).map(fromJSOrdered)
+}
 
-  return !isObject(js) ? js :
-    Array.isArray(js) ?
-      Im.Seq(js).map(fromJSOrdered).toList() :
-      Im.OrderedMap(js).map(fromJSOrdered)
+/**
+ * Convert a FormData object into plain object
+ * Append a hashIdx and counter to the key name, if multiple exists
+ * if single, key name = <original>
+ * if multiple, key name = <original><hashIdx><count>
+ * @param {FormData} fdObj - a FormData object
+ * @return {Object} - a plain object
+ */
+export function createObjWithHashedKeys (fdObj) {
+  if (!fdObj.entries) {
+    return fdObj // not a FormData object with iterable
+  }
+  const newObj = {}
+  const hashIdx = "_**[]" // our internal identifier
+  const trackKeys = {}
+  for (let pair of fdObj.entries()) {
+    if (!newObj[pair[0]] && !(trackKeys[pair[0]] && trackKeys[pair[0]].containsMultiple)) {
+      newObj[pair[0]] = pair[1] // first key name: no hash required
+    } else {
+      if (!trackKeys[pair[0]]) {
+        // initiate tracking key for multiple
+        trackKeys[pair[0]] = {
+          containsMultiple: true,
+          length: 1
+        }
+        // "reassign" first pair to matching hashed format for multiple
+        let hashedKeyFirst = `${pair[0]}${hashIdx}${trackKeys[pair[0]].length}`
+        newObj[hashedKeyFirst] = newObj[pair[0]]
+        // remove non-hashed key of multiple
+        delete newObj[pair[0]] // first
+      }
+      trackKeys[pair[0]].length += 1
+      let hashedKeyCurrent = `${pair[0]}${hashIdx}${trackKeys[pair[0]].length}`
+      newObj[hashedKeyCurrent] = pair[1]
+    } 
+  }
+  return newObj
 }
 
 export function bindToState(obj, state) {

--- a/test/mocha/core/curlify.js
+++ b/test/mocha/core/curlify.js
@@ -143,6 +143,26 @@ describe("curlify", function() {
         expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"content-type: multipart/form-data\" -F \"id=123\" -F \"name=Sahar\"")
     })
 
+    it("should print a curl with formData that extracts array representation with hashIdx", function() {
+        // Note: hashIdx = `_**[]${counter}`
+        // Usage of hashIdx is an internal SwaggerUI method to convert formData array into something curlify can handle 
+        const req = {
+            url: "http://example.com",
+            method: "POST",
+            headers: { "content-type": "multipart/form-data" },
+            body: {
+                id: "123",
+                "fruits[]_**[]1": "apple",
+                "fruits[]_**[]2": "banana",
+                "fruits[]_**[]3": "grape"
+            }
+        }
+
+        let curlified = curl(Im.fromJS(req))
+
+        expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"content-type: multipart/form-data\" -F \"id=123\" -F \"fruits[]=apple\" -F \"fruits[]=banana\" -F \"fruits[]=grape\"")
+    })
+
     it("should print a curl with formData and file", function() {
         var file = new win.File()
         file.name = "file.txt"


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
- Requires merging of PR from Swagger Client, https://github.com/swagger-api/swagger-js/pull/1527

1. SwaggerClient returned incorrect FormData object that did not support multiple key names. This is now fixed in SwaggerClient.
2. SwaggerUI utils.fromJSOrdered
  a. Immutable's OrderedMap does not support duplicate keynames, and will overwrite with new value(s)
  b. We now create an object, if multiple, where a hashIndex is appended to the original keyname, along with a counter
  c. If multiple, the original key name (without hashIndex) is deleted
  d. This object is returned and used to change state for spec.mutatedRequest
  e. curlify.js is modified to check for presence of hashIndex, and is able to extract the original key name to push into its return array (to join into String)
3. Sidenote, spec.mutatedRequest appears to only be used for the Curl component within SwaggerUI


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->
Fixes #3838 


### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New test added to verify handling of `hashIdx`


### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
