### PR TITLE
Add Runme button to demonstrate the latest version of application

### DIFF
--- a/.runme/config.yaml
+++ b/.runme/config.yaml
@@ -1,0 +1,10 @@
+version: 1.0
+publish: app
+services:
+  app:
+    build:
+      type: dockerfile
+      config: ./Dockerfile
+    ports:
+    - container: 8080
+      public: 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,7 @@ COPY ./docker/configurator /usr/share/nginx/configurator
 RUN chmod +x /usr/share/nginx/run.sh && \
     chmod -R a+rw /usr/share/nginx && \
     chmod -R a+rw /etc/nginx && \
-    chmod -R a+rw /var && \
-    chmod -R a+rw /var/run
+    chmod -R a+rw /var
 
 EXPOSE 8080
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 ![monthly packagist installs](https://img.shields.io/packagist/dm/swagger-api/swagger-ui.svg?label=packagist%20installs)
 ![gzip size](https://img.shields.io/bundlephobia/minzip/swagger-ui.svg?label=gzip%20size)
 
+[![Runme](https://svc.runme.io/static/button.svg)](https://runme.io/run?app_id=1e3d281a-d725-4e49-b60b-fe810ae64b56)
+
 **👉🏼 Want to score an easy open-source contribution?** Check out our [Good first issue](https://github.com/swagger-api/swagger-ui/issues?q=is%3Aissue+is%3Aopen+label%3A%22Good+first+issue%22) label.
 
 **🕰️ Looking for the older version of Swagger UI?** Refer to the [*2.x* branch](https://github.com/swagger-api/swagger-ui/tree/2.x).


### PR DESCRIPTION
This PR adds Runme button-label [![Runme](https://svc.runme.io/static/button.svg)](https://runme.io/run?app_id=cc7b2d88-a168-4332-83c1-ad97bef8007a) (clickable) to run the project from latest commit with one click.

Also, this PR removes unnecessary action from Dockerfile which raises the error `chmod: /var/run: No such file or directory` in [kaniko builds](https://github.com/GoogleContainerTools/kaniko).

**How it works:**
1. Runme clones the repository and builds a docker image for latest commit or use already built docker image;
2. deploys the docker image to k8s cluster;
3. creates domain with SSL certificate;
4. shows web application;
5. destroys app instance after 10 minutes.

You can find detailed information how this works [here](https://runme.io/how-it-works). The small demo you can find [here](https://www.youtube.com/channel/UCEysV237wo321JatUTC6Rlg).

**Why do you need this?**
- Runme is perfect solution to demonstrate current state of code/repository, anybody can just click the button and see the state;
- Runme totally free, we love open source projects and want to support them;
- Runme can be used as a tool for preparation docker images with a developer's version of code

**Screenshot**
build
![build](https://user-images.githubusercontent.com/8326634/83257681-8c1fb300-a1bd-11ea-8c49-402f3dcbd574.png)

result
![result](https://user-images.githubusercontent.com/8326634/83257702-9641b180-a1bd-11ea-896c-d4d236ebeb8c.png)
