### PR TITLE
fix: remove unused non-compliant system method inside 'err' reducer

### DIFF
--- a/src/core/plugins/err/error-transformers/hook.js
+++ b/src/core/plugins/err/error-transformers/hook.js
@@ -7,9 +7,13 @@ const errorTransformers = [
   ParameterOneOf
 ]
 
-export default function transformErrors (errors, system) {
+export default function transformErrors (errors) {
+  // Dev note: unimplemented artifact where
+  // jsSpec: system.specSelectors.specJson().toJS()
+  // regardless, to be compliant with redux@4, instead of calling the store method here,
+  // jsSpec should be pass down as an argument,
   let inputs = {
-    jsSpec: system.specSelectors.specJson().toJS()
+    jsSpec: {}
   }
 
   let transformedErrors = reduce(errorTransformers, (result, transformer) => {

--- a/src/core/plugins/err/reducers.js
+++ b/src/core/plugins/err/reducers.js
@@ -19,13 +19,13 @@ let DEFAULT_ERROR_STRUCTURE = {
   message: "Unknown error"
 }
 
-export default function(system) {
+export default function() {
   return {
     [NEW_THROWN_ERR]: (state, { payload }) => {
       let error = Object.assign(DEFAULT_ERROR_STRUCTURE, payload, {type: "thrown"})
       return state
         .update("errors", errors => (errors || List()).push( fromJS( error )) )
-        .update("errors", errors => transformErrors(errors, system.getSystem()))
+        .update("errors", errors => transformErrors(errors))
     },
 
     [NEW_THROWN_ERR_BATCH]: (state, { payload }) => {
@@ -34,7 +34,7 @@ export default function(system) {
       })
       return state
         .update("errors", errors => (errors || List()).concat( fromJS( payload )) )
-        .update("errors", errors => transformErrors(errors, system.getSystem()))
+        .update("errors", errors => transformErrors(errors))
     },
 
     [NEW_SPEC_ERR]: (state, { payload }) => {
@@ -42,7 +42,7 @@ export default function(system) {
       error = error.set("type", "spec")
       return state
         .update("errors", errors => (errors || List()).push( fromJS(error)).sortBy(err => err.get("line")) )
-        .update("errors", errors => transformErrors(errors, system.getSystem()))
+        .update("errors", errors => transformErrors(errors))
     },
 
     [NEW_SPEC_ERR_BATCH]: (state, { payload }) => {
@@ -50,8 +50,8 @@ export default function(system) {
         return fromJS(Object.assign(DEFAULT_ERROR_STRUCTURE, err, { type: "spec" }))
       })
       return state
-      .update("errors", errors => (errors || List()).concat( fromJS( payload )) )
-      .update("errors", errors => transformErrors(errors, system.getSystem()))
+        .update("errors", errors => (errors || List()).concat(fromJS(payload)))
+        .update("errors", errors => transformErrors(errors))
     },
 
     [NEW_AUTH_ERR]: (state, { payload }) => {
@@ -60,7 +60,7 @@ export default function(system) {
       error = error.set("type", "auth")
       return state
         .update("errors", errors => (errors || List()).push( fromJS(error)) )
-        .update("errors", errors => transformErrors(errors, system.getSystem()))
+        .update("errors", errors => transformErrors(errors))
     },
 
     [CLEAR]: (state, { payload }) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

* remove  use of `system.getSystem()` inside the `err` reducer
* assign empty `{}` to pass to one of the `err-transformer` methods as temporary solution. Note, `system.getSystem()` was used to retrieve the jsonSpec, but then not yet implemented.

This PR does NOT resolve a separate issue regarding migration to `redux@4` and `react-redux@5`

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Swagger Editor render error when using various sample api definitions. Example from swagger-editor unit test:

```
swagger: '2.0'
securityDefinitions:
  api_key:
    type: apiKey
    name: apikey
    in: query
    scopes:
      asdf: blah blah
paths:
  /:
    get:
      description: asdf
      security:
        - api_key:
            - 'write:pets'

```

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


swagger-editor visual render without console errors

Note, existing swagger-ui tests do not catch this error

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
