### PR TITLE
feat: Prevent background scrolling when modal is open

### DIFF
--- a/src/core/components/auth/authorization-popup.jsx
+++ b/src/core/components/auth/authorization-popup.jsx
@@ -2,10 +2,24 @@ import React from "react"
 import PropTypes from "prop-types"
 
 export default class AuthorizationPopup extends React.Component {
-  close =() => {
+  close = () => {
     let { authActions } = this.props
 
     authActions.showDefinitions(false)
+  }
+
+  componentDidMount = () => {
+    // prevent background scroll when modal open
+    document.body.style.top = `-${window.scrollY}px`
+    document.body.style.position = "fixed"
+  }
+
+  componentWillUnmount = () => {
+    // restore body scroll
+    const scrollY = document.body.style.top
+    document.body.style.position = ""
+    document.body.style.top = ""
+    window.scrollTo(0, parseInt(scrollY || "0") * -1)
   }
 
   render() {
@@ -15,7 +29,7 @@ export default class AuthorizationPopup extends React.Component {
 
     return (
       <div className="dialog-ux">
-        <div className="backdrop-ux"></div>
+        <div className="backdrop-ux"/>
         <div className="modal-ux">
           <div className="modal-dialog-ux">
             <div className="modal-ux-inner">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
prevent background scrolling when AuthorizationPopup is open.


### Motivation and Context
we expect that background will not scroll when the modal component is opened.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->



### How Has This Been Tested?
when open AuthorizationPopup, you can't scroll background. and closing allows you to scroll again.

<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->



### Screenshots (if appropriate):
![Oct-25-2020 13-45-02](https://user-images.githubusercontent.com/11595293/97099105-6cd37600-16c8-11eb-9bad-d6287cfd9e59.gif)



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
