### PR TITLE
feat(docker): add docker support for persist authorization variable

### DIFF
--- a/docker/configurator/variables.js
+++ b/docker/configurator/variables.js
@@ -79,6 +79,10 @@ const standardVariables = {
     type: "string",
     name: "oauth2RedirectUrl"
   },
+  PERSIST_AUTHORIZATION: {
+    type: "boolean",
+    name: "persistAuthorization"
+  },
   SHOW_MUTATED_REQUEST: {
     type: "boolean",
     name: "showMutatedRequest"

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -89,7 +89,7 @@ Parameter name | Docker variable | Description
 
 Parameter name | Docker variable | Description
 --- | --- | -----
-<a name="persistAuthorization"></a>`persistAuthorization` | _Unavailable_ | `Boolean=false`. If set to `true`, it persists authorization data and it would not be lost on browser close/refresh
+<a name="persistAuthorization"></a>`persistAuthorization` | `PERSIST_AUTHORIZATION` | `Boolean=false`. If set to `true`, it persists authorization data and it would not be lost on browser close/refresh
 
 ### Instance methods
 


### PR DESCRIPTION
### Description
After adding persistAuthorization configuration in #5939, there was a request to add it as a docker environment variable. This pull requests adds docker support for this variable as `PERSIST_AUTHORIZATION`.


### Motivation and Context
It adds docker support to `persistAuthorization` configuration parameter.


### How Has This Been Tested?
All tests had been added in #5939. This one was only tested by building and running swagger's docker container and see if this functionality works correctly by running `docker run -e PERSIST_AUTHORIZATION=true swagger`.


## Checklist

### My PR contains... 
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [x] My changes require a change to the project documentation.
- [x] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
