### PR TITLE
it should not unnecessarily stringify string values for text/plain content type

### DIFF
--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -541,16 +541,6 @@ export const validateParam = (param, value, { isOAS3 = false, bypassRequiredChec
   return errors
 }
 
-export const getSampleSchema = (schema, contentType="", config={}) => {
-  if (/xml/.test(contentType)) {
-    return getXmlSampleSchema(schema, config)
-  } else if (contentType !== "text/plain") {
-    return getTextPlainSampleForSchema(schema, config)
-  } else {
-    return getJsonSampleForSchema(schema, config)
-  }
-}
-
 const getXmlSampleSchema = (schema, config) => {
   if (!schema.xml || !schema.xml.name) {
     schema.xml = schema.xml || {}
@@ -566,21 +556,32 @@ const getXmlSampleSchema = (schema, config) => {
   }
   return memoizedCreateXMLExample(schema, config)
 }
+
+const getStringifiedSampleForSchema = (schema, config, shouldStringifyFn) => {
+  const res = memoizedSampleFromSchema(schema, config)
+  return shouldStringifyFn(res)
+    ? JSON.stringify(res, null, 2)
+    : res
+}
+
 const getTextPlainSampleForSchema = (schema, config) => getStringifiedSampleForSchema(
-    schema,
-    config,
-    typeof res === "object");
+  schema,
+  config,
+  res => typeof res === "object")
 
 const getJsonSampleForSchema = (schema, config) => getStringifiedSampleForSchema(
-    schema,
-    config,
-    typeof res === "object" || typeof res === "string");
+  schema,
+  config,
+  res => typeof res === "object" || typeof res === "string")
 
