### PR TITLE
Request Body examples should respect media-type

### DIFF
--- a/src/core/plugins/oas3/components/request-body.jsx
+++ b/src/core/plugins/oas3/components/request-body.jsx
@@ -5,31 +5,28 @@ import { Map, OrderedMap, List } from "immutable"
 import { getCommonExtensions, getSampleSchema, stringify, isEmptyValue } from "core/utils"
 
 function getDefaultRequestBodyValue(requestBody, mediaType, activeExamplesKey) {
-  let mediaTypeValue = requestBody.getIn(["content", mediaType])
-  let schema = mediaTypeValue.get("schema").toJS()
-  let example =
-    mediaTypeValue.get("example") !== undefined
-      ? stringify(mediaTypeValue.get("example"))
-      : null
-  let currentExamplesValue = mediaTypeValue.getIn([
-    "examples",
-    activeExamplesKey,
-    "value"
-  ])
+  const mediaTypeValue = requestBody.getIn(["content", mediaType])
+  const schema = mediaTypeValue.get("schema").toJS()
 
-  if (mediaTypeValue.get("examples")) {
-    // the media type DOES have examples
-    return stringify(currentExamplesValue) || ""
-  } else {
-    // the media type DOES NOT have examples
-    return stringify(
-      example ||
-        getSampleSchema(schema, mediaType, {
-          includeWriteOnly: true
-        }) ||
-        ""
-    )
-  }
+  const hasExamplesKey = mediaTypeValue.get("examples") !== undefined
+  const exampleSchema = mediaTypeValue.get("example")
+  const mediaTypeExample = hasExamplesKey
+    ? mediaTypeValue.getIn([
+      "examples",
+      activeExamplesKey,
+      "value"
+    ])
+    : exampleSchema
+
+  const exampleValue = getSampleSchema(
+    schema,
+    mediaType,
+    {
+      includeWriteOnly: true
+    },
+    mediaTypeExample
+  )
+  return stringify(exampleValue)
 }
 
 
@@ -212,6 +209,12 @@ const RequestBody = ({
     </div>
   }
 
+  const sampleRequestBody = getDefaultRequestBodyValue(
+    requestBody,
+    contentType,
+    activeExamplesKey,
+  )
+
   return <div>
     { requestBodyDescription &&
       <Markdown source={requestBodyDescription} />
@@ -235,11 +238,7 @@ const RequestBody = ({
           <RequestBodyEditor
             value={requestBodyValue}
             errors={requestBodyErrors}
-            defaultValue={getDefaultRequestBodyValue(
-              requestBody,
-              contentType,
-              activeExamplesKey,
-            )}
+            defaultValue={sampleRequestBody}
             onChange={onChange}
             getComponent={getComponent}
           />
@@ -257,11 +256,7 @@ const RequestBody = ({
             <HighlightCode
               className="body-param__example"
               getConfigs={getConfigs}
-              value={stringify(requestBodyValue) || getDefaultRequestBodyValue(
-                requestBody,
-                contentType,
-                activeExamplesKey,
-              )}
+              value={stringify(requestBodyValue) || sampleRequestBody}
             />
           }
           includeWriteOnly={true}

--- a/test/e2e-cypress/static/documents/bugs/6475.yaml
+++ b/test/e2e-cypress/static/documents/bugs/6475.yaml
@@ -1,0 +1,57 @@
+openapi: 3.0.1
+info:
+ title: Example Swagger
+ version: '1.0'
+servers:
+ - url: /api/v1
+paths:
+ /xmlTest/examples:
+   post:
+     summary: sample issues
+     operationId: xmlTest_examples
+     parameters: []
+     requestBody:
+       description: Simple Test xml examples
+       content:
+           application/xml:
+              schema:
+               $ref: "#/components/schemas/Test"
+              examples:
+                test:
+                  value:
+                    x: should be xml
+     responses:
+       '200':
+         description:  Simple Test xml examples
+         content: {}
+ /xmlTest/example:
+   post:
+     summary: sample issues
+     operationId: xmlTest_example
+     parameters: []
+     requestBody:
+       description: Simple Test xml example
+       content:
+           application/xml:
+              schema:
+               $ref: "#/components/schemas/Test"
+              example:
+                x: should be xml
+     responses:
+       '200':
+         description: Simple Test xml example
+         content: {}
+components:
+  schemas:
+    Test:
+      type: object
+      xml:
+        name: root
+      properties:
+        x:
+          type: string
+        other:
+          type: string
+          format: email
+      example:
+        x: what the f

--- a/test/e2e-cypress/tests/bugs/6475.js
+++ b/test/e2e-cypress/tests/bugs/6475.js
@@ -1,0 +1,65 @@
+describe("#6475: 'Examples' keyword definitions can not be rendered as xml", () => {
+  it("should render requestBody examples preview accourdingly to content-type xml", () => {
+    const xmlIndicator = "<x>should be xml</x>"
+
+    cy
+      .visit("?url=/documents/bugs/6475.yaml")
+      .get("#operations-default-xmlTest_examples")
+      .click()
+      .get(".opblock-section-request-body")
+      .within(() => {
+        cy
+          .get(".microlight")
+          .should("include.text", xmlIndicator)
+      })
+  })
+  it("should requestBody examples input accourdingly to content-type xml", () => {
+    const xmlIndicator = "<x>should be xml</x>"
+
+    cy
+      .visit("?url=/documents/bugs/6475.yaml")
+      .get("#operations-default-xmlTest_examples")
+      .click()
+      .get(".btn.try-out__btn")
+      .click()
+      .get(".opblock-section-request-body")
+      .within(() => {
+        cy
+          .get("textarea")
+          .contains(xmlIndicator)
+      })
+  })
+})
+
+describe("#6475: 'Example' keyword definitions can not be rendered as xml", () => {
+  it("should render requestBody examples preview accourdingly to content-type xml", () => {
+    const xmlIndicator = "<x>should be xml</x>"
+
+    cy
+      .visit("?url=/documents/bugs/6475.yaml")
+      .get("#operations-default-xmlTest_example")
+      .click()
+      .get(".opblock-section-request-body")
+      .within(() => {
+        cy
+          .get(".microlight")
+          .should("include.text", xmlIndicator)
+      })
+  })
+  it("should requestBody examples input accourdingly to content-type xml", () => {
+    const xmlIndicator = "<x>should be xml</x>"
+
+    cy
+      .visit("?url=/documents/bugs/6475.yaml")
+      .get("#operations-default-xmlTest_example")
+      .click()
+      .get(".btn.try-out__btn")
+      .click()
+      .get(".opblock-section-request-body")
+      .within(() => {
+        cy
+          .get("textarea")
+          .contains(xmlIndicator)
+      })
+  })
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Request Body samples do not respect the media type selected.
It just stringifies the json representation of the sample provided via `examples` or `example` keyword.
It should use the `getSampleSchema` method, which does take care of the content-type // media-type.



### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->



### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Fixes #6475 


### Screenshots (if appropriate):
see #6475 


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
