### PR TITLE
fix(OAS3): servers component update on definition change

### DIFF
--- a/src/core/plugins/oas3/components/servers.jsx
+++ b/src/core/plugins/oas3/components/servers.jsx
@@ -30,9 +30,9 @@ export default class Servers extends React.Component {
       servers,
       setServerVariableValue,
       getServerVariable
-    } = this.props
+    } = nextProps
 
-    if(this.props.currentServer !== nextProps.currentServer) {
+    if (this.props.currentServer !== nextProps.currentServer || this.props.servers !== nextProps.servers) {
       // Server has changed, we may need to set default values
       let currentServerDefinition = servers
         .find(v => v.get("url") === nextProps.currentServer)

--- a/test/e2e-cypress/static/documents/features/oas3-multiple-servers-switch.yaml
+++ b/test/e2e-cypress/static/documents/features/oas3-multiple-servers-switch.yaml
@@ -1,9 +1,9 @@
 openapi: 3.0.2
 servers:
-  - url: /test-url-1
-  - url: /test-url-2
+  - url: /test-url-switch-1
+  - url: /test-url-switch-2
 info:
-  title: multi-server test
+  title: multi-server test, switch
   version: 0.0.1
   description: |-
     a simple test to select different servers

--- a/test/e2e-cypress/static/documents/features/oas3-multiple-servers.yaml
+++ b/test/e2e-cypress/static/documents/features/oas3-multiple-servers.yaml
@@ -1,0 +1,16 @@
+openapi: 3.0.2
+servers:
+  - url: /test-url-1
+  - url: /test-url-2
+info:
+  title: multi-server test
+  version: 0.0.1
+  description: |-
+    a simplet test to select different servers
+paths:
+  /:
+    get:
+      summary: an operation
+      responses:
+        "200":
+          description: OK

--- a/test/e2e-cypress/tests/features/oas3-multiple-servers.js
+++ b/test/e2e-cypress/tests/features/oas3-multiple-servers.js
@@ -57,4 +57,26 @@ describe("OpenAPI 3.0 Multiple Servers", () => {
       .get(".responses-wrapper .request-url")
       .should("contains.text", "/test-url-1")
   })
+  it("should render and execute for server '/test-url-switch-1' after changing api defintion", () => {
+    cy.visit(
+      "/?url=/documents/features/oas3-multiple-servers.yaml"
+    )
+      .get(".scheme-container .schemes .servers label > select")
+      .select("/test-url-2")
+    cy.visit(
+      "/?url=/documents/features/oas3-multiple-servers-switch.yaml"
+    )
+      .get(".scheme-container .schemes .servers label > select")
+      .select("/test-url-switch-2")
+      .get("#operations-default-get_")
+      .click()
+      // Expand Try It Out
+      .get(".try-out__btn")
+      .click()
+      // Execute
+      .get(".execute.opblock-control__btn")
+      .click()
+      .get(".responses-wrapper .request-url")
+      .should("contains.text", "/test-url-switch-2")
+  })
 })

--- a/test/e2e-cypress/tests/features/oas3-multiple-servers.js
+++ b/test/e2e-cypress/tests/features/oas3-multiple-servers.js
@@ -1,0 +1,60 @@
+/**
+ * @prettier
+ */
+
+describe("OpenAPI 3.0 Multiple Servers", () => {
+  it("should render and execute for server '/test-url-1'", () => {
+    cy.visit(
+      "/?url=/documents/features/oas3-multiple-servers.yaml"
+    )
+      .get(".scheme-container .schemes .servers label > select")
+      .select("/test-url-1")
+      .get("#operations-default-get_")
+      .click()
+      // Expand Try It Out
+      .get(".try-out__btn")
+      .click()
+      // Execute
+      .get(".execute.opblock-control__btn")
+      .click()
+      .get(".responses-wrapper .request-url")
+      .should("contains.text", "/test-url-1")
+  })
+  it("should render and execute for server '/test-url-2'", () => {
+    cy.visit(
+      "/?url=/documents/features/oas3-multiple-servers.yaml"
+    )
+      .get(".scheme-container .schemes .servers label > select")
+      .select("/test-url-2")
+      .get("#operations-default-get_")
+      .click()
+      // Expand Try It Out
+      .get(".try-out__btn")
+      .click()
+      // Execute
+      .get(".execute.opblock-control__btn")
+      .click()
+      .get(".responses-wrapper .request-url")
+      .should("contains.text", "/test-url-2")
+  })
+  it("should render and execute for server '/test-url-1' after sequence: select '/test-url-2' -> Try-It-Out -> select '/test-url-1'", () => {
+    cy.visit(
+      "/?url=/documents/features/oas3-multiple-servers.yaml"
+    )
+      .get(".scheme-container .schemes .servers label > select")
+      .select("/test-url-2")
+      .get("#operations-default-get_")
+      .click()
+      // Expand Try It Out
+      .get(".try-out__btn")
+      .click()
+      // Select a different server
+      .get(".scheme-container .schemes .servers label > select")
+      .select("/test-url-1")
+      // Execute
+      .get(".execute.opblock-control__btn")
+      .click()
+      .get(".responses-wrapper .request-url")
+      .should("contains.text", "/test-url-1")
+  })
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

* Implement fix from #5759
* Implement Cypress tests for selecting from multiple OAS3 servers from different api definitions

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Resolves #5759 with tests

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

New Cypress tests added for UI.


### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