-const getStringifiedSampleForSchema = (schema, config, shouldStringify) => {
-  const res = memoizedSampleFromSchema(schema, config)
-  return shouldStringify
-    ? JSON.stringify(res, null, 2) 
-    : res
+export const getSampleSchema = (schema, contentType="", config={}) => {
+  if (/xml/.test(contentType)) {
+    return getXmlSampleSchema(schema, config)
+  } else if (contentType === "text/plain") {
+    return getTextPlainSampleForSchema(schema, config)
+  } else {
+    return getJsonSampleForSchema(schema, config)
+  }
 }
 
 export const parseSearch = () => {

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -557,31 +557,34 @@ const getXmlSampleSchema = (schema, config) => {
   return memoizedCreateXMLExample(schema, config)
 }
 
-const getStringifiedSampleForSchema = (schema, config, shouldStringifyFn) => {
+const shouldStringifyTypesConfig = [
+  {
+    when: /json/,
+    shouldStringifyTypes: [
+      "string"
+    ]
+  }
+]
+
+const getStringifiedSampleForSchema = (schema, config, contentType) => {
   const res = memoizedSampleFromSchema(schema, config)
-  return shouldStringifyFn(res)
+  const resType = typeof res
+  const stringifyConfig = shouldStringifyTypesConfig.find(c => c.when.test(contentType))
+  const additionalTypesToStringify = !stringifyConfig
+    ? []
+    : stringifyConfig.shouldStringifyTypes
+
+    return resType === "object" || additionalTypesToStringify.some(x => x === resType)
     ? JSON.stringify(res, null, 2)
     : res
 }
 
-const getTextPlainSampleForSchema = (schema, config) => getStringifiedSampleForSchema(
-  schema,
-  config,
-  res => typeof res === "object")
-
-const getJsonSampleForSchema = (schema, config) => getStringifiedSampleForSchema(
-  schema,
-  config,
-  res => typeof res === "object" || typeof res === "string")
-
 export const getSampleSchema = (schema, contentType="", config={}) => {
   if (/xml/.test(contentType)) {
     return getXmlSampleSchema(schema, config)
-  } else if (contentType === "text/plain") {
-    return getTextPlainSampleForSchema(schema, config)
-  } else {
-    return getJsonSampleForSchema(schema, config)
   }
+
+  return getStringifiedSampleForSchema(schema, config, contentType)
 }
 
 export const parseSearch = () => {

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -560,21 +560,23 @@ const getXmlSampleSchema = (schema, config) => {
 const shouldStringifyTypesConfig = [
   {
     when: /json/,
-    shouldStringifyTypes: [
-      "string"
-    ]
+    shouldStringifyTypes: ["string"]
   }
 ]
+
+const defaultStringifyTypes = ["object"]
 
 const getStringifiedSampleForSchema = (schema, config, contentType) => {
   const res = memoizedSampleFromSchema(schema, config)
   const resType = typeof res
-  const stringifyConfig = shouldStringifyTypesConfig.find(c => c.when.test(contentType))
-  const additionalTypesToStringify = !stringifyConfig
-    ? []
-    : stringifyConfig.shouldStringifyTypes
 
-    return resType === "object" || additionalTypesToStringify.some(x => x === resType)
+  const typesToStringify = shouldStringifyTypesConfig.reduce(
+    (types, nextConfig) => nextConfig.when.test(contentType)
+      ? [...types, ...nextConfig.shouldStringifyTypes]
+      : types,
+    defaultStringifyTypes)
+
+  return some(typesToStringify, x => x === resType)
     ? JSON.stringify(res, null, 2)
     : res
 }

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -559,8 +559,14 @@ export const getSampleSchema = (schema, contentType="", config={}) => {
   }
 
   const res = memoizedSampleFromSchema(schema, config)
+  
+  let shouldStringify = typeof res === "object"
+  if (contentType !== "text/plain")
+  {
+    shouldStringify = shouldStringify || typeof res === "string" 
+  }
 
-  return typeof res === "object" || typeof res === "string" 
+  return shouldStringify
     ? JSON.stringify(res, null, 2) 
     : res
 }

--- a/test/unit/core/utils.js
+++ b/test/unit/core/utils.js
@@ -1505,6 +1505,17 @@ describe("utils", () => {
       expect(res).toEqual(JSON.stringify(new Date().toISOString()))
     })
 
+    it("should not unnecessarily stringify string values for text/plain", () => {
+      // Given
+      const res = getSampleSchema({
+        type: "string",
+        format: "date-time"
+      }, "text/plain")
+      
+      // Then
+      expect(res).toEqual(new Date().toISOString())
+    })
+
     it("should not unnecessarily stringify non-object values", () => {
       // Given
       const res = getSampleSchema({

--- a/test/unit/core/utils.js
+++ b/test/unit/core/utils.js
@@ -1494,23 +1494,23 @@ describe("utils", () => {
       Date = oriDate
     })
     
-    it("should stringify string values", () => {
+    it("should stringify string values if json content-type", () => {
       // Given
       const res = getSampleSchema({
         type: "string",
         format: "date-time"
-      })
+      }, "text/json")
       
       // Then
       expect(res).toEqual(JSON.stringify(new Date().toISOString()))
     })
 
-    it("should not unnecessarily stringify string values for text/plain", () => {
+    it("should not unnecessarily stringify string values for other content-types", () => {
       // Given
       const res = getSampleSchema({
         type: "string",
         format: "date-time"
-      }, "text/plain")
+      })
       
       // Then
       expect(res).toEqual(new Date().toISOString())
@@ -1521,6 +1521,16 @@ describe("utils", () => {
       const res = getSampleSchema({
         type: "number"
       })
+      
+      // Then
+      expect(res).toEqual(0)
+    })
+
+    it("should not unnecessarily stringify non-object values if content-type is json", () => {
+      // Given
+      const res = getSampleSchema({
+        type: "number"
+      }, "application/json")
       
       // Then
       expect(res).toEqual(0)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Sample for text/plain should not be stringified. Introduced with #6412 the json sample for type string will be stringified. This should only be the case if the content type is not text/plain.



### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes #6430

### How Has This Been Tested?
in browser
by new tests


### Screenshots (if appropriate):

see #6430

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
