### PR TITLE
chore(deps): update react-syntax-highlighter from 12.2.1 to 13.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12860,9 +12860,9 @@
       "dev": true
     },
     "highlight.js": {
-      "version": "9.15.10",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.10.tgz",
-      "integrity": "sha512-RoV7OkQm0T3os3Dd2VHLNMoaoDVx77Wygln3n9l5YV172XonWG6rgQD3XnF/BuFFZw9A0TJgmMSO8FEWQgvcXw=="
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.1.2.tgz",
+      "integrity": "sha512-Q39v/Mn5mfBlMff9r+zzA+gWxRsCRKwEMvYTiisLr/XUiFI/4puWt0Ojdko3R3JCNWGdOWaA5g/Yxqa23kC5AA=="
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -18167,12 +18167,12 @@
       "dev": true
     },
     "lowlight": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.12.1.tgz",
-      "integrity": "sha512-OqaVxMGIESnawn+TU/QMV5BJLbUghUfjDWPAtFqDYDmDtr4FnB+op8xM+pR7nKlauHNUHXGt0VgWatFB8voS5w==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.14.0.tgz",
+      "integrity": "sha512-N2E7zTM7r1CwbzwspPxJvmjAbxljCPThTFawEX2Z7+P3NGrrvY54u8kyU16IY4qWfoVIxY8SYCS8jTkuG7TqYA==",
       "requires": {
-        "fault": "^1.0.2",
-        "highlight.js": "~9.15.0"
+        "fault": "^1.0.0",
+        "highlight.js": "~10.1.0"
       }
     },
     "lru-cache": {
@@ -20593,9 +20593,9 @@
       }
     },
     "parse-entities": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
-      "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
+      "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
       "requires": {
         "character-entities": "^1.0.0",
         "character-entities-legacy": "^1.0.0",
@@ -22311,9 +22311,9 @@
       }
     },
     "prismjs": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.20.0.tgz",
-      "integrity": "sha512-AEDjSrVNkynnw6A+B1DsFkd6AVdTnp+/WoUixFRULlCLZVRZlVQMVWio/16jv7G1FscUxQxOQhWwApgbnxr6kQ==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
+      "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
       "requires": {
         "clipboard": "^2.0.0"
       }
@@ -22780,15 +22780,15 @@
       }
     },
     "react-syntax-highlighter": {
-      "version": "12.2.1",
-      "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-12.2.1.tgz",
-      "integrity": "sha512-CTsp0ZWijwKRYFg9xhkWD4DSpQqE4vb2NKVMdPAkomnILSmsNBHE0n5GuI5zB+PU3ySVvXvdt9jo+ViD9XibCA==",
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-13.5.0.tgz",
+      "integrity": "sha512-2nKo8spFxe9shcjbdUiqxkrf/IMDqKUZLx7JVIxEJ17P+fYFGL4CRsZZC66UPeQ2o/f29eKu31CrkKGCK1RHuA==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "highlight.js": "~9.15.1",
-        "lowlight": "1.12.1",
-        "prismjs": "^1.8.4",
-        "refractor": "^2.4.1"
+        "highlight.js": "^10.1.1",
+        "lowlight": "^1.14.0",
+        "prismjs": "^1.21.0",
+        "refractor": "^3.1.0"
       }
     },
     "react-test-renderer": {
@@ -22925,23 +22925,13 @@
       }
     },
     "refractor": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/refractor/-/refractor-2.10.1.tgz",
-      "integrity": "sha512-Xh9o7hQiQlDbxo5/XkOX6H+x/q8rmlmZKr97Ie1Q8ZM32IRRd3B/UxuA/yXDW79DBSXGWxm2yRTbcTVmAciJRw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/refractor/-/refractor-3.1.0.tgz",
+      "integrity": "sha512-bN8GvY6hpeXfC4SzWmYNQGLLF2ZakRDNBkgCL0vvl5hnpMrnyURk8Mv61v6pzn4/RBHzSWLp44SzMmVHqMGNww==",
       "requires": {
         "hastscript": "^5.0.0",
-        "parse-entities": "^1.1.2",
-        "prismjs": "~1.17.0"
-      },
-      "dependencies": {
-        "prismjs": {
-          "version": "1.17.1",
-          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.17.1.tgz",
-          "integrity": "sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==",
-          "requires": {
-            "clipboard": "^2.0.0"
-          }
-        }
+        "parse-entities": "^2.0.0",
+        "prismjs": "~1.21.0"
       }
     },
     "regenerate": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "react-inspector": "^2.3.0",
     "react-motion": "^0.5.2",
     "react-redux": "^5.1.2",
