### PR TITLE
Update documentation to using absolute links

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,22 +40,22 @@ Swagger UI Version | Release Date | OpenAPI Spec compatibility | Notes
 ## Documentation
 
 #### Usage
-- [Installation](docs/usage/installation.md)
-- [Configuration](docs/usage/configuration.md)
-- [CORS](docs/usage/cors.md)
-- [OAuth2](docs/usage/oauth2.md)
-- [Deep Linking](docs/usage/deep-linking.md)
-- [Limitations](docs/usage/limitations.md)
-- [Version detection](docs/usage/version-detection.md)
+- [Installation](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/installation.md)
+- [Configuration](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md)
+- [CORS](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/cors.md)
+- [OAuth2](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/oauth2.md)
+- [Deep Linking](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/deep-linking.md)
+- [Limitations](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/limitations.md)
+- [Version detection](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/version-detection.md)
 
 #### Customization
-- [Overview](docs/customization/overview.md)
-- [Plugin API](docs/customization/plugin-api.md)
-- [Custom layout](docs/customization/custom-layout.md)
+- [Overview](https://github.com/swagger-api/swagger-ui/blob/master/docs/customization/overview.md)
+- [Plugin API](https://github.com/swagger-api/swagger-ui/blob/master/docs/customization/plugin-api.md)
+- [Custom layout](https://github.com/swagger-api/swagger-ui/blob/master/docs/customization/custom-layout.md)
 
 #### Development
-- [Setting up](docs/development/setting-up.md)
-- [Scripts](docs/development/scripts.md)
+- [Setting up](https://github.com/swagger-api/swagger-ui/blob/master/docs/development/setting-up.md)
+- [Scripts](https://github.com/swagger-api/swagger-ui/blob/master/docs/development/scripts.md)
 
 ##### Integration Tests
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Currenttly when clicking some of links in documentation page in [Swagger's Docker Hub Page](https://hub.docker.com/r/swaggerapi/swagger-ui) showing 404 error page. For example, take this [Configuration page](https://hub.docker.com/r/swaggerapi/docs/usage/configuration.md)

### Description
<!--- Describe your changes in detail -->
Update in readme file for documentation links such as usage, customization, and development to be redirected to Github using absolute link instead of relative link.



### Motivation and Context
Fixes #6233 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->



### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- No testing needed


### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
