### PR TITLE
Improve documentation for Standalone plain HTML installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ This repository publishes three different NPM modules:
 
 We strongly suggest that you use `swagger-ui` instead of `swagger-ui-dist` if you're building a single-page application, since `swagger-ui-dist` is significantly larger.
 
+If you are looking for plain ol' HTML/JS/CSS, [download the latest release](https://github.com/swagger-api/swagger-ui/releases/latest) and copy the contents of the `/dist` folder to your server.
+
 
 ## Compatibility
 The OpenAPI Specification has undergone 5 revisions since initial creation in 2010.  Compatibility between Swagger UI and the OpenAPI Specification is as follows:

--- a/docs/usage/installation.md
+++ b/docs/usage/installation.md
@@ -99,3 +99,13 @@ See [unpkg's main page](https://unpkg.com/) for more information on how to use u
 ### Static files without HTTP or HTML
 
 Once swagger-ui has successfully generated the `/dist` directory, you can copy this to your own file system and host from there. 
+
+## Plain old HTML/CSS/JS (Standalone)
+
+The folder `/dist` includes all the HTML, CSS and JS files needed to run SwaggerUI on a static website or CMS, without requiring NPM.
+
+1. Download the [latest release](https://github.com/swagger-api/swagger-ui/releases/latest).
+1. Copy the contents of the `/dist` folder to your server.
+1. Open `index.html` in your HTML editor and replace "https://petstore.swagger.io/v2/swagger.json" with the URL for your OpenAPI 3.0 spec.
+
+


### PR DESCRIPTION
### Description
Update `README` and Installation instructions to better indicate how to use SwaggerUI without NPM.

### Motivation and Context
Current documentation is a bit misleading, and seems to indicate that NPM is required to install and/or run Swagger. Users looking for plain old HTML files might have trouble figuring out how to install SwaggerUI.

### How Has This Been Tested?
Provided easy to follow steps.

## Checklist

### My PR contains... 
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
