### PR TITLE
build(bundle): use ES6 to import swagger-client symbols

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2331,18 +2331,18 @@
       }
     },
     "@babel/runtime-corejs2": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.5.5.tgz",
-      "integrity": "sha512-FYATQVR00NSNi7mUfpPDp7E8RYMXDuO8gaix7u/w3GekfUinKgX1AcTxs7SoiEmoEW9mbpjrwqWSW6zCmw5h8A==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.10.4.tgz",
+      "integrity": "sha512-9sArmpZDQsnR1yyAcU51DxQrntWxt0LUKjPp3pIyo7kVLfaqKt8muppcT87QmFkXV5H50qXAF8JWOjk0jaXRYA==",
       "requires": {
         "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.2"
+        "regenerator-runtime": "^0.13.4"
       },
       "dependencies": {
         "regenerator-runtime": {
-          "version": "0.13.3",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -21154,11 +21154,11 @@
       }
     },
     "swagger-client": {
-      "version": "3.10.9",
-      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.10.9.tgz",
-      "integrity": "sha512-tPnhVQ0AC7wM89jfYsP/LlNvmzArr2Uf0NdQ7N69sHrS+7fibB/i75fOIG1kH4bb78D70Z1hwqszEvAOQaZ0Og==",
+      "version": "3.10.10",
+      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.10.10.tgz",
+      "integrity": "sha512-aOR1SaXa+hfNK5pHXeh1oVHO5aM3AgOmyrzaOazItQf0EuQGDbBlbmbSmyylYmWSMQhdkG1V1SQmGF17NiStXA==",
       "requires": {
-        "@babel/runtime-corejs2": "=7.10.2",
+        "@babel/runtime-corejs2": "=7.10.4",
         "btoa": "=1.2.1",
         "buffer": "=5.6.0",
         "cookie": "=0.4.1",
@@ -21174,15 +21174,6 @@
         "url": "=0.11.0"
       },
       "dependencies": {
-        "@babel/runtime-corejs2": {
-          "version": "7.10.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.10.2.tgz",
-          "integrity": "sha512-ZLwsFnNm3WpIARU1aLFtufjMHsmEnc8TjtrfAjmbgMbeoyR+LuQoyESoNdTfeDhL6IdY12SpeycXMgSgl8XGXA==",
-          "requires": {
-            "core-js": "^2.6.5",
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
         "js-yaml": {
           "version": "3.14.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
@@ -21196,11 +21187,6 @@
           "version": "6.9.4",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
           "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
-        },
-        "regenerator-runtime": {
-          "version": "0.13.5",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "reselect": "^4.0.0",
     "serialize-error": "^2.1.0",
     "sha.js": "^2.4.11",
-    "swagger-client": "=3.10.9",
+    "swagger-client": "=3.10.10",
     "url-parse": "^1.4.7",
     "xml-but-prettier": "^1.0.1",
     "zenscroll": "^4.0.2"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "start": "npm-run-all --parallel serve-static open-static"
   },
   "dependencies": {
-    "@babel/runtime-corejs2": "^7.5.5",
+    "@babel/runtime-corejs2": "^7.10.4",
     "@braintree/sanitize-url": "^4.0.0",
     "@kyleshockey/object-assign-deep": "^0.4.2",
     "@kyleshockey/xml": "^1.0.2",

--- a/src/core/containers/OperationContainer.jsx
+++ b/src/core/containers/OperationContainer.jsx
@@ -1,10 +1,8 @@
 import React, { PureComponent } from "react"
 import PropTypes from "prop-types"
 import ImPropTypes from "react-immutable-proptypes"
-import SwaggerClient from "swagger-client"
+import { opId } from "swagger-client/es/helpers"
 import { Iterable, fromJS, Map } from "immutable"
-
-const { opId } = SwaggerClient.helpers
 
 export default class OperationContainer extends PureComponent {
   constructor(props, context) {

--- a/src/core/plugins/swagger-js/index.js
+++ b/src/core/plugins/swagger-js/index.js
@@ -1,13 +1,17 @@
-import SwaggerClient from "swagger-client"
+import resolve from "swagger-client/es/resolver"
+import { execute, buildRequest } from "swagger-client/es/execute"
+import Http, { makeHttp, serializeRes } from "swagger-client/es/http"
+import resolveSubtree from "swagger-client/es/subtree-resolver"
+import { opId } from "swagger-client/es/helpers"
 import * as configsWrapActions from "./configs-wrap-actions"
 
 export default function({ configs, getConfigs }) {
   return {
     fn: {
-      fetch: SwaggerClient.makeHttp(configs.preFetch, configs.postFetch),
-      buildRequest: SwaggerClient.buildRequest,
-      execute: SwaggerClient.execute,
-      resolve: SwaggerClient.resolve,
+      fetch: makeHttp(Http, configs.preFetch, configs.postFetch),
+      buildRequest,
+      execute,
+      resolve,
       resolveSubtree: (obj, path, opts, ...rest) => {
         if(opts === undefined) {
           const freshConfigs = getConfigs()
@@ -19,10 +23,10 @@ export default function({ configs, getConfigs }) {
           }
         }
 
-        return SwaggerClient.resolveSubtree(obj, path, opts, ...rest)
+        return resolveSubtree(obj, path, opts, ...rest)
       },
-      serializeRes: SwaggerClient.serializeRes,
-      opId: SwaggerClient.helpers.opId
+      serializeRes,
+      opId
     },
     statePlugins: {
       configs: {


### PR DESCRIPTION
swagger-client in versions >3.10.9 exports it's build artifacts in multiple way.
One artifact is exposed as ES5 compatible code with ES6 imports.
We use this fact to utilize webpack tree shaking algorithm.

This commit decreases bundle size for around 10%.

We're now using undocumented symbols from swagger-client library so we have to
be really careful not to change how files and exports are organized in swagger-client.

### Motivation and Context

Using proper build fragments for proper usecases and decreasing the bundle size.


### How Has This Been Tested?

Manually by testing resulting built bundle



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [x] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
