### PR TITLE
Fix 6372: Updating server select prop and test

### DIFF
--- a/src/core/plugins/oas3/components/servers.jsx
+++ b/src/core/plugins/oas3/components/servers.jsx
@@ -104,13 +104,12 @@ export default class Servers extends React.Component {
     return (
       <div className="servers">
         <label htmlFor="servers">
-          <select onChange={ this.onServerChange }>
+          <select onChange={ this.onServerChange } value={currentServer}>
             { servers.valueSeq().map(
               ( server ) =>
               <option
                 value={ server.get("url") }
-                key={ server.get("url") }
-                selected={ currentServer === server.get("url") }>
+                key={ server.get("url") }>
                 { server.get("url") }
                 { server.get("description") && ` - ${server.get("description")}` }
               </option>

--- a/test/e2e-cypress/tests/bugs/6351.js
+++ b/test/e2e-cypress/tests/bugs/6351.js
@@ -3,11 +3,9 @@
 describe("#6351: Server dropdown should change when switched via oas3Actions.setSelectedServer", () => {
   it("should show different selected server", () => {
     cy.visit("/?url=/documents/bugs/6351.yaml")
-      .get("select")
-      .contains("http://testserver1.com")
+      .get("select").should("have.value", "http://testserver1.com")
       .window()
       .then(win => win.ui.oas3Actions.setSelectedServer("http://testserver2.com"))
-      .get("select")
-      .contains("http://testserver2.com")
+      .get("select").should("have.value", "http://testserver2.com")
   })
 })


### PR DESCRIPTION
This PR fixes the prop error generated by React introduced in #6358. Fixes #6372.

### Description
Changes the `currentServer` value to be assigned at the top of the select instead of as a selected prop on the option.

### Motivation and Context
This fixes the React warning introduced in #6358.


### How Has This Been Tested?
Automation was tweaked to fix for this. Tested on local installation with multiple openapi 3 specs.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
