### PR TITLE
fix(sample-gen): should return xml literal example

### DIFF
--- a/src/core/plugins/samples/fn.js
+++ b/src/core/plugins/samples/fn.js
@@ -214,6 +214,9 @@ export const sampleFromSchemaGeneric = (schema, config={}, exampleOverride = und
     // generate xml sample recursively for array case
     if(type === "array") {
       if (!Array.isArray(sample)) {
+        if(typeof sample === "string") {
+          return sample
+        }
         sample = [sample]
       }
       const itemSchema = schema
@@ -239,6 +242,10 @@ export const sampleFromSchemaGeneric = (schema, config={}, exampleOverride = und
 
     // generate xml sample recursively for object case
     if(type === "object") {
+      // case literal example
+      if(typeof sample === "string") {
+        return sample
+      }
       for (let propName in sample) {
         if (!sample.hasOwnProperty(propName)) {
           continue
@@ -382,7 +389,9 @@ export const inferSchema = (thing) => {
 export const createXMLExample = (schema, config, o) => {
   const json = sampleFromSchemaGeneric(schema, config, o, true)
   if (!json) { return }
-
+  if(typeof json === "string") {
+    return json
+  }
   return XML(json, { declaration: true, indent: "\t" })
 }
 

--- a/test/unit/core/plugins/samples/fn.js
+++ b/test/unit/core/plugins/samples/fn.js
@@ -1115,6 +1115,27 @@ describe("createXMLExample", function () {
 
       expect(sut(definition, {}, [{ notalien: "test" }])).toEqual(expected)
     })
+    it("should return literal example", () => {
+      let expected = "<notaliens>\n\t\n\t<dog>0</dog>\n</notaliens>"
+      let definition = {
+        type: "array",
+        items: {
+          properties: {
+            alien: {
+              type: "string"
+            },
+            dog: {
+              type: "integer"
+            }
+          }
+        },
+        xml: {
+          name: "aliens"
+        }
+      }
+
+      expect(sut(definition, {}, expected)).toEqual(expected)
+    })
 })
 
   describe("object", function () {
@@ -1561,6 +1582,25 @@ describe("createXMLExample", function () {
       }
 
       expect(sut(definition, {}, { alien: "test", dog: 1 })).toEqual(expected)
+    })
+    it("should return literal example", () => {
+      let expected = "<notaliens>\n\t\n\t<dog>0</dog>\n</notaliens>"
+      let definition = {
+        type: "object",
+        properties: {
+          alien: {
+            type: "string"
+          },
+          dog: {
+            type: "integer"
+          }
+        },
+        xml: {
+          name: "aliens"
+        }
+      }
+
+      expect(sut(definition, {}, expected)).toEqual(expected)
     })
   })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

A string example for an XML schema should be returned as provided.
In `sampleFromSchemaGeneric` added in case xml object schema the conditional return for the string example.
Added in `createXMLExample` the conditional return for the string example.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes #6818

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

added unit test to ensure literal example is returned as is.


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
