### PR TITLE
fix: curlify agnostic to order of header values

### DIFF
--- a/src/core/curlify.js
+++ b/src/core/curlify.js
@@ -27,11 +27,7 @@ export default function curl( request ){
       let [ h,v ] = p
       curlified.push( "-H " )
       curlified.push( `"${h}: ${v}"` )
-      if (isMultipartFormDataRequest) {
-        break
-      } else {
-        isMultipartFormDataRequest = /^content-type$/i.test(h) && /^multipart\/form-data$/i.test(v)
-      }
+      isMultipartFormDataRequest = isMultipartFormDataRequest || /^content-type$/i.test(h) && /^multipart\/form-data$/i.test(v)
     }
   }
 

--- a/src/core/curlify.js
+++ b/src/core/curlify.js
@@ -16,7 +16,7 @@ const extractKey = (k) => {
 
 export default function curl( request ){
   let curlified = []
-  let type = ""
+  let isMultipartFormDataRequest = false
   let headers = request.get("headers")
   curlified.push( "curl" )
   curlified.push( "-X", request.get("method") )
@@ -25,15 +25,18 @@ export default function curl( request ){
   if ( headers && headers.size ) {
     for( let p of request.get("headers").entries() ){
       let [ h,v ] = p
-      type = v
       curlified.push( "-H " )
       curlified.push( `"${h}: ${v}"` )
+      if (isMultipartFormDataRequest) {
+        break
+      } else {
+        isMultipartFormDataRequest = /^content-type$/i.test(h) && /^multipart\/form-data$/i.test(v)
+      }
     }
   }
 
   if ( request.get("body") ){
-
-    if(type === "multipart/form-data" && ["POST", "PUT", "PATCH"].includes(request.get("method"))) {
+    if (isMultipartFormDataRequest && ["POST", "PUT", "PATCH"].includes(request.get("method"))) {
       for( let [ k,v ] of request.get("body").entrySeq()) {
         let extractedKey = extractKey(k)
         curlified.push( "-F" )

--- a/test/mocha/core/curlify.js
+++ b/test/mocha/core/curlify.js
@@ -3,247 +3,320 @@ import Im from "immutable"
 import curl from "core/curlify"
 import win from "core/window"
 
-describe("curlify", function() {
+describe("curlify", function () {
 
-    it("prints a curl statement with custom content-type", function() {
-        var req = {
-            url: "http://example.com",
-            method: "POST",
-            body: {
-                id: 0,
-                name: "doggie",
-                status: "available"
-            },
-            headers: {
-                Accept: "application/json",
-                "content-type": "application/json"
-            }
-        }
-
-        let curlified = curl(Im.fromJS(req))
-
-        expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"Accept: application/json\" -H  \"content-type: application/json\" -d {\"id\":0,\"name\":\"doggie\",\"status\":\"available\"}")
-    })
-
-    it("does add a empty data param if no request body given", function() {
-      var req = {
-        url: "http://example.com",
-        method: "POST",
+  it("prints a curl statement with custom content-type", function () {
+    let req = {
+      url: "http://example.com",
+      method: "POST",
+      body: {
+        id: 0,
+        name: "doggie",
+        status: "available"
+      },
+      headers: {
+        Accept: "application/json",
+        "content-type": "application/json"
       }
+    }
 
-      let curlified = curl(Im.fromJS(req))
+    let curlified = curl(Im.fromJS(req))
 
-      expect(curlified).toEqual("curl -X POST \"http://example.com\" -d \"\"")
-    })
+    expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"Accept: application/json\" -H  \"content-type: application/json\" -d {\"id\":0,\"name\":\"doggie\",\"status\":\"available\"}")
+  })
 
-    it("does not change the case of header in curl", function() {
-        var req = {
-            url: "http://example.com",
-            method: "POST",
-            headers: {
-                "conTenT Type": "application/Moar"
-            }
-        }
+  it("does add a empty data param if no request body given", function () {
+    let req = {
+      url: "http://example.com",
+      method: "POST",
+    }
 
-        let curlified = curl(Im.fromJS(req))
+    let curlified = curl(Im.fromJS(req))
 
-        expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"conTenT Type: application/Moar\" -d \"\"")
-    })
+    expect(curlified).toEqual("curl -X POST \"http://example.com\" -d \"\"")
+  })
 
-    it("prints a curl statement with an array of query params", function() {
-        var req = {
-            url: "http://swaggerhub.com/v1/one?name=john|smith",
-            method: "GET"
-        }
+  it("does not change the case of header in curl", function () {
+    let req = {
+      url: "http://example.com",
+      method: "POST",
+      headers: {
+        "conTenT Type": "application/Moar"
+      }
+    }
 
-        let curlified = curl(Im.fromJS(req))
+    let curlified = curl(Im.fromJS(req))
 
-        expect(curlified).toEqual("curl -X GET \"http://swaggerhub.com/v1/one?name=john|smith\"")
-    })
+    expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"conTenT Type: application/Moar\" -d \"\"")
+  })
 
-    it("prints a curl statement with an array of query params and auth", function() {
-        var req = {
-            url: "http://swaggerhub.com/v1/one?name=john|smith",
-            method: "GET",
-            headers: {
-                authorization: "Basic Zm9vOmJhcg=="
-            }
-        }
+  it("prints a curl statement with an array of query params", function () {
+    let req = {
+      url: "http://swaggerhub.com/v1/one?name=john|smith",
+      method: "GET"
+    }
 
-        let curlified = curl(Im.fromJS(req))
+    let curlified = curl(Im.fromJS(req))
 
-        expect(curlified).toEqual("curl -X GET \"http://swaggerhub.com/v1/one?name=john|smith\" -H  \"authorization: Basic Zm9vOmJhcg==\"")
-    })
+    expect(curlified).toEqual("curl -X GET \"http://swaggerhub.com/v1/one?name=john|smith\"")
+  })
 
-    it("prints a curl statement with html", function() {
-        var req = {
-            url: "http://swaggerhub.com/v1/one?name=john|smith",
-            method: "GET",
-            headers: {
-                accept: "application/json"
-            },
-            body: {
-                description: "<b>Test</b>"
-            }
-        }
+  it("prints a curl statement with an array of query params and auth", function () {
+    let req = {
+      url: "http://swaggerhub.com/v1/one?name=john|smith",
+      method: "GET",
+      headers: {
+        authorization: "Basic Zm9vOmJhcg=="
+      }
+    }
 
-        let curlified = curl(Im.fromJS(req))
+    let curlified = curl(Im.fromJS(req))
 
-        expect(curlified).toEqual("curl -X GET \"http://swaggerhub.com/v1/one?name=john|smith\" -H  \"accept: application/json\" -d {\"description\":\"<b>Test</b>\"}")
-    })
+    expect(curlified).toEqual("curl -X GET \"http://swaggerhub.com/v1/one?name=john|smith\" -H  \"authorization: Basic Zm9vOmJhcg==\"")
+  })
 
-    it("handles post body with html", function() {
-        var req = {
-            url: "http://swaggerhub.com/v1/one?name=john|smith",
-            method: "POST",
-            headers: {
-                accept: "application/json"
-            },
-            body: {
-                description: "<b>Test</b>"
-            }
-        }
+  it("prints a curl statement with html", function () {
+    let req = {
+      url: "http://swaggerhub.com/v1/one?name=john|smith",
+      method: "GET",
+      headers: {
+        accept: "application/json"
+      },
+      body: {
+        description: "<b>Test</b>"
+      }
+    }
 
-        let curlified = curl(Im.fromJS(req))
+    let curlified = curl(Im.fromJS(req))
 
-        expect(curlified).toEqual("curl -X POST \"http://swaggerhub.com/v1/one?name=john|smith\" -H  \"accept: application/json\" -d {\"description\":\"<b>Test</b>\"}")
-    })
+    expect(curlified).toEqual("curl -X GET \"http://swaggerhub.com/v1/one?name=john|smith\" -H  \"accept: application/json\" -d {\"description\":\"<b>Test</b>\"}")
+  })
 
-    it("handles post body with special chars", function() {
-        var req = {
-            url: "http://swaggerhub.com/v1/one?name=john|smith",
-            method: "POST",
-            body: {
-                description: "@prefix nif:<http://persistence.uni-leipzig.org/nlp2rdf/ontologies/nif-core#> .\n" +
-                "@prefix itsrdf: <http://www.w3.org/2005/11/its/rdf#> ."
-            }
-        }
+  it("handles post body with html", function () {
+    let req = {
+      url: "http://swaggerhub.com/v1/one?name=john|smith",
+      method: "POST",
+      headers: {
+        accept: "application/json"
+      },
+      body: {
+        description: "<b>Test</b>"
+      }
+    }
 
-        let curlified = curl(Im.fromJS(req))
+    let curlified = curl(Im.fromJS(req))
 
-        expect(curlified).toEqual("curl -X POST \"http://swaggerhub.com/v1/one?name=john|smith\" -d {\"description\":\"@prefix nif:<http://persistence.uni-leipzig.org/nlp2rdf/ontologies/nif-core#> .@prefix itsrdf: <http://www.w3.org/2005/11/its/rdf#> .\"}")
-    })
+    expect(curlified).toEqual("curl -X POST \"http://swaggerhub.com/v1/one?name=john|smith\" -H  \"accept: application/json\" -d {\"description\":\"<b>Test</b>\"}")
+  })
 
-    it("handles delete form with parameters", function() {
-        var req = {
-            url: "http://example.com",
-            method: "DELETE",
-            headers: {
-                accept: "application/x-www-form-urlencoded"
-            }
-        }
+  it("handles post body with special chars", function () {
+    let req = {
+      url: "http://swaggerhub.com/v1/one?name=john|smith",
+      method: "POST",
+      body: {
+        description: "@prefix nif:<http://persistence.uni-leipzig.org/nlp2rdf/ontologies/nif-core#> .\n" +
+          "@prefix itsrdf: <http://www.w3.org/2005/11/its/rdf#> ."
+      }
+    }
 
-        let curlified = curl(Im.fromJS(req))
+    let curlified = curl(Im.fromJS(req))
 
-        expect(curlified).toEqual("curl -X DELETE \"http://example.com\" -H  \"accept: application/x-www-form-urlencoded\"")
-    })
+    expect(curlified).toEqual("curl -X POST \"http://swaggerhub.com/v1/one?name=john|smith\" -d {\"description\":\"@prefix nif:<http://persistence.uni-leipzig.org/nlp2rdf/ontologies/nif-core#> .@prefix itsrdf: <http://www.w3.org/2005/11/its/rdf#> .\"}")
+  })
 
-    it("should print a curl with formData", function() {
-        var req = {
-            url: "http://example.com",
-            method: "POST",
-            headers: { "content-type": "multipart/form-data" },
-            body: {
-              id: "123",
-              name: "Sahar"
-            }
-        }
+  it("handles delete form with parameters", function () {
+    let req = {
+      url: "http://example.com",
+      method: "DELETE",
+      headers: {
+        accept: "application/x-www-form-urlencoded"
+      }
+    }
 
-        let curlified = curl(Im.fromJS(req))
+    let curlified = curl(Im.fromJS(req))
 
-        expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"content-type: multipart/form-data\" -F \"id=123\" -F \"name=Sahar\"")
-    })
+    expect(curlified).toEqual("curl -X DELETE \"http://example.com\" -H  \"accept: application/x-www-form-urlencoded\"")
+  })
 
-    it("should print a curl with formData that extracts array representation with hashIdx", function() {
-        // Note: hashIdx = `_**[]${counter}`
-        // Usage of hashIdx is an internal SwaggerUI method to convert formData array into something curlify can handle
-        const req = {
-            url: "http://example.com",
-            method: "POST",
-            headers: { "content-type": "multipart/form-data" },
-            body: {
-                id: "123",
-                "fruits[]_**[]1": "apple",
-                "fruits[]_**[]2": "banana",
-                "fruits[]_**[]3": "grape"
-            }
-        }
+  it("should print a curl with formData", function () {
+    let req = {
+      url: "http://example.com",
+      method: "POST",
+      headers: { "content-type": "multipart/form-data" },
+      body: {
+        id: "123",
+        name: "Sahar"
+      }
+    }
 
-        let curlified = curl(Im.fromJS(req))
+    let curlified = curl(Im.fromJS(req))
 
-        expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"content-type: multipart/form-data\" -F \"id=123\" -F \"fruits[]=apple\" -F \"fruits[]=banana\" -F \"fruits[]=grape\"")
-    })
+    expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"content-type: multipart/form-data\" -F \"id=123\" -F \"name=Sahar\"")
+  })
 
-    it("should print a curl with formData and file", function() {
-        var file = new win.File()
+  it("should print a curl with formData that extracts array representation with hashIdx", function () {
+    // Note: hashIdx = `_**[]${counter}`
+    // Usage of hashIdx is an internal SwaggerUI method to convert formData array into something curlify can handle
+    let req = {
+      url: "http://example.com",
+      method: "POST",
+      headers: { "content-type": "multipart/form-data" },
+      body: {
+        id: "123",
+        "fruits[]_**[]1": "apple",
+        "fruits[]_**[]2": "banana",
+        "fruits[]_**[]3": "grape"
+      }
+    }
+
+    let curlified = curl(Im.fromJS(req))
+
+    expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"content-type: multipart/form-data\" -F \"id=123\" -F \"fruits[]=apple\" -F \"fruits[]=banana\" -F \"fruits[]=grape\"")
+  })
+
+  it("should print a curl with formData and file", function () {
+    var file = new win.File()
+    file.name = "file.txt"
+    file.type = "text/plain"
+
+    let req = {
+      url: "http://example.com",
+      method: "POST",
+      headers: { "content-type": "multipart/form-data" },
+      body: {
+        id: "123",
+        file
+      }
+    }
+
+    let curlified = curl(Im.fromJS(req))
+
+    expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"content-type: multipart/form-data\" -F \"id=123\" -F \"file=@file.txt;type=text/plain\"")
+  })
+
+  it("should print a curl without form data type if type is unknown", function () {
+    var file = new win.File()
+    file.name = "file.txt"
+    file.type = ""
+
+    let req = {
+      url: "http://example.com",
+      method: "POST",
+      headers: { "content-type": "multipart/form-data" },
+      body: {
+        id: "123",
+        file
+      }
+    }
+
+    let curlified = curl(Im.fromJS(req))
+
+    expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"content-type: multipart/form-data\" -F \"id=123\" -F \"file=@file.txt\"")
+  })
+
+  it("prints a curl post statement from an object", function () {
+    let req = {
+      url: "http://example.com",
+      method: "POST",
+      headers: {
+        accept: "application/json"
+      },
+      body: {
+        id: 10101
+      }
+    }
+
+    let curlified = curl(Im.fromJS(req))
+
+    expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"accept: application/json\" -d {\"id\":10101}")
+  })
+
+  it("prints a curl post statement from a string containing a single quote", function () {
+    let req = {
+      url: "http://example.com",
+      method: "POST",
+      headers: {
+        accept: "application/json"
+      },
+      body: "{\"id\":\"foo'bar\"}"
+    }
+
+    let curlified = curl(Im.fromJS(req))
+
+    expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"accept: application/json\" -d \"{\\\"id\\\":\\\"foo'bar\\\"}\"")
+  })
+
+  context("given multiple entries with file", function () {
+    context("and with leading custom header", function () {
+      it("should print a proper curl -F", function () {
+        let file = new win.File()
         file.name = "file.txt"
         file.type = "text/plain"
 
-        var req = {
-            url: "http://example.com",
-            method: "POST",
-            headers: { "content-type": "multipart/form-data" },
-            body: {
-              id: "123",
-              file
-            }
+        let req = {
+          url: "http://example.com",
+          method: "POST",
+          headers: {
+            "x-custom-name": "multipart/form-data",
+            "content-type": "multipart/form-data"
+          },
+          body: {
+            id: "123",
+            file
+          }
         }
 
-        let curlified = curl(Im.fromJS(req))
+        const curlified = curl(Im.fromJS(req))
 
-        expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"content-type: multipart/form-data\" -F \"id=123\" -F \"file=@file.txt;type=text/plain\"")
+        expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"x-custom-name: multipart/form-data\" -H  \"content-type: multipart/form-data\" -F \"id=123\" -F \"file=@file.txt;type=text/plain\"")
+      })
     })
 
-    it("should print a curl without form data type if type is unknown", function() {
-      var file = new win.File()
-      file.name = "file.txt"
-      file.type = ""
+    context("and with trailing custom header; e.g. from requestInterceptor appending req.headers", function () {
+      it("should print a proper curl -F", function () {
+        let file = new win.File()
+        file.name = "file.txt"
+        file.type = "text/plain"
 
-      var req = {
+        let req = {
+          url: "http://example.com",
+          method: "POST",
+          headers: {
+            "content-type": "multipart/form-data",
+            "x-custom-name": "any-value"
+          },
+          body: {
+            id: "123",
+            file
+          }
+        }
+
+        const curlified = curl(Im.fromJS(req))
+
+        expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"content-type: multipart/form-data\" -H  \"x-custom-name: any-value\" -F \"id=123\" -F \"file=@file.txt;type=text/plain\"")
+      })
+    })
+  })
+
+  context("POST when header value is 'multipart/form-data' but header name is not 'content-type'", function () {
+    it("shoud print a proper curl as -d <data>", function () {
+      let file = new win.File()
+      file.name = "file.txt"
+      file.type = "text/plain"
+
+      let req = {
         url: "http://example.com",
         method: "POST",
-        headers: { "content-type": "multipart/form-data" },
+        headers: { "x-custom-name": "multipart/form-data" },
         body: {
           id: "123",
           file
         }
       }
 
-      let curlified = curl(Im.fromJS(req))
+      const curlified = curl(Im.fromJS(req))
 
-      expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"content-type: multipart/form-data\" -F \"id=123\" -F \"file=@file.txt\"")
+      expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"x-custom-name: multipart/form-data\" -d {\"id\":\"123\",\"file\":{\"name\":\"file.txt\",\"type\":\"text/plain\"}}")
     })
-
-    it("prints a curl post statement from an object", function() {
-        var req = {
-            url: "http://example.com",
-            method: "POST",
-            headers: {
-                accept: "application/json"
-            },
-            body: {
-                id: 10101
-            }
-        }
-
-        let curlified = curl(Im.fromJS(req))
-
-        expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"accept: application/json\" -d {\"id\":10101}")
-    })
-
-    it("prints a curl post statement from a string containing a single quote", function() {
-        var req = {
-            url: "http://example.com",
-            method: "POST",
-            headers: {
-                accept: "application/json"
-            },
-            body: "{\"id\":\"foo'bar\"}"
-        }
-
-        let curlified = curl(Im.fromJS(req))
-
-        expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"accept: application/json\" -d \"{\\\"id\\\":\\\"foo'bar\\\"}\"")
-    })
-
+  })
 })

