### PR TITLE
fix(try-it-out): required boolean default value set to empty string

### DIFF
--- a/src/core/json-schema-components.jsx
+++ b/src/core/json-schema-components.jsx
@@ -320,18 +320,16 @@ export class JsonSchema_boolean extends Component {
     let { getComponent, value, errors, schema, required, disabled } = this.props
     errors = errors.toJS ? errors.toJS() : []
     let enumValue = schema && schema.get ? schema.get("enum") : null
-    if (!enumValue) {
-      // in case schema.get() also returns undefined/null
-      enumValue = fromJS(["true", "false"])
-    }
+    let allowEmptyValue = !enumValue || !required
+    let booleanValue = !enumValue && fromJS(["true", "false"])
     const Select = getComponent("Select")
 
     return (<Select className={ errors.length ? "invalid" : ""}
                     title={ errors.length ? errors : ""}
                     value={ String(value) }
                     disabled={ disabled }
-                    allowedValues={ enumValue }
-                    allowEmptyValue={ !required }
+                    allowedValues={ enumValue || booleanValue }
+                    allowEmptyValue={ allowEmptyValue }
                     onChange={ this.onEnumChange }/>)
   }
 }

--- a/test/e2e-cypress/static/documents/features/schema-form-enum-boolean.yaml
+++ b/test/e2e-cypress/static/documents/features/schema-form-enum-boolean.yaml
@@ -1,0 +1,87 @@
+swagger: "2.0"
+info:
+  description: "Test Required Enum and Boolean with Execute" 
+  version: "1.0.0"
+  title: "Swagger Petstore"
+  termsOfService: "http://swagger.io/terms/"
+  contact:
+    email: "apiteam@swagger.io"
+  license:
+    name: "Apache 2.0"
+    url: "http://www.apache.org/licenses/LICENSE-2.0.html"
+host: "petstore.swagger.io"
+basePath: "/v2"
+tags:
+- name: "pet"
+  description: "Everything about your Pets"
+  externalDocs:
+    description: "Find out more"
+    url: "http://swagger.io"
+schemes:
+- "https"
+- "http"
+paths:
+  /pet/findByStatus:
+    get:
+      tags:
+      - "pet"
+      summary: "Finds Pets by status"
+      description: "Multiple status values can be provided with comma separated strings"
+      operationId: "findPetsByStatus"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - name: "status"
+        in: "query"
+        description: "Status values that need to be considered for filter"
+        required: true
+        type: "array"
+        items:
+          type: "string"
+          enum:
+          - "available"
+          - "pending"
+          - "sold"
+          default: "available"
+        collectionFormat: "multi"
+      - name: "expectIsOptional"
+        in: "query"
+        description: "this field should be optional"
+        required: false
+        type: boolean
+      - name: "expectIsRequired"
+        in: "query"
+        description: "this field should be required"
+        required: true
+        type: boolean
+      responses:
+        "200":
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Pet"
+        "400":
+          description: "Invalid status value"
+definitions:
+  Pet:
+    type: "object"
+    required:
+    - "name"
+    properties:
+      id:
+        type: "integer"
+        format: "int64"
+      name:
+        type: "string"
+        example: "doggie"
+      status:
+        type: "string"
+        description: "pet status in the store"
+        enum:
+        - "available"
+        - "pending"
+        - "sold"
+    xml:
+      name: "Pet"

