### PR TITLE
fix(cypress): deep-linking tests should use cy.location

### DIFF
--- a/test/e2e-cypress/tests/features/deep-linking.js
+++ b/test/e2e-cypress/tests/features/deep-linking.js
@@ -201,8 +201,9 @@ function OperationDeeplinkTestFactory({ baseUrl, elementToGet, correctElementId,
     cy.visit(baseUrl)
       .get(elementToGet)
       .click()
-      .window()
-      .should("have.deep.property", "location.hash", correctFragment)
+    cy.location().should((loc) => {
+      expect(loc.hash).to.eq(correctFragment)
+    })
   })
 
   it("should provide an anchor link that has the correct fragment as href", () => {
@@ -211,8 +212,9 @@ function OperationDeeplinkTestFactory({ baseUrl, elementToGet, correctElementId,
       .find("a")
       .should("have.attr", "href", correctHref)
       .click()
-      .window()
-      .should("have.deep.property", "location.hash", correctFragment)
+    cy.location().should((loc) => {
+      expect(loc.hash).to.eq(correctFragment)
+    })
   })
 
   it("should expand the operation when reloaded", () => {
@@ -225,8 +227,9 @@ function OperationDeeplinkTestFactory({ baseUrl, elementToGet, correctElementId,
     cy.visit(`${baseUrl}${correctFragment}`)
       .reload()
       .should("exist")
-      .window()
-      .should("have.deep.property", "location.hash", correctFragment)
+    cy.location().should((loc) => {
+      expect(loc.hash).to.eq(correctFragment)
+    })
   })
 
   it("should expand a tag with docExpansion disabled", () => {
@@ -254,8 +257,9 @@ function TagDeeplinkTestFactory({ baseUrl, elementToGet, correctElementId, corre
       .get(elementToGet)
       .click()
       .click() // tags need two clicks because they're expanded by default
-      .window()
-      .should("have.deep.property", "location.hash", correctFragment)
+    cy.location().should((loc) => {
+      expect(loc.hash).to.eq(correctFragment)
+    })
   })
 
   it("should provide an anchor link that has the correct fragment as href", () => {
@@ -275,8 +279,9 @@ function TagDeeplinkTestFactory({ baseUrl, elementToGet, correctElementId, corre
     cy.visit(`${baseUrl}${correctFragment}`)
       .reload()
       .should("exist")
-      .window()
-      .should("have.deep.property", "location.hash", correctFragment)
+    cy.location().should((loc) => {
+      expect(loc.hash).to.eq(correctFragment)
+    })
   })
 
   it("should expand a tag with docExpansion disabled", () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Use native `cy.location()` directly instead of inspecting the window object via `cy.window()`

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Preparation to migrate to Cypress@4.x, as this is a breaking test file in Cypress@4.x

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

test file is updated

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