--- a/test/mocha/core/curlify.js
+++ b/test/mocha/core/curlify.js
@@ -266,7 +266,7 @@ describe("curlify", function() {
                     }
                 }
 
-                const curlified = curl(Im.fromJS(req))
+                let curlified = curl(Im.fromJS(req))
 
                 expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"x-custom-name: multipart/form-data\" -H  \"content-type: multipart/form-data\" -F \"id=123\" -F \"file=@file.txt;type=text/plain\"")
             })

--- a/test/mocha/core/curlify.js
+++ b/test/mocha/core/curlify.js
@@ -5,318 +5,318 @@ import win from "core/window"
 
 describe("curlify", function () {
 
-  it("prints a curl statement with custom content-type", function () {
-    let req = {
-      url: "http://example.com",
-      method: "POST",
-      body: {
-        id: 0,
-        name: "doggie",
-        status: "available"
-      },
-      headers: {
-        Accept: "application/json",
-        "content-type": "application/json"
-      }
-    }
+    it("prints a curl statement with custom content-type", function () {
+        let req = {
+            url: "http://example.com",
+            method: "POST",
+            body: {
+                id: 0,
+                name: "doggie",
+                status: "available"
+            },
+            headers: {
+                Accept: "application/json",
+                "content-type": "application/json"
+            }
+        }
 
-    let curlified = curl(Im.fromJS(req))
+        let curlified = curl(Im.fromJS(req))
 
-    expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"Accept: application/json\" -H  \"content-type: application/json\" -d {\"id\":0,\"name\":\"doggie\",\"status\":\"available\"}")
-  })
+        expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"Accept: application/json\" -H  \"content-type: application/json\" -d {\"id\":0,\"name\":\"doggie\",\"status\":\"available\"}")
+    })
 
