### PR TITLE
fix: bugs/4641 flaky test

### DIFF
--- a/src/core/plugins/auth/reducers.js
+++ b/src/core/plugins/auth/reducers.js
@@ -1,5 +1,5 @@
 import { fromJS, Map } from "immutable"
-import { btoa } from "core/utils"
+import { btoa, isFunc } from "core/utils"
 
 import {
   SHOW_AUTH_POPUP,
@@ -20,6 +20,9 @@ export default {
 
     // refactor withMutations
     securities.entrySeq().forEach( ([ key, security ]) => {
+      if (!isFunc(security.getIn)) {
+        return state.set("authorized", map)
+      }
       let type = security.getIn(["schema", "type"])
 
       if ( type === "apiKey" || type === "http" ) {

--- a/test/e2e-cypress/tests/bugs/4641.js
+++ b/test/e2e-cypress/tests/bugs/4641.js
@@ -1,10 +1,8 @@
 const clickTryItOutAndExecute = () => {
   return cy
-    .get(".opblock-summary")
+    .get(".btn.try-out__btn") // expand "try it out"
     .click()
-    .get(".try-out > .btn") // expand "try it out"
-    .click()
-    .get(".execute-wrapper > .btn") // excecute request
+    .get(".btn.execute") // execute request
     .click()
 }
 
@@ -44,7 +42,8 @@ describe("#4641: The Logout button in Authorize popup not clearing API Key", () 
       .within(fillInApiKeyAndAuthorise("my_api_key"))
       .get(".close-modal") // close authorise popup button
       .click()
-      .get("#operations-default-get_4641_1") // expand the route details
+      .get("#operations-default-get_4641_1") // expand the route details onClick
+      .click()
       .within(clickTryItOutAndExecute)
       .get("@request")
       .its("request")
@@ -64,7 +63,8 @@ describe("#4641: The Logout button in Authorize popup not clearing API Key", () 
       .within(clickLogoutAndReauthorise)
       .get(".close-modal") // close authorise popup button
       .click()
-      .get("#operations-default-get_4641_1") // expand the route details
+      .get("#operations-default-get_4641_1") // expand the route details onClick
+      .click()
       .within(clickTryItOutAndExecute)
       .get("@request")
       .its("request")
@@ -86,7 +86,8 @@ describe("#4641: The Logout button in Authorize popup not clearing API Key", () 
       .within(clickLogoutAndReauthorise)
       .get(".close-modal") // close authorise popup button
       .click()
-      .get("#operations-default-get_4641_2") // expand the route details
+      .get("#operations-default-get_4641_2") // expand the route details onClick
+      .click()
       .within(clickTryItOutAndExecute)
       .get("@request")
       .its("request")


### PR DESCRIPTION
also... 
fix: apply isFunc check for security.getIn
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

For `bugs/4641` test, after `.get()` an operation ID, add a `.click()` to expand the model view. Now Cypress should be able to select and click on the "Try-It-Out" button (and then select and click on "Execute")

Also, using `opblock-summary` had 2 issues:
1. In an expanded model, `opblock-summary` appears in multiple cases, so Cypress is unable to determine which to use
2. In a closed model, `opblock-summary` still appears, and no "Try It Out" element exists

In addition, this PR applies a fix, to validate that `securities.getIn()` is a function. This console error would appear during the `bugs/4641` test, even though all tests still pass. Applying this fix also results in all existing tests passing.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Second attempt
fixes #6001 

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Trying different `.select <element>` within an expanded operations view, such as `opblock-body`, would not be found without this change (to `.click()` first), despite existing in the DOM.

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
