### PR TITLE
fix(buildUrl): relative url is invalid URL (OAS3) or non-url (OAS2)

### DIFF
--- a/src/core/utils/url.js
+++ b/src/core/utils/url.js
@@ -3,21 +3,25 @@ export function isAbsoluteUrl(url) {
 }
 
 export function addProtocol(url) {
-  if(!url.match(/^\/\//i)) return url // Checks if protocol is missing e.g. //example.com
+  if (!url.match(/^\/\//i)) return url // Checks if protocol is missing e.g. //example.com
+
   return `${window.location.protocol}${url}`
 }
 
 export function buildBaseUrl(selectedServer, specUrl) {
-  if(!selectedServer) return specUrl
-  if(isAbsoluteUrl(selectedServer)) return addProtocol(selectedServer)
-  
+  if (!selectedServer) return specUrl
+  if (isAbsoluteUrl(selectedServer)) return addProtocol(selectedServer)
+
   return new URL(selectedServer, specUrl).href    
 }
 
-export function buildUrl(url, specUrl, { selectedServer="" } = {}) {  
-  if(!url) return
-  if(isAbsoluteUrl(url)) return url
+export function buildUrl(url, specUrl, { selectedServer="" } = {}) {
+  if (!url) return
+  if (isAbsoluteUrl(url)) return url
 
   const baseUrl = buildBaseUrl(selectedServer, specUrl)
+  if (!isAbsoluteUrl(baseUrl)) {
+    return new URL(url, window.location.href).href
+  }
   return new URL(url, baseUrl).href
 }

--- a/test/unit/core/utils.js
+++ b/test/unit/core/utils.js
@@ -39,6 +39,7 @@ import {
 } from "core/utils/url"
 
 import win from "core/window"
+import { afterAll, beforeAll, expect, jest } from "@jest/globals"
 
 describe("utils", () => {
 
@@ -1389,6 +1390,17 @@ describe("utils", () => {
   })
 
   describe("buildUrl", () => {
+    const { location } = window
+    beforeAll(() => {
+      delete window.location
+      window.location = {
+        href: "http://localhost/",
+      }
+    })
+    afterAll(() => {
+      window.location = location
+    })
+
     const specUrl = "https://petstore.swagger.io/v2/swagger.json"
 
     const noUrl = ""
@@ -1400,6 +1412,9 @@ describe("utils", () => {
     const absoluteServerUrl = "https://server-example.com/base-path/path"
     const serverUrlRelativeToBase = "server-example/base-path/path"
     const serverUrlRelativeToHost = "/server-example/base-path/path"
+
+    const specUrlAsInvalidUrl = "./examples/test.yaml"
+    const specUrlOas2NonUrlString = "an allowed OAS2 TermsOfService description string"
 
     it("build no url", () => {
       expect(buildUrl(noUrl, specUrl, { selectedServer: absoluteServerUrl })).toBe(undefined)
@@ -1431,6 +1446,14 @@ describe("utils", () => {
     it("build relative url with server url relative to host", () => {
       expect(buildUrl(urlRelativeToBase, specUrl, { selectedServer: serverUrlRelativeToHost })).toBe("https://petstore.swagger.io/server-example/base-path/relative-url/base-path/path")
       expect(buildUrl(urlRelativeToHost, specUrl, { selectedServer: serverUrlRelativeToHost })).toBe("https://petstore.swagger.io/relative-url/base-path/path")
+    })
+
+    it("build relative url when no servers defined AND specUrl is invalid Url", () => {
+      expect(buildUrl(urlRelativeToHost, specUrlAsInvalidUrl, { selectedServer: noServerSelected })).toBe("http://localhost/relative-url/base-path/path")
+    })
+
+    it("build relative url when no servers defined AND specUrl is OAS2 non-url string", () => {
+      expect(buildUrl(urlRelativeToHost, specUrlOas2NonUrlString, { selectedServer: noServerSelected })).toBe("http://localhost/relative-url/base-path/path")
     })
   })
 


### PR DESCRIPTION
* OAS3: relative url when no servers defined AND specUrl is invalid Url

* OAS2: specUrl is non-url string

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Add support in the cases where `specUrl` is not part of a valid URL string. The URL() method was returning an "Invalid baseURL" response. If 'baseURL' is not a valid URL, substitute browser's own location instead.

OAS3: relative url is invalid URL, AND no servers defined. Config per reported issue
OAS2: Terms of Service is not required to be a URL.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes #6863
Closes https://github.com/swagger-api/swagger-ui/pull/6788

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Browser and Jest unit tests

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
