### PR TITLE
Fix 6351: Server select usable via oas3Actions

### DIFF
--- a/src/core/plugins/oas3/components/servers.jsx
+++ b/src/core/plugins/oas3/components/servers.jsx
@@ -109,7 +109,8 @@ export default class Servers extends React.Component {
               ( server ) =>
               <option
                 value={ server.get("url") }
-                key={ server.get("url") }>
+                key={ server.get("url") }
+                selected={ currentServer === server.get("url") }>
                 { server.get("url") }
                 { server.get("description") && ` - ${server.get("description")}` }
               </option>

--- a/test/e2e-cypress/static/documents/bugs/6351.yaml
+++ b/test/e2e-cypress/static/documents/bugs/6351.yaml
@@ -1,0 +1,13 @@
+openapi: 3.0.2
+info:
+  title: OAS 3.0 sample with multiple servers
+  version: 0.1.0
+servers:
+  - url: http://testserver1.com
+  - url: http://testserver2.com
+paths:
+  /test/:
+    get:
+      responses:
+        '200':
+          description: Successful Response

--- a/test/e2e-cypress/tests/bugs/6351.js
+++ b/test/e2e-cypress/tests/bugs/6351.js
@@ -1,0 +1,13 @@
+// http://github.com/swagger-api/swagger-ui/issues/6351
+
+describe("#6351: Server dropdown should change when switched via oas3Actions.setSelectedServer", () => {
+  it("should show different selected server", () => {
+    cy.visit("/?url=/documents/bugs/6351.yaml")
+      .get("select")
+      .contains("http://testserver1.com")
+      .window()
+      .then(win => win.ui.oas3Actions.setSelectedServer("http://testserver2.com"))
+      .get("select")
+      .contains("http://testserver2.com")
+  })
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
This fix allows the current server to dictate the selected server option in the servers dropdown. This allows for programatic changing of the servers component via the `oas3Actions.setSelectedServer` method.

### Motivation and Context
Fixes #6351 

Resolves issues where swagger-ui does not correctly update when the server is set programmatically.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->



### How Has This Been Tested?
Cypress automation tests
Swagger-ui tested and interacted via console
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
