### PR TITLE
refactor(build): increase maxEntrypointSize for core-js@3

### DIFF
--- a/webpack/_config-builder.js
+++ b/webpack/_config-builder.js
@@ -118,7 +118,7 @@ export default function buildConfig(
         // these aliases make sure that we don't bundle same libraries twice
         // when the versions of these libraries diverge between swagger-js and swagger-ui
         alias: {
-          "@babel/runtime-corejs2": path.resolve(__dirname, "..", "node_modules/@babel/runtime-corejs2"),
+          "@babel/runtime-corejs3": path.resolve(__dirname, "..", "node_modules/@babel/runtime-corejs3"),
           "js-yaml": path.resolve(__dirname, "..", "node_modules/js-yaml"),
           "lodash": path.resolve(__dirname, "..", "node_modules/lodash")
         },
@@ -134,8 +134,8 @@ export default function buildConfig(
 
       performance: {
         hints: "error",
-        maxEntrypointSize: 1024000,
-        maxAssetSize: 1024000,
+        maxEntrypointSize: 1072000,
+        maxAssetSize: 1072000,
       },
 
       optimization: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Increase webpack maxEntrypointSize and maxAssetSize

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Updating dependency to `core-js@3` in #6410 increased the bundle size by 47 KiB, triggering the 1MB error

PR #6410 was done in conjunction with SwaggerClient dependency update to `core-js@3` in https://github.com/swagger-api/swagger-js/pull/1716

I also tried to remove all dependency from `core-js@` and `core-js@2`. This includes removing `src/core/components/debug.jsx`, which appears to be unused, and the two dependencies it imports, which requires `core-js@2` (react-motion, react-inspector). Further, I updated to React 16, which although known to be breaking to swagger-ui, yielded a bundle size result of 997 KiB, which is still 34 KiB increase.

Choice is being made to stay updated with actively maintained `core-js@3` with the tradeoff in increased bundle size.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->



### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
