### PR TITLE
ref #5025 - hide pwd content in curl try it out

### DIFF
--- a/src/core/curlify.js
+++ b/src/core/curlify.js
@@ -28,6 +28,23 @@ export default function curl( request ){
           curlified.push( `"${k}=${v}"` )
         }
       }
+    } else if (type === "application/x-www-form-urlencoded" && request.get("method") === "POST") {
+      curlified.push("-d")
+      let formDataParams = []
+      let pairs = request.get("body").split("&")
+      for (let i = 0; i < pairs.length; i++) {
+        if(!pairs[i])
+          continue
+        let pair = pairs[i].split("=")
+        let k = pair[0]
+        let v = pair[1]
+        if (k.toLowerCase() !== "password") {
+          formDataParams.push(`${k}=${v}`)
+        } else {
+          formDataParams.push(`${k}=******`)
+        }
+      }
+      curlified.push(`"${formDataParams.join("&")}"`)
     } else {
       curlified.push( "-d" )
       curlified.push( JSON.stringify( request.get("body") ).replace(/\\n/g, "") )

--- a/test/mocha/core/curlify.js
+++ b/test/mocha/core/curlify.js
@@ -215,4 +215,20 @@ describe("curlify", function() {
         expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"accept: application/json\" -d \"{\\\"id\\\":\\\"foo'bar\\\"}\"")
     })
 
+  it("prints a curl post statement with a password hidden", function() {
+    var req = {
+      url: "http://example.com",
+      method: "POST",
+      headers: {
+        accept: "text/plain",
+        "content-type": "application/x-www-form-urlencoded"
+      },
+      body: "username=foo&password=hidden"
+    }
+
+    let curlified = curl(Im.fromJS(req))
+
+    expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"accept: text/plain\" -H  \"content-type: application/x-www-form-urlencoded\" -d \"username=foo&password=******\"")
+  })
+
 })


### PR DESCRIPTION
Naïve but effective way to replace the content of any field named "password"
with "******" in the curl view when using try it out and with a
"x-www-form-urlencoded" content type header

### Description
Replace the value of any url parameter named "password" with "******" in the curl view when using the Try it out function.
This is very simple fix, it can be way more better, by using the format of the source fields instead of using the name "password". But it should cover 90% of the cases when the password field is actually named "password" (case insensitive).

### Motivation and Context
Do not show a sensitive data.
Fixes #5025

### How Has This Been Tested?
I created a new test with mocha to handle this specific case.
Then I build the project and tested the UI with my openapi.json file.

### Screenshots (if appropriate):
![swagger_password](https://user-images.githubusercontent.com/4737770/81727234-ef54da00-9488-11ea-9838-eda9c9c55481.png)

## Checklist

### My PR contains... 
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [ ] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
