### PR TITLE
Setting up syntax highlighting of code section - Configuration fix for Examples

### DIFF
--- a/src/core/components/example.jsx
+++ b/src/core/components/example.jsx
@@ -8,7 +8,7 @@ import ImPropTypes from "react-immutable-proptypes"
 import { stringify } from "core/utils"
 
 export default function Example(props) {
-  const { example, showValue, getComponent } = props
+  const { example, showValue, getComponent, getConfigs } = props
 
   const Markdown = getComponent("Markdown", true)
   const HighlightCode = getComponent("highlightCode")
@@ -28,7 +28,7 @@ export default function Example(props) {
       {showValue && example.has("value") ? (
         <section className="example__section">
           <div className="example__section-header">Example Value</div>
-          <HighlightCode value={stringify(example.get("value"))} />
+          <HighlightCode getConfigs={ getConfigs } value={stringify(example.get("value"))} />
         </section>
       ) : null}
     </div>
@@ -39,4 +39,5 @@ Example.propTypes = {
   example: ImPropTypes.map.isRequired,
   showValue: PropTypes.bool,
   getComponent: PropTypes.func.isRequired,
+  getConfigs: PropTypes.func.getConfigs,
 }

--- a/src/core/components/model-example.jsx
+++ b/src/core/components/model-example.jsx
@@ -76,7 +76,7 @@ export default class ModelExample extends React.Component {
         {
           this.state.activeTab === "example" ? (
             example ? example : (
-              <HighlightCode value="(no example available)" />
+              <HighlightCode value="(no example available)" getConfigs={ getConfigs } />
             )
           ) : null
         }

--- a/src/core/components/parameter-row.jsx
+++ b/src/core/components/parameter-row.jsx
@@ -369,6 +369,7 @@ export default class ParameterRow extends Component {
                   oas3Selectors.activeExamplesMember(...pathMethod, "parameters", this.getParamKey())
                 ])}
                 getComponent={getComponent}
+                getConfigs={getConfigs}
               />
             ) : null
           }

--- a/src/core/components/parameters/parameters.jsx
+++ b/src/core/components/parameters/parameters.jsx
@@ -107,6 +107,7 @@ export default class Parameters extends Component {
     const isExecute = tryItOutEnabled && allowTryItOut
     const isOAS3 = specSelectors.isOAS3()
 
+
     const requestBody = operation.get("requestBody")
     return (
       <div className="opblock-section">
@@ -200,6 +201,7 @@ export default class Parameters extends Component {
                 requestBodyInclusionSetting={oas3Selectors.requestBodyInclusionSetting(...pathMethod)}
                 requestBodyErrors={oas3Selectors.requestBodyErrors(...pathMethod)}
                 isExecute={isExecute}
+                getConfigs={getConfigs}
                 activeExamplesKey={oas3Selectors.activeExamplesMember(
                   ...pathMethod,
                   "requestBody",

--- a/src/core/components/response.jsx
+++ b/src/core/components/response.jsx
@@ -226,6 +226,7 @@ export default class Response extends React.Component {
               <Example
                 example={examplesForMediaType.get(this.getTargetExamplesKey(), Map({}))}
                 getComponent={getComponent}
+                getConfigs={getConfigs}
                 omitValue={true}
               />
           ) : null}

--- a/src/core/plugins/oas3/components/request-body.jsx
+++ b/src/core/plugins/oas3/components/request-body.jsx
@@ -250,6 +250,7 @@ const RequestBody = ({
           example={
             <HighlightCode
               className="body-param__example"
+              getConfigs={getConfigs}
               value={stringify(requestBodyValue) || getDefaultRequestBodyValue(
                 requestBody,
                 contentType,
@@ -266,6 +267,7 @@ const RequestBody = ({
         <Example
           example={examplesForMediaType.get(activeExamplesKey)}
           getComponent={getComponent}
+          getConfigs={getConfigs}
         />
       ) : null
     }


### PR DESCRIPTION
### Description

Complement #5259, getConfigs was not correctly forwarded to Examples 🖇️ 
As a result, [syntax highlight could not be disabled be disabled or configured in that element](https://github.com/swagger-api/swagger-ui/pull/5259#issuecomment-699515953) as was reported by @mariem-89

### Motivation and Context
Achieve expected behavior introduced in  #5259

### How Has This Been Tested?
Ran the test locally and performed local acceptance tests (see screenshots)

### Screenshots (if appropriate):
>Before / After
<img width="1509" alt="Capture d’écran 2020-10-02 à 01 21 09" src="https://user-images.githubusercontent.com/2601132/94872854-01421400-044e-11eb-9e83-f55278718ebb.png">
<img width="1507" alt="Capture d’écran 2020-10-02 à 01 20 57" src="https://user-images.githubusercontent.com/2601132/94872856-03a46e00-044e-11eb-8f4e-ca0157d69dd7.png">


## Checklist

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [x] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [ ] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
