### PR TITLE
Tmkasun ft/5367 support passing presets and default models expand depth

### DIFF
--- a/flavors/swagger-ui-react/README.md
+++ b/flavors/swagger-ui-react/README.md
@@ -101,6 +101,12 @@ If set to `true`, uses the mutated request returned from a requestInterceptor to
 
 ⚠️ This prop is currently only applied once, on mount. Changes to this prop's value will not be propagated to the underlying Swagger UI instance. A future version of this module will remove this limitation, and the change will not be considered a breaking change.
 
+#### `presets`: PropTypes.arrayOf(PropTypes.func),
+
+An array of functions that augment and modify Swagger UI's functionality. See Swagger UI's [Plugin API](https://github.com/swagger-api/swagger-ui/blob/master/docs/customization/plugin-api.md) for more details.
+
+⚠️ This prop is currently only applied once, on mount. Changes to this prop's value will not be propagated to the underlying Swagger UI instance. A future version of this module will remove this limitation, and the change will not be considered a breaking change.
+
 ## Limitations
 
 * Not all configuration bindings are available.

--- a/flavors/swagger-ui-react/index.js
+++ b/flavors/swagger-ui-react/index.js
@@ -84,7 +84,6 @@ SwaggerUI.propTypes = {
     PropTypes.object,
   ]),
   url: PropTypes.string,
-  defaultModelsExpandDepth: PropTypes.number,
   requestInterceptor: PropTypes.func,
   responseInterceptor: PropTypes.func,
   onComplete: PropTypes.func,

--- a/flavors/swagger-ui-react/index.js
+++ b/flavors/swagger-ui-react/index.js
@@ -1,7 +1,6 @@
 import React from "react"
 import PropTypes from "prop-types"
-import swaggerUIConstructor from "./swagger-ui"
-
+import swaggerUIConstructor, {presets} from "./swagger-ui"
 export default class SwaggerUI extends React.Component {
   constructor (props) {
     super(props)
@@ -14,6 +13,8 @@ export default class SwaggerUI extends React.Component {
       plugins: this.props.plugins,
       spec: this.props.spec,
       url: this.props.url,
+      defaultModelsExpandDepth: this.props.defaultModelsExpandDepth,
+      presets: [presets.apis,...this.props.presets],
       requestInterceptor: this.requestInterceptor,
       responseInterceptor: this.responseInterceptor,
       onComplete: this.onComplete,
@@ -83,6 +84,7 @@ SwaggerUI.propTypes = {
     PropTypes.object,
   ]),
   url: PropTypes.string,
+  defaultModelsExpandDepth: PropTypes.number,
   requestInterceptor: PropTypes.func,
   responseInterceptor: PropTypes.func,
   onComplete: PropTypes.func,
@@ -90,12 +92,16 @@ SwaggerUI.propTypes = {
   supportedSubmitMethods: PropTypes.arrayOf(
     PropTypes.oneOf(['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'])
     ),
-  defaultModelExpandDepth: PropTypes.number,
   plugins: PropTypes.arrayOf(PropTypes.object),
   displayOperationId: PropTypes.bool,
   showMutatedRequest: PropTypes.bool,
+  defaultModelExpandDepth: PropTypes.number,
+  presets: PropTypes.arrayOf(PropTypes.func),
 }
 
 SwaggerUI.defaultProps = {
   supportedSubmitMethods: ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'],
+  docExpansion: "list",
+  defaultModelsExpandDepth: 1,
+  presets: []
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Fix merge conflicts and update docs for PR https://github.com/swagger-api/swagger-ui/pull/5386

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

resolves #5386 

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->



### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [x] My changes require a change to the project documentation.
- [x] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
