### PR TITLE
fix(cypress): flakiness in oas3-multiple-media-types test

### DIFF
--- a/test/e2e-cypress/tests/features/oas3-multiple-media-type.js
+++ b/test/e2e-cypress/tests/features/oas3-multiple-media-type.js
@@ -30,10 +30,10 @@ describe("OpenAPI 3.0 Multiple Media Types with different schemas", () => {
     it("should execute multipart/form-data", () => {
       cy.get("@selectMediaType")
         .select(mediaTypeFormData)
-      cy.get("@executeBtn")
+        .get("@executeBtn")
         .click()
-      // cURL component
-      cy.get(".responses-wrapper .curl-command")
+        // cURL component
+        .get(".responses-wrapper .curl-command")
         .should("exist")
         .get(".responses-wrapper .curl-command span")
         .should("contains.text", "bar")
@@ -42,14 +42,14 @@ describe("OpenAPI 3.0 Multiple Media Types with different schemas", () => {
     it("should execute application/x-www-form-urlencoded THEN execute multipart/form-data", () => {
       cy.get("@selectMediaType")
         .select(mediaTypeUrlencoded)
-      cy.get("@executeBtn")
+        .get("@executeBtn")
         .click()
-      cy.get("@selectMediaType")
+        .get("@selectMediaType")
         .select(mediaTypeFormData)
-      cy.get("@executeBtn")
+        .get("@executeBtn")
         .click()
-      // cURL component
-      cy.get(".responses-wrapper .curl-command")
+        // cURL component
+        .get(".responses-wrapper .curl-command")
         .should("exist")
         .get(".responses-wrapper .curl-command span")
         .should("contains.text", "bar")
@@ -58,14 +58,14 @@ describe("OpenAPI 3.0 Multiple Media Types with different schemas", () => {
     it("should execute application/json THEN execute multipart/form-data", () => {
       cy.get("@selectMediaType")
         .select(mediaTypeJson)
-      cy.get("@executeBtn")
+        .get("@executeBtn")
         .click()
-      cy.get("@selectMediaType")
+        .get("@selectMediaType")
         .select(mediaTypeFormData)
-      cy.get("@executeBtn")
+        .get("@executeBtn")
         .click()
-      // cURL component
-      cy.get(".responses-wrapper .curl-command")
+        // cURL component
+        .get(".responses-wrapper .curl-command")
         .should("exist")
         .get(".responses-wrapper .curl-command span")
         .should("contains.text", "bar")
@@ -77,10 +77,10 @@ describe("OpenAPI 3.0 Multiple Media Types with different schemas", () => {
     it("should execute application/x-www-form-urlencoded", () => {
       cy.get("@selectMediaType")
         .select(mediaTypeUrlencoded)
-      cy.get("@executeBtn")
+        .get("@executeBtn")
         .click()
-      // cURL component
-      cy.get(".responses-wrapper .curl-command")
+        // cURL component
+        .get(".responses-wrapper .curl-command")
         .should("exist")
         .get(".responses-wrapper .curl-command span")
         .should("contains.text", "foo")
@@ -89,14 +89,14 @@ describe("OpenAPI 3.0 Multiple Media Types with different schemas", () => {
     it("should execute multipart/form-data THEN execute application/x-www-form-urlencoded", () => {
       cy.get("@selectMediaType")
         .select(mediaTypeFormData)
-      cy.get("@executeBtn")
+        .get("@executeBtn")
         .click()
-      cy.get("@selectMediaType")
+        .get("@selectMediaType")
         .select(mediaTypeUrlencoded)
-      cy.get("@executeBtn")
+        .get("@executeBtn")
         .click()
-      // cURL component
-      cy.get(".responses-wrapper .curl-command")
+        // cURL component
+        .get(".responses-wrapper .curl-command")
         .should("exist")
         .get(".responses-wrapper .curl-command span")
         .should("contains.text", "foo")
@@ -105,14 +105,14 @@ describe("OpenAPI 3.0 Multiple Media Types with different schemas", () => {
     it("should execute application/json THEN execute application/x-www-form-urlencoded", () => {
       cy.get("@selectMediaType")
         .select(mediaTypeJson)
-      cy.get("@executeBtn")
+        .get("@executeBtn")
         .click()
-      cy.get("@selectMediaType")
+        .get("@selectMediaType")
         .select(mediaTypeUrlencoded)
-      cy.get("@executeBtn")
+        .get("@executeBtn")
         .click()
-      // cURL component
-      cy.get(".responses-wrapper .curl-command")
+        // cURL component
+        .get(".responses-wrapper .curl-command")
         .should("exist")
         .get(".responses-wrapper .curl-command span")
         .should("contains.text", "foo")
@@ -126,12 +126,12 @@ describe("OpenAPI 3.0 Multiple Media Types with different schemas", () => {
       // final curl should have both "bar" and "foo"
       cy.get("@selectMediaType")
         .select(mediaTypeJson)
-      cy.get("@executeBtn")
+        .get("@executeBtn")
         .click()
-      cy.get("@executeBtn")
+        .get("@executeBtn")
         .click()
-      // cURL component
-      cy.get(".responses-wrapper .curl-command")
+        // cURL component
+        .get(".responses-wrapper .curl-command")
         .should("exist")
         .get(".responses-wrapper .curl-command span")
         .should("contains.text", "foo")
@@ -140,14 +140,14 @@ describe("OpenAPI 3.0 Multiple Media Types with different schemas", () => {
     it("should execute multipart/form-data THEN execute application/json", () => {
       cy.get("@selectMediaType")
         .select(mediaTypeFormData)
-      cy.get("@executeBtn")
+        .get("@executeBtn")
         .click()
-      cy.get("@selectMediaType")
+        .get("@selectMediaType")
         .select(mediaTypeJson)
-      cy.get("@executeBtn")
+        .get("@executeBtn")
         .click()
-      // cURL component
-      cy.get(".responses-wrapper .curl-command")
+        // cURL component
+        .get(".responses-wrapper .curl-command")
         .should("exist")
         .get(".responses-wrapper .curl-command span")
         .should("contains.text", "foo")
@@ -157,14 +157,14 @@ describe("OpenAPI 3.0 Multiple Media Types with different schemas", () => {
       // final curl should have both "bar" and "foo"
       cy.get("@selectMediaType")
         .select(mediaTypeUrlencoded)
-      cy.get("@executeBtn")
+        .get("@executeBtn")
         .click()
-      cy.get("@selectMediaType")
+        .get("@selectMediaType")
         .select(mediaTypeJson)
-      cy.get("@executeBtn")
+        .get("@executeBtn")
         .click()
-      // cURL component
-      cy.get(".responses-wrapper .curl-command")
+        // cURL component
+        .get(".responses-wrapper .curl-command")
         .should("exist")
         .get(".responses-wrapper .curl-command span")
         .should("contains.text", "foo")


### PR DESCRIPTION
refs #6570

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Combine multiple `cy.` chains into a single `cy.` chain. This matches the behavior of other Cypress tests with `execute`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

fixes #6570 

Hopefully resolves async issues.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->



### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
