### PR TITLE
Fixes #6365 add stub for errActions to prevent unhandled promise rejections…

### DIFF
--- a/test/unit/core/plugins/auth/actions.js
+++ b/test/unit/core/plugins/auth/actions.js
@@ -1,7 +1,7 @@
 import { Map } from "immutable"
 import {
   authorizeRequest,
-  authorizeAccessCodeWithFormParams,  
+  authorizeAccessCodeWithFormParams,
   authorizeWithPersistOption,
   authorizeOauth2WithPersistOption,
   logoutWithPersistOption,
@@ -57,7 +57,7 @@ describe("auth plugin - actions", () => {
         },
         "http://specs/authorize"
       ],
-    ].forEach(([{oas3, server, effectiveServer, scheme, host, url}, expectedFetchUrl]) => {
+    ].forEach(([{ oas3, server, effectiveServer, scheme, host, url }, expectedFetchUrl]) => {
       it("should resolve authorization endpoint against the server URL", () => {
 
         // Given
@@ -71,6 +71,9 @@ describe("auth plugin - actions", () => {
           getConfigs: () => ({}),
           authSelectors: {
             getConfigs: () => ({})
+          },
+          errActions: {
+            newAuthErr: () => ({})
           },
           oas3Selectors: {
             selectedServer: () => server,
@@ -89,7 +92,7 @@ describe("auth plugin - actions", () => {
 
         // Then
         expect(system.fn.fetch.mock.calls.length).toEqual(1)
-        expect(system.fn.fetch.mock.calls[0][0]).toEqual(expect.objectContaining({url: expectedFetchUrl}))
+        expect(system.fn.fetch.mock.calls[0][0]).toEqual(expect.objectContaining({ url: expectedFetchUrl }))
       })
     })
 
@@ -110,6 +113,9 @@ describe("auth plugin - actions", () => {
               myCustomParam: "abc123"
             }
           })
+        },
+        errActions: {
+          newAuthErr: () => ({})
         },
         specSelectors: {
           isOAS3: () => false,
@@ -139,6 +145,9 @@ describe("auth plugin - actions", () => {
         fn: {
           fetch: jest.fn().mockImplementation(() => Promise.resolve())
         },
+        errActions: {
+          newAuthErr: () => ({})
+        },
         getConfigs: () => ({}),
         authSelectors: {
           getConfigs: () => ({
@@ -167,7 +176,7 @@ describe("auth plugin - actions", () => {
     })
   })
 
-  describe("tokenRequest", function() {
+  describe("tokenRequest", function () {
     it("should send the code verifier when set", () => {
       const data = {
         auth: {
@@ -200,17 +209,17 @@ describe("auth plugin - actions", () => {
         const data = {
           "api_key": {}
         }
-        const system = {          
+        const system = {
           getConfigs: () => ({}),
           authActions: {
-            authorize: jest.fn(()=>{}),
-            persistAuthorizationIfNeeded: jest.fn(()=>{})
+            authorize: jest.fn(() => { }),
+            persistAuthorizationIfNeeded: jest.fn(() => { })
           }
         }
-  
+
         // When
         authorizeWithPersistOption(data)(system)
-  
+
         // Then
         expect(system.authActions.authorize).toHaveBeenCalled()
         expect(system.authActions.authorize).toHaveBeenCalledWith(data)
@@ -223,17 +232,17 @@ describe("auth plugin - actions", () => {
         const data = {
           "api_key": {}
         }
-        const system = {          
+        const system = {
           getConfigs: () => ({}),
           authActions: {
-            authorizeOauth2: jest.fn(()=>{}),
-            persistAuthorizationIfNeeded: jest.fn(()=>{})
+            authorizeOauth2: jest.fn(() => { }),
+            persistAuthorizationIfNeeded: jest.fn(() => { })
           }
         }
-  
+
         // When
         authorizeOauth2WithPersistOption(data)(system)
-  
+
         // Then
         expect(system.authActions.authorizeOauth2).toHaveBeenCalled()
         expect(system.authActions.authorizeOauth2).toHaveBeenCalledWith(data)
@@ -246,23 +255,23 @@ describe("auth plugin - actions", () => {
         const data = {
           "api_key": {}
         }
-        const system = {          
+        const system = {
           getConfigs: () => ({}),
           authActions: {
-            logout: jest.fn(()=>{}),
-            persistAuthorizationIfNeeded: jest.fn(()=>{})
+            logout: jest.fn(() => { }),
+            persistAuthorizationIfNeeded: jest.fn(() => { })
           }
         }
-  
+
         // When
         logoutWithPersistOption(data)(system)
-  
+
         // Then
         expect(system.authActions.logout).toHaveBeenCalled()
         expect(system.authActions.logout).toHaveBeenCalledWith(data)
         expect(system.authActions.persistAuthorizationIfNeeded).toHaveBeenCalled()
       })
-    })    
+    })
 
     describe("persistAuthorizationIfNeeded", () => {
       beforeEach(() => {
@@ -270,18 +279,18 @@ describe("auth plugin - actions", () => {
       })
       it("should skip if `persistAuthorization` is turned off", () => {
         // Given        
-        const system = {          
+        const system = {
           getConfigs: () => ({
             persistAuthorization: false
-          }),          
+          }),
           authSelectors: {
-            authorized: jest.fn(()=>{})
+            authorized: jest.fn(() => { })
           }
         }
-  
+
         // When
         persistAuthorizationIfNeeded()(system)
-  
+
         // Then
         expect(system.authSelectors.authorized).not.toHaveBeenCalled()
       })
@@ -290,22 +299,25 @@ describe("auth plugin - actions", () => {
         const data = {
           "api_key": {}
         }
-        const system = {          
+        const system = {
           getConfigs: () => ({
             persistAuthorization: true
-          }),          
+          }),
+          errActions: {
+            newAuthErr: () => ({})
+          },
           authSelectors: {
-            authorized: jest.fn(()=>Map(data))
+            authorized: jest.fn(() => Map(data))
           }
-        }        
+        }
         jest.spyOn(Object.getPrototypeOf(window.localStorage), "setItem")
 
         // When
         persistAuthorizationIfNeeded()(system)
 
         expect(localStorage.setItem).toHaveBeenCalled()
-        expect(localStorage.setItem).toHaveBeenCalledWith("authorized", JSON.stringify(data))        
-  
+        expect(localStorage.setItem).toHaveBeenCalledWith("authorized", JSON.stringify(data))
+
       })
     })
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Added stub/mock for newAuthErr-action to prevent unhandled promise rejection.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes #6365


### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Successfully ran the unit tests without warnings or errors

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