-  it("does add a empty data param if no request body given", function () {
-    let req = {
-      url: "http://example.com",
-      method: "POST",
-    }
+    it("does add a empty data param if no request body given", function () {
+        let req = {
+            url: "http://example.com",
+            method: "POST",
+        }
 
-    let curlified = curl(Im.fromJS(req))
+        let curlified = curl(Im.fromJS(req))
 
-    expect(curlified).toEqual("curl -X POST \"http://example.com\" -d \"\"")
-  })
+        expect(curlified).toEqual("curl -X POST \"http://example.com\" -d \"\"")
+    })
 
-  it("does not change the case of header in curl", function () {
-    let req = {
-      url: "http://example.com",
-      method: "POST",
-      headers: {
-        "conTenT Type": "application/Moar"
-      }
-    }
+    it("does not change the case of header in curl", function () {
+        let req = {
+            url: "http://example.com",
+            method: "POST",
+            headers: {
+                "conTenT Type": "application/Moar"
+            }
+        }
 
-    let curlified = curl(Im.fromJS(req))
+        let curlified = curl(Im.fromJS(req))
 
-    expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"conTenT Type: application/Moar\" -d \"\"")
-  })
+        expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"conTenT Type: application/Moar\" -d \"\"")
+    })
 
-  it("prints a curl statement with an array of query params", function () {
-    let req = {
-      url: "http://swaggerhub.com/v1/one?name=john|smith",
-      method: "GET"
-    }
+    it("prints a curl statement with an array of query params", function () {
+        let req = {
+            url: "http://swaggerhub.com/v1/one?name=john|smith",
+            method: "GET"
+        }
 
-    let curlified = curl(Im.fromJS(req))
+        let curlified = curl(Im.fromJS(req))
 
-    expect(curlified).toEqual("curl -X GET \"http://swaggerhub.com/v1/one?name=john|smith\"")
-  })
+        expect(curlified).toEqual("curl -X GET \"http://swaggerhub.com/v1/one?name=john|smith\"")
+    })
 
