### PR TITLE
fix: entries as property name

### DIFF
--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -18,6 +18,7 @@ import _memoize from "lodash/memoize"
 import find from "lodash/find"
 import some from "lodash/some"
 import eq from "lodash/eq"
+import isFunction from "lodash/isFunction"
 import { memoizedSampleFromSchema, memoizedCreateXMLExample } from "core/plugins/samples/fn"
 import win from "./window"
 import cssEscape from "css.escape"
@@ -80,10 +81,13 @@ export function fromJSOrdered(js) {
   if (Array.isArray(js)) {
     return Im.Seq(js).map(fromJSOrdered).toList()
   }
-  if (js.entries) {
+  if (isFunction(js.entries)) {
     // handle multipart/form-data
     const objWithHashedKeys = createObjWithHashedKeys(js)
     return Im.OrderedMap(objWithHashedKeys).map(fromJSOrdered)
+  }
+  if (js.entries && !isFunction(js.entries)) {
+    return Im.OrderedMap(js.entries).map(fromJSOrdered)
   }
   return Im.OrderedMap(js).map(fromJSOrdered)
 }

--- a/test/e2e-cypress/static/documents/bugs/6016-oas2.yaml
+++ b/test/e2e-cypress/static/documents/bugs/6016-oas2.yaml
@@ -1,0 +1,28 @@
+swagger: "2.0"
+info:
+  description: "OAS2 sample with entries as property name"
+  version: "0.0.1"
+  title: "Swagger Sample"
+paths:
+  /pet:
+    post:
+      summary: "Add a new pet to the store"
+      description: ""
+      parameters:
+      - in: "body"
+        name: "body"
+        schema:
+          $ref: "#/definitions/Pet"
+      responses:
+        "405":
+          description: "Invalid input"
+definitions:
+  Pet:
+    type: "object"
+    properties:
+      id:
+        type: "integer"
+      entries: # <-- evaluate
+        type: "array"
+        items:
+          type: "string"

--- a/test/e2e-cypress/static/documents/bugs/6016-oas3.yaml
+++ b/test/e2e-cypress/static/documents/bugs/6016-oas3.yaml
@@ -1,0 +1,31 @@
+openapi: 3.0.2
+info:
+  title: OAS 3.0 sample with entries as property name
+  version: 0.1.0
+paths:
+  /test/:
+    get:
+      summary: Test
+      operationId: test_test__get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Testmodel'
+components:
+  schemas:
+    Testmodel:
+      title: Testmodel
+      required:
+        - name
+        - entries
+      type: object
+      properties:
+        name:
+          title: Name
+          type: string
+        entries:
+          title: Entries
+          type: integer

--- a/test/e2e-cypress/tests/bugs/6016.js
+++ b/test/e2e-cypress/tests/bugs/6016.js
@@ -1,0 +1,12 @@
+describe("Entries should be valid property name", () => {
+  it("should render a OAS3.0 definition that uses 'entries' as a property name", () => {
+    cy.visit("/?url=/documents/bugs/6016-oas3.yaml")
+      .get("#operations-tag-default")
+      .should("exist")
+  })
+  it("should render a OAS2.0 definition that uses 'entries' as a property name", () => {
+    cy.visit("/?url=/documents/bugs/6016-oas2.yaml")
+      .get("#operations-default-post_pet")
+      .should("exist")
+  })
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Add a `isFunction` check to determine how to handle `js.entries`. E.g. as plain property name vs. FormData instance

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes #6016 

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

New Cypress tests with OAS2 and OAS3.0 samples confirm proper rendering. Also confirmed multipart/form-data try-it-out still working.


### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
