### PR TITLE
chore: update .gitignore with dev-helpers/examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ selenium-debug.log
 chromedriver.log
 test/e2e/db.json
 docs/_book
+dev-helpers/examples
 
 # dist
 flavors/**/dist/*

--- a/docs/development/setting-up.md
+++ b/docs/development/setting-up.md
@@ -30,6 +30,22 @@ Unsupported Node.js LTS that should still work:
 5. Wait a bit
 6. Open http://localhost:3200/
 
+### Using your own local api definition with local dev build
+
+You can specify a local file in `dev-helpers/index.html` by changing the `url` parameter. This local file MUST be located in the `dev-helpers` directory or a subdirectory. As a convenience and best practice, we recommend that you create a subdirectory, `dev-helpers/examples`, which is already specified in `.gitignore`.
+
+replace
+```
+url: "https://petstore.swagger.io/v2/swagger.json",
+```
+
+with
+```
+url: "./examples/your-local-api-definition.yaml",
+```
+
+Files in `dev-helpers` should NOT be committed to git. The exception is if you are fixing something in `index.html` or `oauth2-redirect.html`, or introducing a new support file.
+
 ## Bonus points
 
 - Swagger UI includes an ESLint rule definition. If you use a graphical editor, consider installing an ESLint plugin, which will point out syntax and style errors for you as you code.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Add `dev-helopers/examples` directory to `.gitignore`. This directory is for dev use to test various local json/yaml files, and is convenient when frequently examining different json/yaml files.

Manual changes to `dev-helpers/index.html` is still required for testing, and should not be committed. A user still could use the `dev-helpers` "root" to place their sample api definition.

Also, although this PR doesn't require a change to documentation, I updated the documentation anyways. 😉 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Keep git clean

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually changing the url in `dev-helpers/index.html` still works

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