-  it("prints a curl statement with an array of query params and auth", function () {
-    let req = {
-      url: "http://swaggerhub.com/v1/one?name=john|smith",
-      method: "GET",
-      headers: {
-        authorization: "Basic Zm9vOmJhcg=="
-      }
-    }
+    it("prints a curl statement with an array of query params and auth", function () {
+        let req = {
+            url: "http://swaggerhub.com/v1/one?name=john|smith",
+            method: "GET",
+            headers: {
+                authorization: "Basic Zm9vOmJhcg=="
+            }
+        }
 
-    let curlified = curl(Im.fromJS(req))
+        let curlified = curl(Im.fromJS(req))
 
-    expect(curlified).toEqual("curl -X GET \"http://swaggerhub.com/v1/one?name=john|smith\" -H  \"authorization: Basic Zm9vOmJhcg==\"")
-  })
+        expect(curlified).toEqual("curl -X GET \"http://swaggerhub.com/v1/one?name=john|smith\" -H  \"authorization: Basic Zm9vOmJhcg==\"")
+    })
 
-  it("prints a curl statement with html", function () {
-    let req = {
-      url: "http://swaggerhub.com/v1/one?name=john|smith",
-      method: "GET",
-      headers: {
-        accept: "application/json"
-      },
-      body: {
-        description: "<b>Test</b>"
-      }
-    }
+    it("prints a curl statement with html", function () {
+        let req = {
+            url: "http://swaggerhub.com/v1/one?name=john|smith",
+            method: "GET",
+            headers: {
+                accept: "application/json"
+            },
+            body: {
+                description: "<b>Test</b>"
+            }
+        }
 
-    let curlified = curl(Im.fromJS(req))
+        let curlified = curl(Im.fromJS(req))
 
-    expect(curlified).toEqual("curl -X GET \"http://swaggerhub.com/v1/one?name=john|smith\" -H  \"accept: application/json\" -d {\"description\":\"<b>Test</b>\"}")
-  })
+        expect(curlified).toEqual("curl -X GET \"http://swaggerhub.com/v1/one?name=john|smith\" -H  \"accept: application/json\" -d {\"description\":\"<b>Test</b>\"}")
+    })
 
-  it("handles post body with html", function () {
-    let req = {
-      url: "http://swaggerhub.com/v1/one?name=john|smith",
-      method: "POST",
-      headers: {
-        accept: "application/json"
-      },
-      body: {
-        description: "<b>Test</b>"
-      }
-    }
+    it("handles post body with html", function () {
+        let req = {
+            url: "http://swaggerhub.com/v1/one?name=john|smith",
+            method: "POST",
+            headers: {
+                accept: "application/json"
+            },
+            body: {
+                description: "<b>Test</b>"
+            }
+        }
 
-    let curlified = curl(Im.fromJS(req))
+        let curlified = curl(Im.fromJS(req))
 
-    expect(curlified).toEqual("curl -X POST \"http://swaggerhub.com/v1/one?name=john|smith\" -H  \"accept: application/json\" -d {\"description\":\"<b>Test</b>\"}")
-  })
+        expect(curlified).toEqual("curl -X POST \"http://swaggerhub.com/v1/one?name=john|smith\" -H  \"accept: application/json\" -d {\"description\":\"<b>Test</b>\"}")
+    })
 
-  it("handles post body with special chars", function () {
-    let req = {
-      url: "http://swaggerhub.com/v1/one?name=john|smith",
-      method: "POST",
-      body: {
-        description: "@prefix nif:<http://persistence.uni-leipzig.org/nlp2rdf/ontologies/nif-core#> .\n" +
-          "@prefix itsrdf: <http://www.w3.org/2005/11/its/rdf#> ."
-      }
-    }
+    it("handles post body with special chars", function () {
+        let req = {
+            url: "http://swaggerhub.com/v1/one?name=john|smith",
+            method: "POST",
+            body: {
+                description: "@prefix nif:<http://persistence.uni-leipzig.org/nlp2rdf/ontologies/nif-core#> .\n" +
+                    "@prefix itsrdf: <http://www.w3.org/2005/11/its/rdf#> ."
+            }
+        }
 
-    let curlified = curl(Im.fromJS(req))
+        let curlified = curl(Im.fromJS(req))
 
-    expect(curlified).toEqual("curl -X POST \"http://swaggerhub.com/v1/one?name=john|smith\" -d {\"description\":\"@prefix nif:<http://persistence.uni-leipzig.org/nlp2rdf/ontologies/nif-core#> .@prefix itsrdf: <http://www.w3.org/2005/11/its/rdf#> .\"}")
-  })
+        expect(curlified).toEqual("curl -X POST \"http://swaggerhub.com/v1/one?name=john|smith\" -d {\"description\":\"@prefix nif:<http://persistence.uni-leipzig.org/nlp2rdf/ontologies/nif-core#> .@prefix itsrdf: <http://www.w3.org/2005/11/its/rdf#> .\"}")
+    })
 
