### PR TITLE
fix(rendering): components should rely on getSampleSchema utility

### DIFF
--- a/test/unit/components/parameter-row.jsx
+++ b/test/unit/components/parameter-row.jsx
@@ -15,7 +15,8 @@ describe("<ParameterRow/>", () => {
     param,
     rawParam: param,
     pathMethod: [],
-    getConfigs: () => ({})
+    getConfigs: () => ({}),
+    onChange: () => {}
   })
 
   it("Can render Swagger 2 parameter type with format", () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Reduces global inconsistency of displaying schema samples(see #6470).
@shockey Maybe you can have a look at this PR and tell if you have added tests for the replaced code of #5571 [in lines](https://github.com/swagger-api/swagger-ui/blob/master/src/core/components/parameter-row.jsx#L153-L173) so i can safely remove them.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes #6791

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

do we need additional tests here?

### Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/11584315/104370058-9b6e2980-551e-11eb-9117-72481a2cf526.png)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
