### PR TITLE
Fix to show "Choose file" button when the format is byte

### DIFF
--- a/src/core/plugins/oas3/wrap-components/json-schema-string.jsx
+++ b/src/core/plugins/oas3/wrap-components/json-schema-string.jsx
@@ -13,7 +13,7 @@ export default OAS3ComponentWrapFactory(({ Ori, ...props }) => {
   const type = schema && schema.get ? schema.get("type") : null
   const Input = getComponent("Input")
 
-  if(type && type === "string" && (format && (format === "binary" || format === "base64"))) {
+  if(type && type === "string" && (format && (format === "binary" || format === "base64" || format === "byte"))) {
     return <Input type="file"
                    className={ errors.length ? "invalid" : ""}
                    title={ errors.length ? errors : ""}

--- a/test/e2e-cypress/static/documents/bugs/6361.yaml
+++ b/test/e2e-cypress/static/documents/bugs/6361.yaml
@@ -1,0 +1,24 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets/{petId}/image:
+    post:
+      summary: Add a new pet image
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                base64Image:
+                  type: string
+                  format: byte
+      responses:
+        '201':
+          description: Created

--- a/test/e2e-cypress/tests/bugs/6361.js
+++ b/test/e2e-cypress/tests/bugs/6361.js
@@ -1,0 +1,13 @@
+// http://github.com/swagger-api/swagger-ui/issues/6361
+
+describe("#6361: Button 'Choose file' missed if type byte", () => {
+  it("should render a 'Choose file' button", () => {
+    cy.visit("/?url=/documents/bugs/6361.yaml")
+      .get("#operations-default-post_pets__petId__image")
+      .click()
+      .get(".try-out__btn")
+      .click()
+      .get("input[type='file']")
+      .should("exist")
+  })
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Now the button "Choose type" will be shown when the format is `byte` like in:
```
   requestBody:
       content:
         multipart/form-data:
           schema:
             type: object
             properties:
               base64Image:
                 type: string
                 format: byte
```


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->
Fixes #6361 


### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally using this yaml:
```
openapi: "3.0.0"
info:
  version: 1.0.0
  title: Swagger Petstore
  license:
    name: MIT
servers:
  - url: http://petstore.swagger.io/v1
paths:
  /pets/{petId}/image:
    post:
      summary: Add a new pet image
      requestBody:
        content:
          multipart/form-data:
            schema:
              type: object
              properties:
                base64Image:
                  type: string
                  format: byte
      responses:
        '201':
          description: Created
```


### Screenshots (if appropriate):
**Before**
![image](https://user-images.githubusercontent.com/15196342/95072282-3f1f9080-070b-11eb-95b1-b70043eae9f1.png)

**After**
![image](https://user-images.githubusercontent.com/15196342/95072159-113a4c00-070b-11eb-8e12-e1146a2d34e7.png)



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

**I think I might need to change the documentation here https://swagger.io/docs/specification/describing-request-body/multipart-requests/ on the table under "Specifying Content-Type" to include byte but I'm not sure. Should I?**

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