--- a/test/e2e-cypress/tests/features/schema-form-enum-boolean.js
+++ b/test/e2e-cypress/tests/features/schema-form-enum-boolean.js
@@ -1,0 +1,129 @@
+/**
+ * @prettier
+ */
+
+describe("JSON Schema Form: Enum & Boolean in a Parameter", () => {
+  beforeEach(() => {
+    cy.visit(
+      "/?url=/documents/features/schema-form-enum-boolean.yaml"
+    )
+      .get("#operations-pet-findPetsByStatus")
+      .click()
+      // Expand Try It Out
+      .get(".try-out__btn")
+      .click()
+    // @alias Execute Button
+    cy.get(".execute.opblock-control__btn").as("executeBtn")
+    // @alias Parameters
+    cy.get(".opblock-section tbody > tr > .parameters-col_description > select")
+      .eq(0)
+      .as("enumIsRequired")
+    cy.get(".opblock-section tbody > tr > .parameters-col_description > select")
+      .eq(1)
+      .as("booleanIsOptional")
+    cy.get(".opblock-section tbody > tr > .parameters-col_description > select")
+      .eq(2)
+      .as("booleanIsRequired")
+  })
+
+  it("should render @enumIsRequired with list of three options", () => {
+    cy.get("@enumIsRequired")
+      .should("contains.text", "available")
+      .should("contains.text", "pending")
+      .should("contains.text", "sold")
+      .should("not.contains.text", "--")
+      .find("option")
+      .should("have.length", 3)
+  })
+  it("should render @booleanIsOptional with default empty string value (display '--')", () => {
+    cy.get("@booleanIsOptional")
+      .should("have.value", "")
+      .should("contains.text", "--")
+  })
+  it("should render @booleanIsRequired with default empty string value (display '--')", () => {
+    cy.get("@booleanIsRequired")
+      .should("have.value", "")
+      .should("contains.text", "--")
+  })
+  it("should NOT be able to execute with empty @enumIsRequired and @booleanIsRequired values", () => {
+    // Execute
+    cy.get("@executeBtn")
+      .click()
+    cy.get("@enumIsRequired")
+      .should("have.class", "invalid")
+    cy.get("@booleanIsRequired")
+      .should("have.class", "invalid")
+    // cURL component
+    cy.get(".responses-wrapper .curl-command")
+      .should("not.exist")
+  })
+  it("should NOT be able to execute with empty @booleanIsRequired value, but valid @enumIsRequired", () => {
+    cy.get("@enumIsRequired")
+      .select("pending")
+    // Execute
+    cy.get("@executeBtn")
+      .click()
+    cy.get("@enumIsRequired")
+      .should("not.have.class", "invalid")
+    cy.get("@booleanIsRequired")
+      .should("have.class", "invalid")
+    // cURL component
+    cy.get(".responses-wrapper .curl-command")
+      .should("not.exist")
+  })
+  it("should NOT be able to execute with empty @enumIsRequired value, but valid @booleanIsRequired", () => {
+    cy.get("@booleanIsRequired")
+      .select("false")
+    // Execute
+    cy.get("@executeBtn")
+      .click()
+    cy.get("@enumIsRequired")
+      .should("have.class", "invalid")
+    cy.get("@booleanIsRequired")
+      .should("not.have.class", "invalid")
+    // cURL component
+    cy.get(".responses-wrapper .curl-command")
+      .should("not.exist")
+  })
+  it("should execute, if @booleanIsOptional value is 'false'", () => {
+    cy.get("@enumIsRequired")
+      .select("pending")
+    cy.get("@booleanIsRequired")
+      .select("false")
+    cy.get("@booleanIsOptional")
+      .select("false")
+    // Execute
+    cy.get("@executeBtn")
+      .click()
+    cy.get("@enumIsRequired")
+      .should("not.have.class", "invalid")
+    cy.get("@booleanIsRequired")
+      .should("not.have.class", "invalid")
+      .should("not.contains.text", "expectIsOptional")
+    // cURL component
+    cy.get(".responses-wrapper .curl-command")
+      .should("exist")
+      .get(".responses-wrapper .curl-command span")
+      .should("contains.text", "expectIsOptional=false")
+  })
+  it("should execute, but NOT send @booleanIsOptional value if not provided", () => {
+    cy.get("@enumIsRequired")
+      .select("pending")
+    cy.get("@booleanIsRequired")
+      .select("false")
+    // Execute
+    cy.get("@executeBtn")
+      .click()
+    cy.get("@enumIsRequired")
+      .should("not.have.class", "invalid")
+    cy.get("@booleanIsRequired")
+      .should("not.have.class", "invalid")
+      .should("not.contains.text", "expectIsOptional")
+    // cURL component
+    cy.get(".responses-wrapper .curl-command")
+      .should("exist")
+      .get(".responses-wrapper .curl-command span")
+      .should("not.contains.text", "expectIsOptional")
+  })
+
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

* Restored `allowedValue` to accept either `enumValue` or `booleanValue`.
This will allow a `boolean` to have an empty default value, regardless of the if the field is `required`. On load (operation expanded), a required boolean field no longer inaccurately displays as `true`. Therefore a user must select a valid boolean value in order to execute the request.

* Created new Cypress tests to test rendering and validation of `required` enum and boolean fields.
This also includes a test to validate that an optional empty value is NOT sent.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

fixes #6429 

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

New Cypress tests.

### Screenshots (if appropriate):

![ui-6429-fixed](https://user-images.githubusercontent.com/12902658/94745005-c1d0d600-032e-11eb-91d5-760519da1f2f.png)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