-  it("handles delete form with parameters", function () {
-    let req = {
-      url: "http://example.com",
-      method: "DELETE",
-      headers: {
-        accept: "application/x-www-form-urlencoded"
-      }
-    }
+    it("handles delete form with parameters", function () {
+        let req = {
+            url: "http://example.com",
+            method: "DELETE",
+            headers: {
+                accept: "application/x-www-form-urlencoded"
+            }
+        }
 
-    let curlified = curl(Im.fromJS(req))
+        let curlified = curl(Im.fromJS(req))
 
-    expect(curlified).toEqual("curl -X DELETE \"http://example.com\" -H  \"accept: application/x-www-form-urlencoded\"")
-  })
+        expect(curlified).toEqual("curl -X DELETE \"http://example.com\" -H  \"accept: application/x-www-form-urlencoded\"")
+    })
 
-  it("should print a curl with formData", function () {
-    let req = {
-      url: "http://example.com",
-      method: "POST",
-      headers: { "content-type": "multipart/form-data" },
-      body: {
-        id: "123",
-        name: "Sahar"
-      }
-    }
+    it("should print a curl with formData", function () {
+        let req = {
+            url: "http://example.com",
+            method: "POST",
+            headers: { "content-type": "multipart/form-data" },
+            body: {
+                id: "123",
+                name: "Sahar"
+            }
+        }
 
-    let curlified = curl(Im.fromJS(req))
+        let curlified = curl(Im.fromJS(req))
 
-    expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"content-type: multipart/form-data\" -F \"id=123\" -F \"name=Sahar\"")
-  })
+        expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"content-type: multipart/form-data\" -F \"id=123\" -F \"name=Sahar\"")
+    })
 
-  it("should print a curl with formData that extracts array representation with hashIdx", function () {
-    // Note: hashIdx = `_**[]${counter}`
-    // Usage of hashIdx is an internal SwaggerUI method to convert formData array into something curlify can handle
-    let req = {
-      url: "http://example.com",
-      method: "POST",
-      headers: { "content-type": "multipart/form-data" },
-      body: {
-        id: "123",
-        "fruits[]_**[]1": "apple",
-        "fruits[]_**[]2": "banana",
-        "fruits[]_**[]3": "grape"
-      }
-    }
+    it("should print a curl with formData that extracts array representation with hashIdx", function () {
+        // Note: hashIdx = `_**[]${counter}`
+        // Usage of hashIdx is an internal SwaggerUI method to convert formData array into something curlify can handle
+        let req = {
+            url: "http://example.com",
+            method: "POST",
+            headers: { "content-type": "multipart/form-data" },
+            body: {
+                id: "123",
+                "fruits[]_**[]1": "apple",
+                "fruits[]_**[]2": "banana",
+                "fruits[]_**[]3": "grape"
+            }
+        }
 
-    let curlified = curl(Im.fromJS(req))
+        let curlified = curl(Im.fromJS(req))
 
-    expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"content-type: multipart/form-data\" -F \"id=123\" -F \"fruits[]=apple\" -F \"fruits[]=banana\" -F \"fruits[]=grape\"")
-  })
+        expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"content-type: multipart/form-data\" -F \"id=123\" -F \"fruits[]=apple\" -F \"fruits[]=banana\" -F \"fruits[]=grape\"")
+    })
 
-  it("should print a curl with formData and file", function () {
-    var file = new win.File()
-    file.name = "file.txt"
-    file.type = "text/plain"
-
-    let req = {
-      url: "http://example.com",
-      method: "POST",
-      headers: { "content-type": "multipart/form-data" },
-      body: {
-        id: "123",
-        file
-      }
-    }
-
-    let curlified = curl(Im.fromJS(req))
-
-    expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"content-type: multipart/form-data\" -F \"id=123\" -F \"file=@file.txt;type=text/plain\"")
-  })
-
-  it("should print a curl without form data type if type is unknown", function () {
-    var file = new win.File()
-    file.name = "file.txt"
-    file.type = ""
-
-    let req = {
-      url: "http://example.com",
-      method: "POST",
-      headers: { "content-type": "multipart/form-data" },
-      body: {
-        id: "123",
-        file
-      }
-    }
-
-    let curlified = curl(Im.fromJS(req))
-
-    expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"content-type: multipart/form-data\" -F \"id=123\" -F \"file=@file.txt\"")
-  })
-
-  it("prints a curl post statement from an object", function () {
-    let req = {
-      url: "http://example.com",
-      method: "POST",
-      headers: {
-        accept: "application/json"
-      },
-      body: {
-        id: 10101
-      }
-    }
-
-    let curlified = curl(Im.fromJS(req))
-
-    expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"accept: application/json\" -d {\"id\":10101}")
-  })
-
-  it("prints a curl post statement from a string containing a single quote", function () {
-    let req = {
-      url: "http://example.com",
-      method: "POST",
-      headers: {
-        accept: "application/json"
-      },
-      body: "{\"id\":\"foo'bar\"}"
-    }
-
-    let curlified = curl(Im.fromJS(req))
-
-    expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"accept: application/json\" -d \"{\\\"id\\\":\\\"foo'bar\\\"}\"")
-  })
-
-  context("given multiple entries with file", function () {
-    context("and with leading custom header", function () {
-      it("should print a proper curl -F", function () {
-        let file = new win.File()
+    it("should print a curl with formData and file", function () {
+        var file = new win.File()
         file.name = "file.txt"
         file.type = "text/plain"
 
         let req = {
-          url: "http://example.com",
-          method: "POST",
-          headers: {
-            "x-custom-name": "multipart/form-data",
-            "content-type": "multipart/form-data"
-          },
-          body: {
-            id: "123",
-            file
-          }
+            url: "http://example.com",
+            method: "POST",
+            headers: { "content-type": "multipart/form-data" },
+            body: {
+                id: "123",
+                file
+            }
         }
 
-        const curlified = curl(Im.fromJS(req))
+        let curlified = curl(Im.fromJS(req))
 
-        expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"x-custom-name: multipart/form-data\" -H  \"content-type: multipart/form-data\" -F \"id=123\" -F \"file=@file.txt;type=text/plain\"")
-      })
+        expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"content-type: multipart/form-data\" -F \"id=123\" -F \"file=@file.txt;type=text/plain\"")
     })
 
-    context("and with trailing custom header; e.g. from requestInterceptor appending req.headers", function () {
-      it("should print a proper curl -F", function () {
-        let file = new win.File()
+    it("should print a curl without form data type if type is unknown", function () {
+        var file = new win.File()
         file.name = "file.txt"
-        file.type = "text/plain"
+        file.type = ""
 
         let req = {
-          url: "http://example.com",
-          method: "POST",
-          headers: {
-            "content-type": "multipart/form-data",
-            "x-custom-name": "any-value"
-          },
-          body: {
-            id: "123",
-            file
-          }
+            url: "http://example.com",
+            method: "POST",
+            headers: { "content-type": "multipart/form-data" },
+            body: {
+                id: "123",
+                file
+            }
         }
 
-        const curlified = curl(Im.fromJS(req))
+        let curlified = curl(Im.fromJS(req))
 
-        expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"content-type: multipart/form-data\" -H  \"x-custom-name: any-value\" -F \"id=123\" -F \"file=@file.txt;type=text/plain\"")
-      })
+        expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"content-type: multipart/form-data\" -F \"id=123\" -F \"file=@file.txt\"")
     })
-  })
 
