### PR TITLE
fix: bugs/4641 use wait on route alias

### DIFF
--- a/test/e2e-cypress/tests/bugs/4641.js
+++ b/test/e2e-cypress/tests/bugs/4641.js
@@ -45,7 +45,7 @@ describe("#4641: The Logout button in Authorize popup not clearing API Key", () 
       .get("#operations-default-get_4641_1") // expand the route details onClick
       .click()
       .within(clickTryItOutAndExecute)
-      .get("@request")
+      .wait("@request")
       .its("request")
       .then((req) => {
         expect(req.headers, "request headers").to.have.property("api_key_1", "my_api_key")
@@ -66,7 +66,7 @@ describe("#4641: The Logout button in Authorize popup not clearing API Key", () 
       .get("#operations-default-get_4641_1") // expand the route details onClick
       .click()
       .within(clickTryItOutAndExecute)
-      .get("@request")
+      .wait("@request")
       .its("request")
       .then((req) => {
         expect(req.headers, "request headers").not.to.have.property("api_key_1")
@@ -89,7 +89,7 @@ describe("#4641: The Logout button in Authorize popup not clearing API Key", () 
       .get("#operations-default-get_4641_2") // expand the route details onClick
       .click()
       .within(clickTryItOutAndExecute)
-      .get("@request")
+      .wait("@request")
       .its("request")
       .then((req) => {
         expect(req.headers, "request headers").not.to.have.property("api_key_1")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Per [Cypress Docs](https://docs.cypress.io/api/commands/as.html#Route) example for `.as`, use `cy.wait('@routeAlias')` instead of `cy.get()`. Reason: `cy.get()` will retry until resolved or timeout, while `cy.wait()` will wait until resolved.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

3rd effort...
Fixes #6001 

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

tests continue to pass locally

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
