### PR TITLE
Fix downloading remote config

### DIFF
--- a/src/core/index.js
+++ b/src/core/index.js
@@ -177,15 +177,15 @@ export default function SwaggerUI(opts) {
 
   const configUrl = queryConfig.config || constructorConfig.configUrl
 
-  if (!configUrl || !system.specActions || !system.specActions.getConfigByUrl || system.specActions.getConfigByUrl && !system.specActions.getConfigByUrl({
-    url: configUrl,
-    loadRemoteConfig: true,
-    requestInterceptor: constructorConfig.requestInterceptor,
-    responseInterceptor: constructorConfig.responseInterceptor,
-  }, downloadSpec)) {
-    return downloadSpec()
+  if (configUrl && system.specActions && system.specActions.getConfigByUrl) {
+    system.specActions.getConfigByUrl({
+      url: configUrl,
+      loadRemoteConfig: true,
+      requestInterceptor: constructorConfig.requestInterceptor,
+      responseInterceptor: constructorConfig.responseInterceptor,
+    }, downloadSpec)
   } else {
-    system.specActions.getConfigByUrl(configUrl, downloadSpec)
+    return downloadSpec()
   }
 
   return system


### PR DESCRIPTION
### Description
I found that the problem was introduced in [this merge](https://github.com/swagger-api/swagger-ui/pull/4349/commits/c611381210dc7f294f7b684dc391a4c7c257b5f3).


### Motivation and Context
Fixes #4825
Also I inverted the predicate for the sake of better maintenance. If any additional changes or tests required, please let me know.


### How Has This Been Tested?
I did manual testing, put the `configUrl` and a remote config and loaded the page. Everything looks good, config loaded only once.

## Checklist
### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