-  context("POST when header value is 'multipart/form-data' but header name is not 'content-type'", function () {
-    it("shoud print a proper curl as -d <data>", function () {
-      let file = new win.File()
-      file.name = "file.txt"
-      file.type = "text/plain"
-
-      let req = {
-        url: "http://example.com",
-        method: "POST",
-        headers: { "x-custom-name": "multipart/form-data" },
-        body: {
-          id: "123",
-          file
+    it("prints a curl post statement from an object", function () {
+        let req = {
+            url: "http://example.com",
+            method: "POST",
+            headers: {
+                accept: "application/json"
+            },
+            body: {
+                id: 10101
+            }
         }
-      }
 
-      const curlified = curl(Im.fromJS(req))
+        let curlified = curl(Im.fromJS(req))
 
-      expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"x-custom-name: multipart/form-data\" -d {\"id\":\"123\",\"file\":{\"name\":\"file.txt\",\"type\":\"text/plain\"}}")
+        expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"accept: application/json\" -d {\"id\":10101}")
     })
-  })
+
+    it("prints a curl post statement from a string containing a single quote", function () {
+        let req = {
+            url: "http://example.com",
+            method: "POST",
+            headers: {
+                accept: "application/json"
+            },
+            body: "{\"id\":\"foo'bar\"}"
+        }
+
+        let curlified = curl(Im.fromJS(req))
+
+        expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"accept: application/json\" -d \"{\\\"id\\\":\\\"foo'bar\\\"}\"")
+    })
+
+    context("given multiple entries with file", function () {
+        context("and with leading custom header", function () {
+            it("should print a proper curl -F", function () {
+                let file = new win.File()
+                file.name = "file.txt"
+                file.type = "text/plain"
+
+                let req = {
+                    url: "http://example.com",
+                    method: "POST",
+                    headers: {
+                        "x-custom-name": "multipart/form-data",
+                        "content-type": "multipart/form-data"
+                    },
+                    body: {
+                        id: "123",
+                        file
+                    }
+                }
+
+                const curlified = curl(Im.fromJS(req))
+
+                expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"x-custom-name: multipart/form-data\" -H  \"content-type: multipart/form-data\" -F \"id=123\" -F \"file=@file.txt;type=text/plain\"")
+            })
+        })
+
+        context("and with trailing custom header; e.g. from requestInterceptor appending req.headers", function () {
+            it("should print a proper curl -F", function () {
+                let file = new win.File()
+                file.name = "file.txt"
+                file.type = "text/plain"
+
+                let req = {
+                    url: "http://example.com",
+                    method: "POST",
+                    headers: {
+                        "content-type": "multipart/form-data",
+                        "x-custom-name": "any-value"
+                    },
+                    body: {
+                        id: "123",
+                        file
+                    }
+                }
+
+                const curlified = curl(Im.fromJS(req))
+
+                expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"content-type: multipart/form-data\" -H  \"x-custom-name: any-value\" -F \"id=123\" -F \"file=@file.txt;type=text/plain\"")
+            })
+        })
+    })
+
+    context("POST when header value is 'multipart/form-data' but header name is not 'content-type'", function () {
+        it("shoud print a proper curl as -d <data>", function () {
+            let file = new win.File()
+            file.name = "file.txt"
+            file.type = "text/plain"
+
+            let req = {
+                url: "http://example.com",
+                method: "POST",
+                headers: { "x-custom-name": "multipart/form-data" },
+                body: {
+                    id: "123",
+                    file
+                }
+            }
+
+            const curlified = curl(Im.fromJS(req))
+
+            expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"x-custom-name: multipart/form-data\" -d {\"id\":\"123\",\"file\":{\"name\":\"file.txt\",\"type\":\"text/plain\"}}")
+        })
+    })
 })