-    "react-syntax-highlighter": "=12.2.1",
+    "react-syntax-highlighter": "=13.5.0",
     "redux": "^4.0.5",
     "redux-immutable": "3.1.0",
     "remarkable": "^2.0.1",

--- a/test/e2e-cypress/helpers/multiple-examples.js
+++ b/test/e2e-cypress/helpers/multiple-examples.js
@@ -195,7 +195,7 @@ function RequestBodyPrimitiveTestCases({
       .click()
       // Assert on the static docs value
       .get(`.opblock-section-request-body .microlight`)
-      .should("have.text", exampleA.value)
+      .should("include.text", exampleA.value)
       // Switch to Try-It-Out
       .get(".try-out__btn")
       .click()
@@ -221,7 +221,7 @@ function RequestBodyPrimitiveTestCases({
       .select(exampleB.key)
       // Assert on the static docs value
       .get(`.opblock-section-request-body .microlight`)
-      .should("have.text", exampleB.value)
+      .should("include.text", exampleB.value)
       // Switch to Try-It-Out
       .get(".try-out__btn")
       .click()
@@ -263,7 +263,7 @@ function RequestBodyPrimitiveTestCases({
       .click()
       // Assert on the static docs value
       .get(`.opblock-section-request-body .microlight`)
-      .should("have.text", exampleB.value)
+      .should("include.text", exampleB.value)
   })
 
   it("should return the dropdown entry for an example when manually returning to its value", () => {
@@ -273,7 +273,7 @@ function RequestBodyPrimitiveTestCases({
       .click()
       // Assert on the static docs value
       .get(`.opblock-section-request-body .microlight`)
-      .should("have.text", exampleA.value)
+      .should("include.text", exampleA.value)
       // Switch to Try-It-Out
       .get(".try-out__btn")
       .click()
@@ -294,7 +294,7 @@ function RequestBodyPrimitiveTestCases({
       // Assert on the dropdown value returning to the example value
       .get(".opblock-section-request-body .examples-select > select")
       .find(":selected")
-      .should("have.text", exampleA.summary)
+      .should("include.text", exampleA.summary)
   })
 
   it("should retain choosing a member in static docs when changing the media type", () => {
@@ -310,7 +310,7 @@ function RequestBodyPrimitiveTestCases({
       .select(secondaryMediaType)
       // Assert on the static docs value
       .get(`.opblock-section-request-body .microlight`)
-      .should("have.text", exampleB.value)
+      .should("include.text", exampleB.value)
       // Switch to Try-It-Out
       .get(".try-out__btn")
       .click()
@@ -336,7 +336,7 @@ function RequestBodyPrimitiveTestCases({
       .select(secondaryMediaType)
       // Assert on the static docs value
       .get(`.opblock-section-request-body .microlight`)
-      .should("have.text", exampleA.value)
+      .should("include.text", exampleA.value)
       // Switch to Try-It-Out
       .get(".try-out__btn")
       .click()
@@ -362,44 +362,44 @@ function RequestBodyPrimitiveTestCases({
       .select(secondaryMediaType)
       // Assert on the static docs value
       .get(`.opblock-section-request-body .microlight`)
-      .should("have.text", exampleA.value)
+      .should("include.text", exampleA.value)
       // Assert on the dropdown value
       .get(".opblock-section-request-body .examples-select > select")
       .find(":selected")
-      .should("have.text", exampleA.summary)
+      .should("include.text", exampleA.summary)
 
       // Choose exampleB
       .get(".opblock-section-request-body .examples-select > select")
       .select(exampleB.key)
       // Assert on the static docs value
       .get(`.opblock-section-request-body .microlight`)
-      .should("have.text", exampleB.value)
+      .should("include.text", exampleB.value)
       // Assert on the dropdown value
       .get(".opblock-section-request-body .examples-select > select")
       .find(":selected")
-      .should("have.text", exampleB.summary)
+      .should("include.text", exampleB.summary)
 
       // Change the media type
       .get(".opblock-section-request-body .content-type")
       .select(primaryMediaType)
       // Assert that the static docs value didn't change
       .get(`.opblock-section-request-body .microlight`)
-      .should("have.text", exampleB.value)
+      .should("include.text", exampleB.value)
       // Assert that the dropdown value didn't change
       .get(".opblock-section-request-body .examples-select > select")
       .find(":selected")
-      .should("have.text", exampleB.summary)
+      .should("include.text", exampleB.summary)
 
       // Choose exampleA
       .get(".opblock-section-request-body .examples-select > select")
       .select(exampleA.key)
       // Assert on the static docs value
       .get(`.opblock-section-request-body .microlight`)
-      .should("have.text", exampleA.value)
+      .should("include.text", exampleA.value)
       // Assert on the dropdown value
       .get(".opblock-section-request-body .examples-select > select")
       .find(":selected")
-      .should("have.text", exampleA.summary)
+      .should("include.text", exampleA.summary)
   })
 
   it("Try-It-Out toggling: mediaType -> example -> mediaType -> example", () => {
@@ -415,44 +415,44 @@ function RequestBodyPrimitiveTestCases({
       .select(secondaryMediaType)
       // Assert on the static docs value
       .get(`.opblock-section-request-body textarea`)
-      .should("have.text", exampleA.value)
+      .should("include.text", exampleA.value)
       // Assert on the dropdown value
       .get(".opblock-section-request-body .examples-select > select")
       .find(":selected")
-      .should("have.text", exampleA.summary)
+      .should("include.text", exampleA.summary)
 
       // Choose exampleB
       .get(".opblock-section-request-body .examples-select > select")
       .select(exampleB.key)
       // Assert on the static docs value
       .get(`.opblock-section-request-body textarea`)
-      .should("have.text", exampleB.value)
+      .should("include.text", exampleB.value)
       // Assert on the dropdown value
       .get(".opblock-section-request-body .examples-select > select")
       .find(":selected")
-      .should("have.text", exampleB.summary)
+      .should("include.text", exampleB.summary)
 
       // Change the media type
       .get(".opblock-section-request-body .content-type")
       .select(primaryMediaType)
       // Assert that the static docs value didn't change
       .get(`.opblock-section-request-body textarea`)
-      .should("have.text", exampleB.value)
+      .should("include.text", exampleB.value)
       // Assert that the dropdown value didn't change
       .get(".opblock-section-request-body .examples-select > select")
       .find(":selected")
-      .should("have.text", exampleB.summary)
+      .should("include.text", exampleB.summary)
 
       // Choose exampleA
       .get(".opblock-section-request-body .examples-select > select")
       .select(exampleA.key)
       // Assert on the static docs value
       .get(`.opblock-section-request-body textarea`)
-      .should("have.text", exampleA.value)
+      .should("include.text", exampleA.value)
       // Assert on the dropdown value
       .get(".opblock-section-request-body .examples-select > select")
       .find(":selected")
-      .should("have.text", exampleA.summary)
+      .should("include.text", exampleA.summary)
   })
 
   it("Try-It-Out toggling and execution with modified values: mediaType -> modified value -> example -> mediaType -> example", () => {
@@ -468,11 +468,11 @@ function RequestBodyPrimitiveTestCases({
       .select(secondaryMediaType)
       // Assert on the static docs value
       .get(`.opblock-section-request-body textarea`)
-      .should("have.text", exampleA.value)
+      .should("include.text", exampleA.value)
       // Assert on the dropdown value
       .get(".opblock-section-request-body .examples-select > select")
       .find(":selected")
-      .should("have.text", exampleA.summary)
+      .should("include.text", exampleA.summary)
 
       // Modify the value
       .get(`.opblock-section-request-body textarea`)
@@ -497,11 +497,11 @@ function RequestBodyPrimitiveTestCases({
       .select(exampleB.key)
       // Assert on the static docs value
       .get(`.opblock-section-request-body textarea`)
-      .should("have.text", exampleB.value)
+      .should("include.text", exampleB.value)
       // Assert on the dropdown value
       .get(".opblock-section-request-body .examples-select > select")
       .find(":selected")
-      .should("have.text", exampleB.summary)
+      .should("include.text", exampleB.summary)
       // Fire the operation
       .get(".execute")
       .click()
@@ -519,11 +519,11 @@ function RequestBodyPrimitiveTestCases({
       .select(primaryMediaType)
       // Assert that the static docs value didn't change
       .get(`.opblock-section-request-body textarea`)
-      .should("have.text", exampleB.value)
+      .should("include.text", exampleB.value)
       // Assert that the dropdown value didn't change
       .get(".opblock-section-request-body .examples-select > select")
       .find(":selected")
-      .should("have.text", exampleB.summary)
+      .should("include.text", exampleB.summary)
       // Fire the operation
       .get(".execute")
       .click()
@@ -541,11 +541,11 @@ function RequestBodyPrimitiveTestCases({
       .select(exampleA.key)
       // Assert on the static docs value
       .get(`.opblock-section-request-body textarea`)
-      .should("have.text", exampleA.value)
+      .should("include.text", exampleA.value)
       // Assert on the dropdown value
       .get(".opblock-section-request-body .examples-select > select")
       .find(":selected")
-      .should("have.text", exampleA.summary)
+      .should("include.text", exampleA.summary)
       // Fire the operation
       .get(".execute")
       .click()
@@ -592,9 +592,9 @@ function ResponsePrimitiveTestCases({
       .within(() => {
         cy.get(".examples-select > select")
           .find(":selected")
-          .should("have.text", exampleA.summary)
+          .should("include.text", exampleA.summary)
           .get(".microlight")
-          .should("have.text", exampleA.value)
+          .should("include.text", exampleA.value)
       })
   })
   it("should render the second example", () => {
@@ -606,9 +606,9 @@ function ResponsePrimitiveTestCases({
         cy.get(".examples-select > select")
           .select(exampleB.key)
           .find(":selected")
-          .should("have.text", exampleB.summary)
+          .should("include.text", exampleB.summary)
           .get(".microlight")
-          .should("have.text", exampleB.value)
+          .should("include.text", exampleB.value)
       })
   })
 
@@ -624,10 +624,10 @@ function ResponsePrimitiveTestCases({
           .select(exampleB.key)
           // Assert against dropdown value
           .find(":selected")
-          .should("have.text", exampleB.summary)
+          .should("include.text", exampleB.summary)
           // Assert against example value
           .get(".microlight")
-          .should("have.text", exampleB.value)
+          .should("include.text", exampleB.value)
 
           // Change media types
           .get(".content-type")
@@ -635,10 +635,10 @@ function ResponsePrimitiveTestCases({
           // Assert against dropdown value
           .get(".examples-select > select")
           .find(":selected")
-          .should("have.text", exampleB.summary)
+          .should("include.text", exampleB.summary)
           // Assert against example value
           .get(".microlight")
-          .should("have.text", exampleB.value)
+          .should("include.text", exampleB.value)
       })
   })
   ;(exampleC ? it : it.skip)(
@@ -658,10 +658,10 @@ function ResponsePrimitiveTestCases({
             .select(exampleC.key)
             // Assert against dropdown value
             .find(":selected")
-            .should("have.text", exampleC.summary || exampleC.key)
+            .should("include.text", exampleC.summary || exampleC.key)
             // Assert against example value
             .get(".microlight")
-            .should("have.text", exampleC.value)
+            .should("include.text", exampleC.value)
 
             // Change media types
             .get(".content-type")
@@ -669,10 +669,10 @@ function ResponsePrimitiveTestCases({
             // Assert against dropdown value
             .get(".examples-select > select")
             .find(":selected")
-            .should("have.text", exampleA.summary)
+            .should("include.text", exampleA.summary)
             // Assert against example value
             .get(".microlight")
-            .should("have.text", exampleA.value)
+            .should("include.text", exampleA.value)
         })
     }
   )

--- a/test/e2e-cypress/tests/features/multiple-examples-core.js
+++ b/test/e2e-cypress/tests/features/multiple-examples-core.js
@@ -390,7 +390,7 @@ describe("OpenAPI 3.0 Multiple Examples - core features", () => {
           .click()
           // Check HighlightCode value
           .get(".opblock-section-request-body .highlight-code")
-          .should("have.text", JSON.stringify(["a", "b", "c"], null, 2))
+          .should("include.text", JSON.stringify(["a", "b", "c"], null, 2))
           // Check dropdown value
           .get(".opblock-section-request-body .examples-select > select")
           .find(":selected")
@@ -415,7 +415,7 @@ describe("OpenAPI 3.0 Multiple Examples - core features", () => {
           .get(".opblock-section-request-body .examples-select > select")
           .select("ArrayExampleB")
           .get(".opblock-section-request-body .highlight-code")
-          .should("have.text", JSON.stringify([1, 2, 3, 4], null, 2))
+          .should("include.text", JSON.stringify([1, 2, 3, 4], null, 2))
           .get(".opblock-section-request-body .examples-select > select")
           .find(":selected")
           .should("have.text", "A lowly array of numbers")
@@ -424,7 +424,7 @@ describe("OpenAPI 3.0 Multiple Examples - core features", () => {
           .click()
           // Check textarea value
           .get(".opblock-section-request-body textarea")
-          .should("have.text", JSON.stringify([1, 2, 3, 4], null, 2))
+          .should("include.text", JSON.stringify([1, 2, 3, 4], null, 2))
           // Check dropdown value
           .get(".opblock-section-request-body .examples-select > select")
           .find(":selected")
@@ -451,7 +451,7 @@ describe("OpenAPI 3.0 Multiple Examples - core features", () => {
           .should("have.text", "[Modified value]")
           // Check textarea value
           .get(".opblock-section-request-body textarea")
-          .should("have.text", JSON.stringify([1, 2, 3, 4, 5], null, 2))
+          .should("include.text", JSON.stringify([1, 2, 3, 4, 5], null, 2))
       })
 
       it("should retain a modified value, and support returning to it", () => {
@@ -475,7 +475,7 @@ describe("OpenAPI 3.0 Multiple Examples - core features", () => {
           .should("have.text", "[Modified value]")
           // Check textarea value
           .get(".opblock-section-request-body textarea")
-          .should("have.text", JSON.stringify([1, 2, 3, 4, 5], null, 2))
+          .should("include.text", JSON.stringify([1, 2, 3, 4, 5], null, 2))
           // Choose the second example
           .get(".opblock-section-request-body .examples-select > select")
           .select("ArrayExampleB")
@@ -485,13 +485,13 @@ describe("OpenAPI 3.0 Multiple Examples - core features", () => {
           .should("have.text", "A lowly array of numbers")
           // Check textarea value
           .get(".opblock-section-request-body textarea")
-          .should("have.text", JSON.stringify([1, 2, 3, 4], null, 2))
+          .should("include.text", JSON.stringify([1, 2, 3, 4], null, 2))
           // Switch back to the modified value
           .get(".opblock-section-request-body .examples-select > select")
           .select("__MODIFIED__VALUE__")
           // Check textarea value
           .get(".opblock-section-request-body textarea")
-          .should("have.text", JSON.stringify([1, 2, 3, 4, 5], null, 2))
+          .should("include.text", JSON.stringify([1, 2, 3, 4, 5], null, 2))
       })
     })
     describe("in a Response", () => {
@@ -507,7 +507,7 @@ describe("OpenAPI 3.0 Multiple Examples - core features", () => {
           .should("have.text", "A lowly array of strings")
           // Assert on the example value
           .get(".example.microlight")
-          .should("have.text", JSON.stringify(["a", "b", "c"], null, 2))
+          .should("include.text", JSON.stringify(["a", "b", "c"], null, 2))
       })
       it("should render and apply the second value when chosen", () => {
         cy.visit(
@@ -522,7 +522,7 @@ describe("OpenAPI 3.0 Multiple Examples - core features", () => {
           .should("have.text", "A lowly array of numbers")
           // Assert on the example value
           .get(".example.microlight")
-          .should("have.text", JSON.stringify([1, 2, 3, 4], null, 2))
+          .should("include.text", JSON.stringify([1, 2, 3, 4], null, 2))
       })
     })
   })


### PR DESCRIPTION
* includes prismjs@1.21.0 security update
* fix(cypress): use less restrictive 'include.text' assertion

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

* update react-syntax-highlighter from 12.2.1 to 13.5.0
* update Cypress `multiple-examples` tests to use a less restrictive `include.text` assertion instead of `have.text`. This change is backwards compatible with `react-syntax-highlighter@12.2.1`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Addresses security update fixed in `prismjs@1.21.0`. 

Note, `prismjs` is a dependency of `react-syntax-highlighter`, but swagger-ui does not use `prismjs` within `react-syntax-highlighter`

Also, `react-syntax-highlighter@13.x` also changes output from `react-syntax-highlighter@12.2.1`. Specifically adding leading and trailing double-quote to the `<code>` section. Cypress tests have been updated to reflect this change.



### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->



### Screenshots (if appropriate):

before (v12):
![highlight-v12](https://user-images.githubusercontent.com/12902658/90563038-0e35cd00-e158-11ea-9a27-73d796b1f690.png)

after (v13):
![highlight-v13](https://user-images.githubusercontent.com/12902658/90563059-17269e80-e158-11ea-91b4-e33d5a669989.png)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [x] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
