### PR TITLE
fix(sample-gen): case yaml parsed example is number but string schema

### DIFF
--- a/src/core/plugins/samples/fn.js
+++ b/src/core/plugins/samples/fn.js
@@ -203,8 +203,12 @@ export const sampleFromSchemaGeneric = (schema, config={}, exampleOverride = und
 
     // if json just return
     if(!respectXML) {
+      // spacial case yaml parser can not know about
+      if(typeof sample === "number" && type === "string") {
+        return `${sample}`
+      }
       // return if sample does not need any parsing
-      if(typeof sample !== "string") {
+      if(typeof sample !== "string" || type === "string") {
         return sample
       }
       // check if sample is parsable or just a plain string

--- a/test/unit/core/utils.js
+++ b/test/unit/core/utils.js
@@ -1582,6 +1582,42 @@ describe("utils", () => {
       expect(actual.test).toEqual(123)
     })
 
+    it("should handle number example with string schema as string", () => {
+      // Given
+      const expected = 123
+      const res = getSampleSchema({
+        type: "string",
+      }, "text/json", {}, expected)
+
+      // Then
+      const actual = JSON.parse(res)
+      expect(actual).toEqual("123")
+    })
+
+    it("should handle number literal example with string schema as string", () => {
+      // Given
+      const expected = "123"
+      const res = getSampleSchema({
+        type: "string",
+      }, "text/json", {}, expected)
+
+      // Then
+      const actual = JSON.parse(res)
+      expect(actual).toEqual("123")
+    })
+
+    it("should handle number literal example with number schema as number", () => {
+      // Given
+      const expected = "123"
+      const res = getSampleSchema({
+        type: "number",
+      }, "text/json", {}, expected)
+
+      // Then
+      const actual = JSON.parse(res)
+      expect(actual).toEqual(123)
+    })
+
     it("should return yaml example if yaml is contained in the content-type", () => {
       const res = getSampleSchema({
         type: "object",


### PR DESCRIPTION
Fixes #6827:

https://gist.githubusercontent.com/mathis-m/6ccf292b5560fc09f50e52f2ad0f1e23/raw/f8b16efb750879d279e1c1fb3fffdb521b6dcad0/rxx6ldSupt.txt
![image](https://user-images.githubusercontent.com/11584315/106049880-effcd180-60e6-11eb-8e22-58fecd8012d0.png)

_Originally posted by @smagafurov in https://github.com/swagger-api/swagger-ui/issues/6827#issuecomment-768512523_
