### PR TITLE
Fix so query parameter filter=true/false enables/disables the filter bar instead of filtering by that string

### DIFF
--- a/src/core/components/operations.jsx
+++ b/src/core/components/operations.jsx
@@ -48,7 +48,7 @@ export default class Operations extends React.Component {
     let filter = layoutSelectors.currentFilter()
 
     if (filter) {
-      if (filter !== true) {
+      if (filter !== true && filter !== "true" && filter !== "false") {
         taggedOps = fn.opsFilter(taggedOps, filter)
       }
     }

--- a/src/core/containers/filter.jsx
+++ b/src/core/containers/filter.jsx
@@ -29,7 +29,7 @@ export default class FilterContainer extends React.Component {
 
     return (
       <div>
-        {filter === null || filter === false ? null :
+        {filter === null || filter === false || filter === "false" ? null :
           <div className="filter-container">
             <Col className="filter wrapper" mobile={12}>
               <input className={classNames.join(" ")} placeholder="Filter by tag" type="text"

--- a/test/e2e-cypress/tests/bugs/6276.js
+++ b/test/e2e-cypress/tests/bugs/6276.js
@@ -1,0 +1,43 @@
+describe("#6276: Query parameter filter=true is filtering by the value 'true'", () => {
+  describe("With filter=true", () => {
+    it("should display the filter bar", () => {
+      cy.visit("/?url=/documents/petstore.swagger.yaml&filter=true")
+        .get(".operation-filter-input")
+        .should("exist")
+        .should("be.empty")
+        .get(".opblock-tag[data-tag='pet']")
+        .should("exist")
+        .get(".opblock-tag[data-tag='store']")
+        .should("exist")
+        .get(".opblock-tag[data-tag='user']")
+        .should("exist")
+    })
+  })
+  describe("With filter=false", () => {
+    it("should not display the filter bar", () => {
+      cy.visit("/?url=/documents/petstore.swagger.yaml&filter=false")
+        .get(".operation-filter-input")
+        .should("not.exist")
+        .get(".opblock-tag[data-tag='pet']")
+        .should("exist")
+        .get(".opblock-tag[data-tag='store']")
+        .should("exist")
+        .get(".opblock-tag[data-tag='user']")
+        .should("exist")
+    })
+  })
+  describe("With filter=pet", () => {
+    it("should display the filter bar and only show the operations tagged with pet", () => {
+      cy.visit("/?url=/documents/petstore.swagger.yaml&filter=pet")
+        .get(".operation-filter-input")
+        .should("exist")
+        .should("have.value", "pet")
+        .get(".opblock-tag[data-tag='pet']")
+        .should("exist")
+        .get(".opblock-tag[data-tag='store']")
+        .should("not.exist")
+        .get(".opblock-tag[data-tag='user']")
+        .should("not.exist")
+    })
+  })
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
According to the [configuration documentation](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md#display) filter "Can be Boolean to enable or disable, or a string, in which case filtering will be enabled using that string as the filter expression."

Since url parameters are string we should compare against strings instead of booleans to check if the value is `true` to show the bar without filtering by any value or `false` to hide the bar (although it is also hidden if no parameter is set).

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->
Fixes #6276 
While testing I also realized that when `filter=false` instead of hiding the bar would filter by the word "false" https://petstore.swagger.io/?filter=false 

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally I have tested by sending the value `true`, `false` and also other strings.

### Screenshots (if appropriate):
**filter=true**
![image](https://user-images.githubusercontent.com/15196342/95225331-fbf11a80-07fb-11eb-9b40-96dbb9cc0e78.png)

**filter=false**
![image](https://user-images.githubusercontent.com/15196342/95225387-090e0980-07fc-11eb-84cd-dbcd8a217140.png)

**filter=other-value**
![image](https://user-images.githubusercontent.com/15196342/95225461-1f1bca00-07fc-11eb-8c6b-75d129aa540d.png)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