--- a/test/mocha/core/curlify.js
+++ b/test/mocha/core/curlify.js
@@ -26,14 +26,14 @@ describe("curlify", function() {
     })
 
     it("does add a empty data param if no request body given", function() {
-        var req = {
-            url: "http://example.com",
-            method: "POST",
-        }
+      var req = {
+        url: "http://example.com",
+        method: "POST",
+      }
 
-        let curlified = curl(Im.fromJS(req))
+      let curlified = curl(Im.fromJS(req))
 
-        expect(curlified).toEqual("curl -X POST \"http://example.com\" -d \"\"")
+      expect(curlified).toEqual("curl -X POST \"http://example.com\" -d \"\"")
     })
 
     it("does not change the case of header in curl", function() {
@@ -115,7 +115,7 @@ describe("curlify", function() {
             method: "POST",
             body: {
                 description: "@prefix nif:<http://persistence.uni-leipzig.org/nlp2rdf/ontologies/nif-core#> .\n" +
-                    "@prefix itsrdf: <http://www.w3.org/2005/11/its/rdf#> ."
+                "@prefix itsrdf: <http://www.w3.org/2005/11/its/rdf#> ."
             }
         }
 
@@ -144,8 +144,8 @@ describe("curlify", function() {
             method: "POST",
             headers: { "content-type": "multipart/form-data" },
             body: {
-                id: "123",
-                name: "Sahar"
+              id: "123",
+              name: "Sahar"
             }
         }
 
@@ -184,8 +184,8 @@ describe("curlify", function() {
             method: "POST",
             headers: { "content-type": "multipart/form-data" },
             body: {
-                id: "123",
-                file
+              id: "123",
+              file
             }
         }
 
@@ -195,23 +195,23 @@ describe("curlify", function() {
     })
 
     it("should print a curl without form data type if type is unknown", function() {
-        var file = new win.File()
-        file.name = "file.txt"
-        file.type = ""
+      var file = new win.File()
+      file.name = "file.txt"
+      file.type = ""
 
-        var req = {
-            url: "http://example.com",
-            method: "POST",
-            headers: { "content-type": "multipart/form-data" },
-            body: {
-                id: "123",
-                file
-            }
-        }
+      var req = {
+          url: "http://example.com",
+          method: "POST",
+          headers: { "content-type": "multipart/form-data" },
+          body: {
+              id: "123",
+              file
+          }
+      }
 
-        let curlified = curl(Im.fromJS(req))
+      let curlified = curl(Im.fromJS(req))
 
-        expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"content-type: multipart/form-data\" -F \"id=123\" -F \"file=@file.txt\"")
+      expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"content-type: multipart/form-data\" -F \"id=123\" -F \"file=@file.txt\"")
     })
 
     it("prints a curl post statement from an object", function() {

--- a/test/mocha/core/curlify.js
+++ b/test/mocha/core/curlify.js
@@ -3,9 +3,9 @@ import Im from "immutable"
 import curl from "core/curlify"
 import win from "core/window"
 
-describe("curlify", function () {
+describe("curlify", function() {
 
-    it("prints a curl statement with custom content-type", function () {
+    it("prints a curl statement with custom content-type", function() {
         var req = {
             url: "http://example.com",
             method: "POST",
@@ -25,7 +25,7 @@ describe("curlify", function () {
         expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"Accept: application/json\" -H  \"content-type: application/json\" -d {\"id\":0,\"name\":\"doggie\",\"status\":\"available\"}")
     })
 
-    it("does add a empty data param if no request body given", function () {
+    it("does add a empty data param if no request body given", function() {
         var req = {
             url: "http://example.com",
             method: "POST",
@@ -36,7 +36,7 @@ describe("curlify", function () {
         expect(curlified).toEqual("curl -X POST \"http://example.com\" -d \"\"")
     })
 
-    it("does not change the case of header in curl", function () {
+    it("does not change the case of header in curl", function() {
         var req = {
             url: "http://example.com",
             method: "POST",
@@ -50,7 +50,7 @@ describe("curlify", function () {
         expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"conTenT Type: application/Moar\" -d \"\"")
     })
 
-    it("prints a curl statement with an array of query params", function () {
+    it("prints a curl statement with an array of query params", function() {
         var req = {
             url: "http://swaggerhub.com/v1/one?name=john|smith",
             method: "GET"
@@ -61,7 +61,7 @@ describe("curlify", function () {
         expect(curlified).toEqual("curl -X GET \"http://swaggerhub.com/v1/one?name=john|smith\"")
     })
 
-    it("prints a curl statement with an array of query params and auth", function () {
+    it("prints a curl statement with an array of query params and auth", function() {
         var req = {
             url: "http://swaggerhub.com/v1/one?name=john|smith",
             method: "GET",
@@ -75,7 +75,7 @@ describe("curlify", function () {
         expect(curlified).toEqual("curl -X GET \"http://swaggerhub.com/v1/one?name=john|smith\" -H  \"authorization: Basic Zm9vOmJhcg==\"")
     })
 
-    it("prints a curl statement with html", function () {
+    it("prints a curl statement with html", function() {
         var req = {
             url: "http://swaggerhub.com/v1/one?name=john|smith",
             method: "GET",
@@ -92,7 +92,7 @@ describe("curlify", function () {
         expect(curlified).toEqual("curl -X GET \"http://swaggerhub.com/v1/one?name=john|smith\" -H  \"accept: application/json\" -d {\"description\":\"<b>Test</b>\"}")
     })
 
-    it("handles post body with html", function () {
+    it("handles post body with html", function() {
         var req = {
             url: "http://swaggerhub.com/v1/one?name=john|smith",
             method: "POST",
@@ -109,7 +109,7 @@ describe("curlify", function () {
         expect(curlified).toEqual("curl -X POST \"http://swaggerhub.com/v1/one?name=john|smith\" -H  \"accept: application/json\" -d {\"description\":\"<b>Test</b>\"}")
     })
 
-    it("handles post body with special chars", function () {
+    it("handles post body with special chars", function() {
         var req = {
             url: "http://swaggerhub.com/v1/one?name=john|smith",
             method: "POST",
@@ -124,7 +124,7 @@ describe("curlify", function () {
         expect(curlified).toEqual("curl -X POST \"http://swaggerhub.com/v1/one?name=john|smith\" -d {\"description\":\"@prefix nif:<http://persistence.uni-leipzig.org/nlp2rdf/ontologies/nif-core#> .@prefix itsrdf: <http://www.w3.org/2005/11/its/rdf#> .\"}")
     })
 
-    it("handles delete form with parameters", function () {
+    it("handles delete form with parameters", function() {
         var req = {
             url: "http://example.com",
             method: "DELETE",
@@ -138,7 +138,7 @@ describe("curlify", function () {
         expect(curlified).toEqual("curl -X DELETE \"http://example.com\" -H  \"accept: application/x-www-form-urlencoded\"")
     })
 
-    it("should print a curl with formData", function () {
+    it("should print a curl with formData", function() {
         var req = {
             url: "http://example.com",
             method: "POST",
@@ -157,7 +157,7 @@ describe("curlify", function () {
     it("should print a curl with formData that extracts array representation with hashIdx", function() {
         // Note: hashIdx = `_**[]${counter}`
         // Usage of hashIdx is an internal SwaggerUI method to convert formData array into something curlify can handle
-        var req = {
+        const req = {
             url: "http://example.com",
             method: "POST",
             headers: { "content-type": "multipart/form-data" },
@@ -174,7 +174,7 @@ describe("curlify", function () {
         expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"content-type: multipart/form-data\" -F \"id=123\" -F \"fruits[]=apple\" -F \"fruits[]=banana\" -F \"fruits[]=grape\"")
     })
 
-    it("should print a curl with formData and file", function () {
+    it("should print a curl with formData and file", function() {
         var file = new win.File()
         file.name = "file.txt"
         file.type = "text/plain"
@@ -194,7 +194,7 @@ describe("curlify", function () {
         expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"content-type: multipart/form-data\" -F \"id=123\" -F \"file=@file.txt;type=text/plain\"")
     })
 
-    it("should print a curl without form data type if type is unknown", function () {
+    it("should print a curl without form data type if type is unknown", function() {
         var file = new win.File()
         file.name = "file.txt"
         file.type = ""
@@ -214,7 +214,7 @@ describe("curlify", function () {
         expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"content-type: multipart/form-data\" -F \"id=123\" -F \"file=@file.txt\"")
     })
 
-    it("prints a curl post statement from an object", function () {
+    it("prints a curl post statement from an object", function() {
         var req = {
             url: "http://example.com",
             method: "POST",
@@ -231,7 +231,7 @@ describe("curlify", function () {
         expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"accept: application/json\" -d {\"id\":10101}")
     })
 
-    it("prints a curl post statement from a string containing a single quote", function () {
+    it("prints a curl post statement from a string containing a single quote", function() {
         var req = {
             url: "http://example.com",
             method: "POST",
@@ -246,9 +246,9 @@ describe("curlify", function () {
         expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"accept: application/json\" -d \"{\\\"id\\\":\\\"foo'bar\\\"}\"")
     })
 
-    context("given multiple entries with file", function () {
-        context("and with leading custom header", function () {
-            it("should print a proper curl -F", function () {
+    context("given multiple entries with file", function() {
+        context("and with leading custom header", function() {
+            it("should print a proper curl -F", function() {
                 let file = new win.File()
                 file.name = "file.txt"
                 file.type = "text/plain"
@@ -272,8 +272,8 @@ describe("curlify", function () {
             })
         })
 
-        context("and with trailing custom header; e.g. from requestInterceptor appending req.headers", function () {
-            it("should print a proper curl -F", function () {
+        context("and with trailing custom header; e.g. from requestInterceptor appending req.headers", function() {
+            it("should print a proper curl -F", function() {
                 let file = new win.File()
                 file.name = "file.txt"
                 file.type = "text/plain"
@@ -298,8 +298,8 @@ describe("curlify", function () {
         })
     })
 
-    context("POST when header value is 'multipart/form-data' but header name is not 'content-type'", function () {
-        it("shoud print a proper curl as -d <data>", function () {
+    context("POST when header value is 'multipart/form-data' but header name is not 'content-type'", function() {
+        it("shoud print a proper curl as -d <data>", function() {
             let file = new win.File()
             file.name = "file.txt"
             file.type = "text/plain"

--- a/test/mocha/core/curlify.js
+++ b/test/mocha/core/curlify.js
@@ -291,7 +291,7 @@ describe("curlify", function() {
                     }
                 }
 
-                const curlified = curl(Im.fromJS(req))
+                let curlified = curl(Im.fromJS(req))
 
                 expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"content-type: multipart/form-data\" -H  \"x-custom-name: any-value\" -F \"id=123\" -F \"file=@file.txt;type=text/plain\"")
             })

--- a/test/mocha/core/curlify.js
+++ b/test/mocha/core/curlify.js
@@ -200,13 +200,13 @@ describe("curlify", function() {
       file.type = ""
 
       var req = {
-          url: "http://example.com",
-          method: "POST",
-          headers: { "content-type": "multipart/form-data" },
-          body: {
-              id: "123",
-              file
-          }
+        url: "http://example.com",
+        method: "POST",
+        headers: { "content-type": "multipart/form-data" },
+        body: {
+          id: "123",
+          file
+        }
       }
 
       let curlified = curl(Im.fromJS(req))

--- a/test/mocha/core/curlify.js
+++ b/test/mocha/core/curlify.js
@@ -314,7 +314,7 @@ describe("curlify", function() {
                 }
             }
 
-            const curlified = curl(Im.fromJS(req))
+            let curlified = curl(Im.fromJS(req))
 
             expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"x-custom-name: multipart/form-data\" -d {\"id\":\"123\",\"file\":{\"name\":\"file.txt\",\"type\":\"text/plain\"}}")
         })

--- a/test/mocha/core/curlify.js
+++ b/test/mocha/core/curlify.js
@@ -6,7 +6,7 @@ import win from "core/window"
 describe("curlify", function () {
 
     it("prints a curl statement with custom content-type", function () {
-        let req = {
+        var req = {
             url: "http://example.com",
             method: "POST",
             body: {
@@ -26,7 +26,7 @@ describe("curlify", function () {
     })
 
     it("does add a empty data param if no request body given", function () {
-        let req = {
+        var req = {
             url: "http://example.com",
             method: "POST",
         }
@@ -37,7 +37,7 @@ describe("curlify", function () {
     })
 
     it("does not change the case of header in curl", function () {
-        let req = {
+        var req = {
             url: "http://example.com",
             method: "POST",
             headers: {
@@ -51,7 +51,7 @@ describe("curlify", function () {
     })
 
     it("prints a curl statement with an array of query params", function () {
-        let req = {
+        var req = {
             url: "http://swaggerhub.com/v1/one?name=john|smith",
             method: "GET"
         }
@@ -62,7 +62,7 @@ describe("curlify", function () {
     })
 
     it("prints a curl statement with an array of query params and auth", function () {
-        let req = {
+        var req = {
             url: "http://swaggerhub.com/v1/one?name=john|smith",
             method: "GET",
             headers: {
@@ -76,7 +76,7 @@ describe("curlify", function () {
     })
 
     it("prints a curl statement with html", function () {
-        let req = {
+        var req = {
             url: "http://swaggerhub.com/v1/one?name=john|smith",
             method: "GET",
             headers: {
@@ -93,7 +93,7 @@ describe("curlify", function () {
     })
 
     it("handles post body with html", function () {
-        let req = {
+        var req = {
             url: "http://swaggerhub.com/v1/one?name=john|smith",
             method: "POST",
             headers: {
@@ -110,7 +110,7 @@ describe("curlify", function () {
     })
 
     it("handles post body with special chars", function () {
-        let req = {
+        var req = {
             url: "http://swaggerhub.com/v1/one?name=john|smith",
             method: "POST",
             body: {
@@ -125,7 +125,7 @@ describe("curlify", function () {
     })
 
     it("handles delete form with parameters", function () {
-        let req = {
+        var req = {
             url: "http://example.com",
             method: "DELETE",
             headers: {
@@ -139,7 +139,7 @@ describe("curlify", function () {
     })
 
     it("should print a curl with formData", function () {
-        let req = {
+        var req = {
             url: "http://example.com",
             method: "POST",
             headers: { "content-type": "multipart/form-data" },
@@ -154,10 +154,10 @@ describe("curlify", function () {
         expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"content-type: multipart/form-data\" -F \"id=123\" -F \"name=Sahar\"")
     })
 
-    it("should print a curl with formData that extracts array representation with hashIdx", function () {
+    it("should print a curl with formData that extracts array representation with hashIdx", function() {
         // Note: hashIdx = `_**[]${counter}`
         // Usage of hashIdx is an internal SwaggerUI method to convert formData array into something curlify can handle
-        let req = {
+        var req = {
             url: "http://example.com",
             method: "POST",
             headers: { "content-type": "multipart/form-data" },
@@ -179,7 +179,7 @@ describe("curlify", function () {
         file.name = "file.txt"
         file.type = "text/plain"
 
-        let req = {
+        var req = {
             url: "http://example.com",
             method: "POST",
             headers: { "content-type": "multipart/form-data" },
@@ -199,7 +199,7 @@ describe("curlify", function () {
         file.name = "file.txt"
         file.type = ""
 
-        let req = {
+        var req = {
             url: "http://example.com",
             method: "POST",
             headers: { "content-type": "multipart/form-data" },
@@ -215,7 +215,7 @@ describe("curlify", function () {
     })
 
     it("prints a curl post statement from an object", function () {
-        let req = {
+        var req = {
             url: "http://example.com",
             method: "POST",
             headers: {
@@ -232,7 +232,7 @@ describe("curlify", function () {
     })
 
     it("prints a curl post statement from a string containing a single quote", function () {
-        let req = {
+        var req = {
             url: "http://example.com",
             method: "POST",
             headers: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

In `curlify`, the `type` would overwrite the string value to the latest header value. In the case of using `requestInterceptor` that appends a header, the final string would be whatever was provided by the `requestInterceptor`.

This fix will try to update `isMultipartFormDataRequest` until it is `true`.

This change also reorganizes and fixes the linting in the `curlify` test file

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes #6082

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

New mocha tests that places leading/trailing custom header. There already exists a mocha test with no custom header. Note, although the term `custom` is used, any header and order should not impact the curlify result.

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
