### PR TITLE
fix(parameter-row): rendering of default/example values of 0

### DIFF
--- a/src/core/components/parameter-row.jsx
+++ b/src/core/components/parameter-row.jsx
@@ -119,17 +119,26 @@ export default class ParameterRow extends Component {
       //// Find an initial value
 
       if (specSelectors.isSwagger2()) {
-        initialValue = paramWithMeta.get("x-example")
-          || paramWithMeta.getIn(["schema", "example"])
-          || (schema && schema.getIn(["default"]))
+        initialValue =
+          paramWithMeta.get("x-example") !== undefined
+          ? paramWithMeta.get("x-example")
+          : paramWithMeta.getIn(["schema", "example"]) !== undefined
+          ? paramWithMeta.getIn(["schema", "example"])
+          : (schema && schema.getIn(["default"]))
       } else if (specSelectors.isOAS3()) {
         const currentExampleKey = oas3Selectors.activeExamplesMember(...pathMethod, "parameters", this.getParamKey())
-        initialValue = paramWithMeta.getIn(["examples", currentExampleKey, "value"])
-          || paramWithMeta.getIn(["content", parameterMediaType, "example"])
-          || paramWithMeta.get("example")
-          || (schema && schema.get("example"))
-          || (schema && schema.get("default"))
-          || paramWithMeta.get("default") // ensures support for `parameterMacro`
+        initialValue = 
+          paramWithMeta.getIn(["examples", currentExampleKey, "value"]) !== undefined
+          ? paramWithMeta.getIn(["examples", currentExampleKey, "value"])
+          : paramWithMeta.getIn(["content", parameterMediaType, "example"]) !== undefined
+          ? paramWithMeta.getIn(["content", parameterMediaType, "example"])
+          : paramWithMeta.get("example") !== undefined
+          ? paramWithMeta.get("example")
+          : (schema && schema.get("example")) !== undefined
+          ? (schema && schema.get("example"))
+          : (schema && schema.get("default")) !== undefined
+          ? (schema && schema.get("default"))
+          : paramWithMeta.get("default") // ensures support for `parameterMacro`
       }
 
       //// Process the initial value

--- a/test/unit/components/parameter-row.jsx
+++ b/test/unit/components/parameter-row.jsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { fromJS } from "immutable"
+import { List, fromJS } from "immutable"
 import { render } from "enzyme"
 import ParameterRow from "components/parameter-row"
 
@@ -82,5 +82,144 @@ describe("<ParameterRow/>", () => {
 
     expect(wrapper.find(".parameter__type").length).toEqual(1)
     expect(wrapper.find(".parameter__type").text()).toEqual("string")
+  })
+})
+
+describe("bug #5573: zero default and example values", function () {
+  it("should apply a Swagger 2.0 default value of zero", function () {
+    const paramValue = fromJS({
+      description: "a pet",
+      type: "integer",
+      default: 0
+    })
+
+    let props = {
+      getComponent: () => "div",
+      specSelectors: {
+        security() { },
+        parameterWithMetaByIdentity() { return paramValue },
+        isOAS3() { return false },
+        isSwagger2() { return true }
+      },
+      fn: {},
+      operation: { get: () => { } },
+      onChange: jest.fn(),
+      param: paramValue,
+      rawParam: paramValue,
+      onChangeConsumes: () => { },
+      pathMethod: [],
+      getConfigs: () => { return {} },
+      specPath: List([])
+    }
+
+    render(<ParameterRow {...props} />)
+
+    expect(props.onChange).toHaveBeenCalled()
+    expect(props.onChange).toHaveBeenCalledWith(paramValue, "0", false)
+  })
+  it("should apply a Swagger 2.0 example value of zero", function () {
+    const paramValue = fromJS({
+      description: "a pet",
+      type: "integer",
+      schema: {
+        example: 0
+      }
+    })
+
+    let props = {
+      getComponent: () => "div",
+      specSelectors: {
+        security() { },
+        parameterWithMetaByIdentity() { return paramValue },
+        isOAS3() { return false },
+        isSwagger2() { return true }
+      },
+      fn: {},
+      operation: { get: () => { } },
+      onChange: jest.fn(),
+      param: paramValue,
+      rawParam: paramValue,
+      onChangeConsumes: () => { },
+      pathMethod: [],
+      getConfigs: () => { return {} },
+      specPath: List([])
+    }
+
+    render(<ParameterRow {...props} />)
+
+    expect(props.onChange).toHaveBeenCalled()
+    expect(props.onChange).toHaveBeenCalledWith(paramValue, "0", false)
+  })
+  it("should apply an OpenAPI 3.0 default value of zero", function () {
+    const paramValue = fromJS({
+      description: "a pet",
+      schema: {
+        type: "integer",
+        default: 0
+      }
+    })
+
+    let props = {
+      getComponent: () => "div",
+      specSelectors: {
+        security() { },
+        parameterWithMetaByIdentity() { return paramValue },
+        isOAS3() { return true },
+        isSwagger2() { return false }
+      },
+      oas3Selectors: {
+        activeExamplesMember: () => null
+      },
+      fn: {},
+      operation: { get: () => { } },
+      onChange: jest.fn(),
+      param: paramValue,
+      rawParam: paramValue,
+      onChangeConsumes: () => { },
+      pathMethod: [],
+      getConfigs: () => { return {} },
+      specPath: List([])
+    }
+
+    render(<ParameterRow {...props} />)
+
+    expect(props.onChange).toHaveBeenCalled()
+    expect(props.onChange).toHaveBeenCalledWith(paramValue, "0", false)
+  })
+  it("should apply an OpenAPI 3.0 example value of zero", function () {
+    const paramValue = fromJS({
+      description: "a pet",
+      schema: {
+        type: "integer",
+        example: 0
+      }
+    })
+
+    let props = {
+      getComponent: () => "div",
+      specSelectors: {
+        security() { },
+        parameterWithMetaByIdentity() { return paramValue },
+        isOAS3() { return true },
+        isSwagger2() { return false }
+      },
+      oas3Selectors: {
+        activeExamplesMember: () => null
+      },
+      fn: {},
+      operation: { get: () => { } },
+      onChange: jest.fn(),
+      param: paramValue,
+      rawParam: paramValue,
+      onChangeConsumes: () => { },
+      pathMethod: [],
+      getConfigs: () => { return {} },
+      specPath: List([])
+    }
+
+    render(<ParameterRow {...props} />)
+
+    expect(props.onChange).toHaveBeenCalled()
+    expect(props.onChange).toHaveBeenCalledWith(paramValue, "0", false)
   })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Use ternary expressions to explicitly check for `undefined` values instead of "false-y" values.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes #5573 

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Jest unit tests adapted from PR #5666

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
