### PR TITLE
build(webpack): make sure we're not bundling same deps twice

### DIFF
--- a/webpack/bundle.babel.js
+++ b/webpack/bundle.babel.js
@@ -2,6 +2,8 @@
  * @prettier
  */
 
+import path from "path"
+
 import configBuilder from "./_config-builder"
 
 const result = configBuilder(
@@ -21,6 +23,14 @@ const result = configBuilder(
 
     output: {
       library: "SwaggerUIBundle",
+    },
+    resolve: {
+      // these aliases make sure that we don't bundle same libraries twice
+      // when the versions of these libraries diverge between swagger-js and swagger-ui
+      alias: {
+        "@babel/runtime-corejs2": path.resolve(__dirname, '..', 'node_modules/@babel/runtime-corejs2'),
+        "js-yaml": path.resolve(__dirname, '..', 'node_modules/js-yaml')
+      },
     },
   }
 )


### PR DESCRIPTION
As versions of libraries that are both used by swagger-js and swagger-ui
may diverge in time, we must use webpack resolve aliases to make sure
that only one version of these libraries gets bundled.

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->



### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->



### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->



### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
