### PR TITLE
build(webpack): move resolve alises to one common place

### DIFF
--- a/webpack/_config-builder.js
+++ b/webpack/_config-builder.js
@@ -115,6 +115,12 @@ export default function buildConfig(
       resolve: {
         modules: [path.join(projectBasePath, "./src"), "node_modules"],
         extensions: [".web.js", ".js", ".jsx", ".json", ".less"],
+        // these aliases make sure that we don't bundle same libraries twice
+        // when the versions of these libraries diverge between swagger-js and swagger-ui
+        alias: {
+          "@babel/runtime-corejs2": path.resolve(__dirname, '..', 'node_modules/@babel/runtime-corejs2'),
+          "js-yaml": path.resolve(__dirname, '..', 'node_modules/js-yaml')
+        },
       },
 
       // If we're mangling, size is a concern -- so use trace-only sourcemaps

--- a/webpack/bundle.babel.js
+++ b/webpack/bundle.babel.js
@@ -24,14 +24,6 @@ const result = configBuilder(
     output: {
       library: "SwaggerUIBundle",
     },
-    resolve: {
-      // these aliases make sure that we don't bundle same libraries twice
-      // when the versions of these libraries diverge between swagger-js and swagger-ui
-      alias: {
-        "@babel/runtime-corejs2": path.resolve(__dirname, '..', 'node_modules/@babel/runtime-corejs2'),
-        "js-yaml": path.resolve(__dirname, '..', 'node_modules/js-yaml')
-      },
-    },
   }
 )
 


### PR DESCRIPTION
As resolving applies to everything and not just specific builds
the resolve.aliases have been moved to one common place.



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
