### PR TITLE
Allow Docker image to receive a URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ ENV API_KEY "**None**"
 ENV SWAGGER_JSON "/app/swagger.json"
 ENV PORT 8080
 ENV BASE_URL ""
+ENV SWAGGER_JSON_URL ""
 
 COPY ./docker/nginx.conf ./docker/cors.conf /etc/nginx/
 

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -29,8 +29,13 @@ fi
 
 replace_in_index myApiKeyXXXX123456789 $API_KEY
 
-if [[ -f $SWAGGER_JSON ]]; then
-  cp -s $SWAGGER_JSON $NGINX_ROOT
+if [ "$SWAGGER_JSON_URL" ]; then
+  sed -i "s|https://petstore.swagger.io/v2/swagger.json|$SWAGGER_JSON_URL|g" $INDEX_FILE
+  sed -i "s|http://example.com/api|$SWAGGER_JSON_URL|g" $INDEX_FILE
+fi
+
+if [[ -f "$SWAGGER_JSON" ]]; then
+  cp -s "$SWAGGER_JSON" "$NGINX_ROOT"
   REL_PATH="./$(basename $SWAGGER_JSON)"
   sed -i "s|https://petstore.swagger.io/v2/swagger.json|$REL_PATH|g" $INDEX_FILE
   sed -i "s|http://example.com/api|$REL_PATH|g" $INDEX_FILE


### PR DESCRIPTION
This PR simply allows for an URL option to provide the initial json/yml for `swagger-ui`.
The `SWAGGER_JSON` parameter requires the provided path to be a local file, the new `SWAGGER_JSON_URL` parameter also allows URLs

This is a followup of https://github.com/swagger-api/swagger-ui/pull/5941 because someone force pushed master and I had to start from scratch