### PR TITLE
fix: remove special handling of non-FormData entries

### DIFF
--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -86,9 +86,6 @@ export function fromJSOrdered(js) {
     const objWithHashedKeys = createObjWithHashedKeys(js)
     return Im.OrderedMap(objWithHashedKeys).map(fromJSOrdered)
   }
-  if (js.entries && !isFunction(js.entries)) {
-    return Im.OrderedMap(js.entries).map(fromJSOrdered)
-  }
   return Im.OrderedMap(js).map(fromJSOrdered)
 }
 
@@ -97,11 +94,21 @@ export function fromJSOrdered(js) {
  * Append a hashIdx and counter to the key name, if multiple exists
  * if single, key name = <original>
  * if multiple, key name = <original><hashIdx><count>
+ * @example <caption>single entry for vegetable</caption>
+ * fdObj.entries.vegtables: "carrot"
+ * // returns newObj.vegetables : "carrot"
+ * @example <caption>multiple entries for fruits[]</caption>
+ * fdObj.entries.fruits[]: "apple"
+ * // returns newObj.fruits[]_**[]1 : "apple"
+ * fdObj.entries.fruits[]: "banana"
+ * // returns newObj.fruits[]_**[]2 : "banana"
+ * fdObj.entries.fruits[]: "grape"
+ * // returns newObj.fruits[]_**[]3 : "grape"
  * @param {FormData} fdObj - a FormData object
  * @return {Object} - a plain object
  */
 export function createObjWithHashedKeys (fdObj) {
-  if (!fdObj.entries) {
+  if (!isFunction(fdObj.entries)) {
     return fdObj // not a FormData object with iterable
   }
   const newObj = {}

--- a/test/e2e-cypress/tests/bugs/6016.js
+++ b/test/e2e-cypress/tests/bugs/6016.js
@@ -1,12 +1,42 @@
 describe("Entries should be valid property name", () => {
-  it("should render a OAS3.0 definition that uses 'entries' as a property name", () => {
+  it("should render a OAS3.0 definition that uses 'entries' as a 'components' property name", () => {
     cy.visit("/?url=/documents/bugs/6016-oas3.yaml")
       .get("#operations-tag-default")
       .should("exist")
   })
-  it("should render a OAS2.0 definition that uses 'entries' as a property name", () => {
+  it("should render expanded Operations of OAS3.0 definition that uses 'entries' as a 'components' property name", () => {
+    cy.visit("/?url=/documents/bugs/6016-oas3.yaml")
+      .get("#operations-default-test_test__get")
+      .click()
+      .get("#operations-default-test_test__get > div .opblock-body")
+      .should("exist")
+
+  })
+  it("should render expanded Models of OAS3.0 definition that uses 'entries' as a 'components' property name", () => {
+    cy.visit("/?url=/documents/bugs/6016-oas3.yaml")
+      .get("#model-Testmodel > span .model-box")
+      .click()
+      .get("div .model-box")
+      .should("exist")
+  })
+  it("should render a OAS2.0 definition that uses 'entries' as a 'definitions' property name", () => {
     cy.visit("/?url=/documents/bugs/6016-oas2.yaml")
       .get("#operations-default-post_pet")
+      .should("exist")
+  })
+  it("should render expanded Operations of OAS2.0 definition that uses 'entries' as a 'definitions' property name", () => {
+    cy.visit("/?url=/documents/bugs/6016-oas2.yaml")
+      .get("#operations-default-post_pet")
+      .click()
+      .get("#operations-default-post_pet > div .opblock-body")
+      .should("exist")
+
+  })
+  it("should render expanded Models of OAS2.0 definition that uses 'entries' as a 'defintions' property name", () => {
+    cy.visit("/?url=/documents/bugs/6016-oas2.yaml")
+      .get("#model-Pet > span .model-box")
+      .click()
+      .get("div .model-box")
       .should("exist")
   })
 })


### PR DESCRIPTION
Ref: #6033

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

PR #6025 fix to `entries` was over-strict on handling `js.entries`. The extra handling for an `js` object that may have contained `.entries` as a key has been removed. The `js` object is now processed in its entirety without further modification.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes #6033 

The render failure to expand `Models` was not previously covered in PR #6025.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Additional tests to expand both the `Operation` and `Models` have been added.

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
