### PR TITLE
Preventing long strings from overflowing (fix #5934)

### DIFF
--- a/src/style/_markdown.scss
+++ b/src/style/_markdown.scss
@@ -1,6 +1,9 @@
 .markdown, .renderedMarkdown {
   p, pre {
     margin: 1em auto;
+
+    word-break: break-all; /* Fallback trick */
+    word-break: break-word;
   }
   pre {
     color: black;
@@ -8,7 +11,6 @@
     white-space: pre-wrap;
     background: none;
     padding: 0px;
-    overflow-wrap: break-word;
   }
 
   code {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed the bug for which the text was overflowing if it was containing a single very long string (see #5934).

### Description
<!--- Describe your changes in detail -->
The fix makes use of the `word-break`  CSS property and its recent option [`break-word`](https://caniuse.com/mdn-css_properties_word-break_break-word) and supports the option [`break-all`](https://caniuse.com/word-break) as a fallback solution on older browsers.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->
Fixes #5934.


### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Firefox and Chromium on Linux and Edge on windows.


### Screenshots (if appropriate):
![immagine](https://user-images.githubusercontent.com/8852116/95692393-b2eafd00-0c25-11eb-87fc-9a65749e5fc5.png)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
