### PR TITLE
refactor(swagger-client): fix import of helpers

### DIFF
--- a/src/core/containers/OperationContainer.jsx
+++ b/src/core/containers/OperationContainer.jsx
@@ -1,10 +1,10 @@
 import React, { PureComponent } from "react"
 import PropTypes from "prop-types"
 import ImPropTypes from "react-immutable-proptypes"
-import { helpers } from "swagger-client"
+import SwaggerClient from "swagger-client"
 import { Iterable, fromJS, Map } from "immutable"
 
-const { opId } = helpers
+const { opId } = SwaggerClient.helpers
 
 export default class OperationContainer extends PureComponent {
   constructor(props, context) {

--- a/src/core/plugins/swagger-js/index.js
+++ b/src/core/plugins/swagger-js/index.js
@@ -1,13 +1,13 @@
-import Swagger from "swagger-client"
+import SwaggerClient from "swagger-client"
 import * as configsWrapActions from "./configs-wrap-actions"
 
 export default function({ configs, getConfigs }) {
   return {
     fn: {
-      fetch: Swagger.makeHttp(configs.preFetch, configs.postFetch),
-      buildRequest: Swagger.buildRequest,
-      execute: Swagger.execute,
-      resolve: Swagger.resolve,
+      fetch: SwaggerClient.makeHttp(configs.preFetch, configs.postFetch),
+      buildRequest: SwaggerClient.buildRequest,
+      execute: SwaggerClient.execute,
+      resolve: SwaggerClient.resolve,
       resolveSubtree: (obj, path, opts, ...rest) => {
         if(opts === undefined) {
           const freshConfigs = getConfigs()
@@ -19,10 +19,10 @@ export default function({ configs, getConfigs }) {
           }
         }
 
-        return Swagger.resolveSubtree(obj, path, opts, ...rest)
+        return SwaggerClient.resolveSubtree(obj, path, opts, ...rest)
       },
-      serializeRes: Swagger.serializeRes,
-      opId: Swagger.helpers.opId
+      serializeRes: SwaggerClient.serializeRes,
+      opId: SwaggerClient.helpers.opId
     },
     statePlugins: {
       configs: {


### PR DESCRIPTION
Import of helpers from swagger-client worked because of the fact
that commonjs exports are basically an objects that can be destructured.
Whenever swagger-client switches to ES6 imports as primary mechanism
of webpack consuptions imports like that will fail. This change makes
sure that import mechanism is both compatible with ES6 and commonjs
import systems.

Along with that rename default import of swagger-client
to more appropriate SwaggerClient.


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
