### PR TITLE
fix(curlify): replace all occurrences of `$`

### DIFF
--- a/src/core/curlify.js
+++ b/src/core/curlify.js
@@ -27,7 +27,7 @@ export default function curl( request ){
     for( let p of request.get("headers").entries() ){
       let [ h,v ] = p
       curlified.push( "-H " )
-      curlified.push( `"${h}: ${v.replace("$", "\\$")}"` )
+      curlified.push( `"${h}: ${v.replace(/\$/g, "\\$")}"` )
       isMultipartFormDataRequest = isMultipartFormDataRequest || /^content-type$/i.test(h) && /^multipart\/form-data$/i.test(v)
     }
   }
@@ -47,7 +47,7 @@ export default function curl( request ){
       curlified.push( "-d" )
       let reqBody = request.get("body")
       if (!Map.isMap(reqBody)) {
-        curlified.push( JSON.stringify( request.get("body") ).replace(/\\n/g, "").replace("$", "\\$") )
+        curlified.push( JSON.stringify( request.get("body") ).replace(/\\n/g, "").replace(/\$/g, "\\$") )
       } else {
         let curlifyToJoin = []
         for (let [k, v] of request.get("body").entrySeq()) {

--- a/test/unit/core/curlify.js
+++ b/test/unit/core/curlify.js
@@ -351,4 +351,17 @@ describe("curlify", function () {
 
     expect(curlified).toEqual("curl -X POST \"http://example.com\" -H  \"X-DOLLAR: token/123\\$\" -d \"CREATE (\\$props)\"")
   })
+
+  it("should escape multiple dollar signs", function () {
+    let req = {
+      url: "http://example.com",
+      method: "POST",
+      headers: { },
+      body: "RETURN $x + $y"
+    }
+
+    let curlified = curl(Im.fromJS(req))
+
+    expect(curlified).toEqual("curl -X POST \"http://example.com\" -d \"RETURN \\$x + \\$y\"")
+  })
 })


### PR DESCRIPTION
Call `replace` with a global regex argument so that all occurrences are replace.

### Description

In #6245 I forgot that calling `replace` with a string as the first
argument replaces only the first occurrence of the string. In order to
replace all occurrences, we need to use a regex with the global (g)
modifier.

Sorry. 😖 

### Motivation and Context

Fixes escaping of curl requests that have two dollar signs (see the test for a complete example)

### How Has This Been Tested?

Added a unit test

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
