### PR TITLE
Remove max-width for textarea media < 768px

### DIFF
--- a/src/style/_form.scss
+++ b/src/style/_form.scss
@@ -46,6 +46,12 @@ label
     @include text_headline();
 }
 
+input {
+    @media (max-width: 768px) {
+      max-width: 175px;
+    }
+}
+
 
 input[type=text],
 input[type=password],
@@ -61,9 +67,6 @@ textarea
     border: 1px solid $form-input-border-color;
     border-radius: 4px;
     background: $form-input-background-color;
-    @media (max-width: 768px) {
-      max-width: 175px;
-    }
 
 
     &.invalid

--- a/src/style/_form.scss
+++ b/src/style/_form.scss
@@ -46,7 +46,12 @@ label
     @include text_headline();
 }
 
-input {
+input[type=text],
+input[type=password],
+input[type=search],
+input[type=email],
+input[type=file]
+{
     @media (max-width: 768px) {
       max-width: 175px;
     }


### PR DESCRIPTION
Unknown why it was added, but it makes swagger-ui look horrible on a
decent laptop in a tiling wm

Signed-off-by: Wesley Schwengle <wesley@opndev.io>

### Screenshots (if appropriate):
Before:
![swagger-max-width-pre](https://user-images.githubusercontent.com/6317502/82126309-e52d2700-9779-11ea-9196-6a1a687cb662.png)

After:
![swagger-max-width-post](https://user-images.githubusercontent.com/6317502/82126308-e3fbfa00-9779-11ea-9563-57b84bd33637.png)

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
- [x] I'm unaware how this is tested.