### PR TITLE
fix(requestInterceptor): use async/await to support return new Promise

### DIFF
--- a/src/core/plugins/spec/actions.js
+++ b/src/core/plugins/spec/actions.js
@@ -429,8 +429,8 @@ export const executeRequest = (req) =>
 
     specActions.setRequest(req.pathName, req.method, parsedRequest)
 
-    let requestInterceptorWrapper = function(r) {
-      let mutatedRequest = requestInterceptor.apply(this, [r])
+    let requestInterceptorWrapper = async (r) => {
+      let mutatedRequest = await requestInterceptor.apply(this, [r])
       let parsedMutatedRequest = Object.assign({}, mutatedRequest)
       specActions.setMutatedRequest(req.pathName, req.method, parsedMutatedRequest)
       return mutatedRequest

--- a/test/mocha/core/plugins/spec/actions.js
+++ b/test/mocha/core/plugins/spec/actions.js
@@ -93,11 +93,11 @@ describe("spec plugin - actions", function(){
       })
     })
 
-    it("should pass requestInterceptor/responseInterceptor to fn.execute", function(){
+    it("should pass requestInterceptor/responseInterceptor to fn.execute", async () => {
       // Given
       let configs = {
         requestInterceptor: createSpy(),
-        responseInterceptor: createSpy()
+        responseInterceptor: createSpy(),
       }
       const system = {
         fn: {
@@ -107,7 +107,8 @@ describe("spec plugin - actions", function(){
         specActions: {
           executeRequest: createSpy(),
           setMutatedRequest: createSpy(),
-          setRequest: createSpy()
+          setRequest: createSpy(),
+          setResponse: createSpy()
         },
         specSelectors: {
           spec: () => fromJS({}),
@@ -137,7 +138,58 @@ describe("spec plugin - actions", function(){
 
 
       let wrappedRequestInterceptor = system.fn.execute.calls[0].arguments[0].requestInterceptor
-      wrappedRequestInterceptor(system.fn.execute.calls[0].arguments[0])
+      await wrappedRequestInterceptor(system.fn.execute.calls[0].arguments[0])
+      expect(configs.requestInterceptor.calls.length).toEqual(1)
+      expect(system.specActions.setMutatedRequest.calls.length).toEqual(1)
+      expect(system.specActions.setRequest.calls.length).toEqual(1)
+    })
+
+    it("should pass requestInterceptor/responseInterceptor with new Promise to fn.execute", async () => {
+      // Given
+      let configs = {
+        requestInterceptor: createSpy(),
+        responseInterceptor: createSpy().andReturn(new Promise((resolve) => resolve())),
+      }
+      const system = {
+        fn: {
+          buildRequest: createSpy(),
+          execute: createSpy().andReturn(Promise.resolve())
+        },
+        specActions: {
+          executeRequest: createSpy(),
+          setMutatedRequest: createSpy(),
+          setRequest: createSpy(),
+          setResponse: createSpy()
+        },
+        specSelectors: {
+          spec: () => fromJS({}),
+          parameterValues: () => fromJS({}),
+          contentTypeValues: () => fromJS({}),
+          url: () => fromJS({}),
+          isOAS3: () => false
+        },
+        getConfigs: () => configs
+      }
+      // When
+      let executeFn = executeRequest({
+        pathName: "/one",
+        method: "GET",
+        operation: fromJS({ operationId: "getOne" })
+      })
+      let res = executeFn(system)
+  
+      // Then
+      expect(system.fn.execute.calls.length).toEqual(1)
+      expect(system.fn.execute.calls[0].arguments[0]).toIncludeKey("requestInterceptor")
+      expect(system.fn.execute.calls[0].arguments[0]).toInclude({
+        responseInterceptor: configs.responseInterceptor
+      })
+      expect(system.specActions.setMutatedRequest.calls.length).toEqual(0)
+      expect(system.specActions.setRequest.calls.length).toEqual(1)
+  
+  
+      let wrappedRequestInterceptor = system.fn.execute.calls[0].arguments[0].requestInterceptor
+      await wrappedRequestInterceptor(system.fn.execute.calls[0].arguments[0])
       expect(configs.requestInterceptor.calls.length).toEqual(1)
       expect(system.specActions.setMutatedRequest.calls.length).toEqual(1)
       expect(system.specActions.setRequest.calls.length).toEqual(1)

--- a/test/mocha/core/plugins/spec/actions.js
+++ b/test/mocha/core/plugins/spec/actions.js
@@ -125,7 +125,7 @@ describe("spec plugin - actions", function(){
         method: "GET",
         operation: fromJS({operationId: "getOne"})
       })
-      let res = executeFn(system)
+      await executeFn(system)
 
       // Then
       expect(system.fn.execute.calls.length).toEqual(1)
@@ -137,57 +137,6 @@ describe("spec plugin - actions", function(){
       expect(system.specActions.setRequest.calls.length).toEqual(1)
 
 
-      let wrappedRequestInterceptor = system.fn.execute.calls[0].arguments[0].requestInterceptor
-      await wrappedRequestInterceptor(system.fn.execute.calls[0].arguments[0])
-      expect(configs.requestInterceptor.calls.length).toEqual(1)
-      expect(system.specActions.setMutatedRequest.calls.length).toEqual(1)
-      expect(system.specActions.setRequest.calls.length).toEqual(1)
-    })
-
-    it("should pass requestInterceptor/responseInterceptor with new Promise to fn.execute", async () => {
-      // Given
-      let configs = {
-        requestInterceptor: createSpy().andReturn(new Promise((resolve) => resolve())),
-        responseInterceptor: createSpy()
-      }
-      const system = {
-        fn: {
-          buildRequest: createSpy(),
-          execute: createSpy().andReturn(Promise.resolve())
-        },
-        specActions: {
-          executeRequest: createSpy(),
-          setMutatedRequest: createSpy(),
-          setRequest: createSpy(),
-          setResponse: createSpy()
-        },
-        specSelectors: {
-          spec: () => fromJS({}),
-          parameterValues: () => fromJS({}),
-          contentTypeValues: () => fromJS({}),
-          url: () => fromJS({}),
-          isOAS3: () => false
-        },
-        getConfigs: () => configs
-      }
-      // When
-      let executeFn = executeRequest({
-        pathName: "/one",
-        method: "GET",
-        operation: fromJS({ operationId: "getOne" })
-      })
-      let res = executeFn(system)
-  
-      // Then
-      expect(system.fn.execute.calls.length).toEqual(1)
-      expect(system.fn.execute.calls[0].arguments[0]).toIncludeKey("requestInterceptor")
-      expect(system.fn.execute.calls[0].arguments[0]).toInclude({
-        responseInterceptor: configs.responseInterceptor
-      })
-      expect(system.specActions.setMutatedRequest.calls.length).toEqual(0)
-      expect(system.specActions.setRequest.calls.length).toEqual(1)
-  
-  
       let wrappedRequestInterceptor = system.fn.execute.calls[0].arguments[0].requestInterceptor
       await wrappedRequestInterceptor(system.fn.execute.calls[0].arguments[0])
       expect(configs.requestInterceptor.calls.length).toEqual(1)

--- a/test/mocha/core/plugins/spec/actions.js
+++ b/test/mocha/core/plugins/spec/actions.js
@@ -97,7 +97,7 @@ describe("spec plugin - actions", function(){
       // Given
       let configs = {
         requestInterceptor: createSpy(),
-        responseInterceptor: createSpy(),
+        responseInterceptor: createSpy()
       }
       const system = {
         fn: {
@@ -147,8 +147,8 @@ describe("spec plugin - actions", function(){
     it("should pass requestInterceptor/responseInterceptor with new Promise to fn.execute", async () => {
       // Given
       let configs = {
-        requestInterceptor: createSpy(),
-        responseInterceptor: createSpy().andReturn(new Promise((resolve) => resolve())),
+        requestInterceptor: createSpy().andReturn(new Promise((resolve) => resolve())),
+        responseInterceptor: createSpy()
       }
       const system = {
         fn: {


### PR DESCRIPTION
ref: #4778

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

* Use async/await to handle cases where requestInterceptor returns a Promise instead of a resolved value.
* Also add `setResponse: createSpy()` to test spec, to suppress pre-existing error report of a missing function (even though tests still passed).

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes #4778
replaces and resolves #5499, #5607

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

unit test updated, new test added

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
