### PR TITLE
feat(auth): Add OpenID Connect Discovery support (#3517)

### DIFF
--- a/src/core/components/auth/oauth2.jsx
+++ b/src/core/components/auth/oauth2.jsx
@@ -122,11 +122,13 @@ export default class Oauth2 extends React.Component {
 
     const { isOAS3 } = specSelectors
 
+    let oidcUrl = isOAS3() ? schema.get("openIdConnectUrl") : null
+
     // Auth type consts
     const IMPLICIT = "implicit"
     const PASSWORD = "password"
-    const ACCESS_CODE = isOAS3() ? "authorizationCode" : "accessCode"
-    const APPLICATION = isOAS3() ? "clientCredentials" : "application"
+    const ACCESS_CODE = isOAS3() ? (oidcUrl ? "authorization_code" : "authorizationCode") : "accessCode"
+    const APPLICATION = isOAS3() ? (oidcUrl ? "client_credentials" : "clientCredentials") : "application"
 
     let flow = schema.get("flow")
     let scopes = schema.get("allowedScopes") || schema.get("scopes")
@@ -144,6 +146,7 @@ export default class Oauth2 extends React.Component {
 
         { isAuthorized && <h6>Authorized</h6> }
 
+        { oidcUrl && <p>OpenID Connect URL: <code>{ oidcUrl }</code></p> }
         { ( flow === IMPLICIT || flow === ACCESS_CODE ) && <p>Authorization URL: <code>{ schema.get("authorizationUrl") }</code></p> }
         { ( flow === PASSWORD || flow === ACCESS_CODE || flow === APPLICATION ) && <p>Token URL:<code> { schema.get("tokenUrl") }</code></p> }
         <p className="flow">Flow: <code>{ schema.get("flow") }</code></p>

--- a/src/core/oauth2-authorize.js
+++ b/src/core/oauth2-authorize.js
@@ -26,11 +26,13 @@ export default function authorize ( { auth, authActions, errActions, configs, au
       break
 
     case "clientCredentials":
+    case "client_credentials":
       // OAS3
       authActions.authorizeApplication(auth)
       return
 
     case "authorizationCode":
+    case "authorization_code":
       // OAS3
       query.push("response_type=code")
       break

--- a/test/unit/core/plugins/oas3/wrap-auth-selectors.js
+++ b/test/unit/core/plugins/oas3/wrap-auth-selectors.js
@@ -1,5 +1,5 @@
 
-import { fromJS } from "immutable"
+import { fromJS, Map } from "immutable"
 import {
   definitionsToAuthorize
 } from "corePlugins/oas3/auth-extensions/wrap-selectors"
@@ -12,6 +12,7 @@ describe("oas3 plugin - auth extensions - wrapSelectors", function(){
       // Given
       const system = {
         getSystem: () => system,
+        getState: () => new Map(),
         specSelectors: {
           specJson: () => fromJS({
             openapi: "3.0.0"
@@ -53,7 +54,39 @@ describe("oas3 plugin - auth extensions - wrapSelectors", function(){
                     }
                   }
                 }
-              }
+              },
+              "oidc": {
+                "type": "openIdConnect",
+                "openIdConnectUrl": "https://accounts.google.com/.well-known/openid-configuration",
+                "openIdConnectData": {
+                  "authorization_endpoint": "https://accounts.google.com/o/oauth2/v2/auth",
+                  "token_endpoint": "https://oauth2.googleapis.com/token",
+                  "scopes_supported": [
+                    "openid",
+                    "email",
+                    "profile"
+                  ],
+                  "grant_types_supported": [
+                    "authorization_code",
+                    "refresh_token",
+                    "urn:ietf:params:oauth:grant-type:device_code",
+                    "urn:ietf:params:oauth:grant-type:jwt-bearer"
+                  ]
+                }
+              },
+              "oidcNoGrant": {
+                "type": "openIdConnect",
+                "openIdConnectUrl": "https://accounts.google.com/.well-known/openid-configuration",
+                "openIdConnectData": {
+                  "authorization_endpoint": "https://accounts.google.com/o/oauth2/v2/auth",
+                  "token_endpoint": "https://oauth2.googleapis.com/token",
+                  "scopes_supported": [
+                    "openid",
+                    "email",
+                    "profile"
+                  ]
+                },
+              },
             })
           }
         }
@@ -102,6 +135,96 @@ describe("oas3 plugin - auth extensions - wrapSelectors", function(){
             tokenUrl: "http://google.com/",
             scopes: {
               "myScope": "our only scope"
+            },
+            type: "oauth2"
+          }
+        },
+        {
+          oidc: {
+            flow: "authorization_code",
+            authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+            tokenUrl: "https://oauth2.googleapis.com/token",
+            openIdConnectUrl: "https://accounts.google.com/.well-known/openid-configuration",
+            scopes: {
+              "openid": "",
+              "email": "",
+              "profile": "",
+            },
+            type: "oauth2"
+          }
+        },
+        {
+          oidc: {
+            flow: "refresh_token",
+            authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+            tokenUrl: "https://oauth2.googleapis.com/token",
+            openIdConnectUrl: "https://accounts.google.com/.well-known/openid-configuration",
+            scopes: {
+              "openid": "",
+              "email": "",
+              "profile": "",
+            },
+            type: "oauth2"
+          }
+        },
+        {
+          oidc: {
+            flow: "urn:ietf:params:oauth:grant-type:device_code",
+            authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+            tokenUrl: "https://oauth2.googleapis.com/token",
+            openIdConnectUrl: "https://accounts.google.com/.well-known/openid-configuration",
+            scopes: {
+              "openid": "",
+              "email": "",
+              "profile": "",
+            },
+            type: "oauth2"
+          }
+        },
+        {
+          oidc: {
+            flow: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+            authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+            tokenUrl: "https://oauth2.googleapis.com/token",
+            openIdConnectUrl: "https://accounts.google.com/.well-known/openid-configuration",
+            scopes: {
+              "openid": "",
+              "email": "",
+              "profile": "",
+            },
+            type: "oauth2"
+          }
+        },
+        {
+          // See https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata
+          // grant_types_supported
+          //   OPTIONAL. JSON array containing a list of the OAuth 2.0 Grant Type values that
+          //   this OP supports. Dynamic OpenID Providers MUST support the authorization_code
+          //   and implicit Grant Type values and MAY support other Grant Types. If omitted,
+          //   the default value is ["authorization_code", "implicit"]. 
+          oidcNoGrant: {
+            flow: "authorization_code",
+            authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+            tokenUrl: "https://oauth2.googleapis.com/token",
+            openIdConnectUrl: "https://accounts.google.com/.well-known/openid-configuration",
+            scopes: {
+              "openid": "",
+              "email": "",
+              "profile": "",
+            },
+            type: "oauth2"
+          }
+        },
+        {
+          oidcNoGrant: {
+            flow: "implicit",
+            authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+            tokenUrl: "https://oauth2.googleapis.com/token",
+            openIdConnectUrl: "https://accounts.google.com/.well-known/openid-configuration",
+            scopes: {
+              "openid": "",
+              "email": "",
+              "profile": "",
             },
             type: "oauth2"
           }


### PR DESCRIPTION
### Description
spec/actions.js: Add OIDC metadata fetching

components/auth/oauth2: Add OIDC URL to the Authorization popup

This implementation requires OIDC metadata field `grant_types_supported` to convert to existing oauth2 flows.

Current implementation does not look at OIDC metadata fields other than `grant_types_supported`, `scopes_supported`, `authorization_endpoint`, and `token_endpoint`. `response_type` is still hard-coded in oauth2-authorize.js.

There is currently no support for flows other than the existing oauth2 flows.

Note: CORS must be enabled at the well-known OIDC endpoint for the OIDC metadata to be fetched. A workaround is to download the OIDC metadata via other means and reference it in swagger-ui with a local file relative URL.



### Motivation and Context
Fixes #3517, or at least the OIDC URL processing, not the nonce part (which can be solved with `additionalQueryStringParams`)



### How Has This Been Tested?
Tested with Google OIDC and proprietary OIDC discovery servers.


### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
