### PR TITLE
fix(cypress): tests should fail on uncaught exception

### DIFF
--- a/test/e2e-cypress/support/index.js
+++ b/test/e2e-cypress/support/index.js
@@ -1,5 +1,3 @@
-import fs from "fs"
-
 // ***********************************************************
 // This example support/index.js is processed and
 // loaded automatically before your test files.
@@ -29,9 +27,6 @@ Cypress.on("window:before:load", win => {
 })
 
 Cypress.on("uncaught:exception", (err, runnable) => {
-  console.log(err)
   console.log(JSON.stringify(err, null, 2))
-  fs.writeFileSync(require("path").normalize(__dirname, "./error.log"), JSON.stringify(err, null, 2))
-
-  throw err
+  return true
 })


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

* replace `throw err` with `return true` to make Cypress fail test in both headless and non-headless mode
* remove logging of unmodified error
* also remove broken file logging

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Cypress was not failing tests on `uncaught exception` errors, even though they are visible when running in dev mode (console).

ref #6305, PR #6307 

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

manually toggle/revert PR #6307 will now fail the `model-collapse` test appropriately. In addition, when failing `model-collapse`, other related cypress tests also now fail (as expected).

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
