### PR TITLE
feat(ux): Disabled Execute button while request is in progress

### DIFF
--- a/src/core/components/execute.jsx
+++ b/src/core/components/execute.jsx
@@ -11,7 +11,8 @@ export default class Execute extends Component {
     method: PropTypes.string.isRequired,
     oas3Selectors: PropTypes.object.isRequired,
     oas3Actions: PropTypes.object.isRequired,
-    onExecute: PropTypes.func
+    onExecute: PropTypes.func,
+    disabled: PropTypes.bool
   }
 
   handleValidateParameters = () => {
@@ -24,7 +25,7 @@ export default class Execute extends Component {
     let { path, method, specSelectors, oas3Selectors, oas3Actions } = this.props
     let validationErrors = {
       missingBodyValue: false,
-      missingRequiredKeys: [] 
+      missingRequiredKeys: []
     }
     // context: reset errors, then (re)validate
     oas3Actions.clearRequestBodyValidateError({ path, method })
@@ -92,8 +93,9 @@ export default class Execute extends Component {
   onChangeProducesWrapper = ( val ) => this.props.specActions.changeProducesValue([this.props.path, this.props.method], val)
 
   render(){
+    const { disabled } = this.props
     return (
-        <button className="btn execute opblock-control__btn" onClick={ this.onClick }>
+        <button className="btn execute opblock-control__btn" onClick={ this.onClick } disabled={disabled}>
           Execute
         </button>
     )

--- a/src/core/components/operation.jsx
+++ b/src/core/components/operation.jsx
@@ -198,7 +198,8 @@ export default class Operation extends PureComponent {
                     oas3Actions={ oas3Actions }
                     path={ path }
                     method={ method }
-                    onExecute={ onExecute } />
+                    onExecute={ onExecute }
+                    disabled={executeInProgress}/>
               }
 
               { (!tryItOutEnabled || !response || !allowTryItOut) ? null :


### PR DESCRIPTION
Avoid sending multiple request while old is in progress

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Avoid sending multiple request while old is in progress.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes #6771

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Browser

### Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/11584315/103849907-3a6dce00-50a6-11eb-9117-138757a46c4c.png)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
