### PR TITLE
Replace info component check for externalDocs to use externalDocsUrl

### DIFF
--- a/src/core/components/info.jsx
+++ b/src/core/components/info.jsx
@@ -148,7 +148,7 @@ export default class Info extends React.Component {
 
         {contact && contact.size ? <Contact getComponent={getComponent} data={ contact } selectedServer={selectedServer} url={url} /> : null }
         {license && license.size ? <License getComponent={getComponent} license={ license } selectedServer={selectedServer} url={url}/> : null }
-        { externalDocs ?
+        { externalDocsUrl ?
             <Link className="info__extdocs" target="_blank" href={sanitizeUrl(externalDocsUrl)}>{externalDocsDescription || externalDocsUrl}</Link>
         : null }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
This change modifies the logic check for displaying the external documentation link in the `Info` component to now check the `externalDocsUrl` variable instead of the `externalDocs` variable. 

### Motivation and Context
Fixes #6975 

This change is necessary to prevent the rendering of the `Link` component when there is no external documentation link provided. This is causing an accessibility issue as links are being rendered without associated URLs.

Currently, `externalDocs` is checked [here](https://github.com/swagger-api/swagger-ui/blob/master/src/core/components/info.jsx#L151-L153), so if `externalDocs` is truthy, then the `Link` component is rendered. However, `externalDocs` is always a truthy value. This is because even when `externalDocs` is not defined in the given API object, it is assigned `new Map()` [here](https://github.com/swagger-api/swagger-ui/blob/master/src/core/plugins/spec/selectors.js#L97-L100), which is a truthy value. My solution is to check `externalDocsUrl` instead, which is already pulled from `externalDocs`, as this is the actual value being displayed in the `Link` component.

Previously, `externalDocsUrl` was used here instead of `externalDocs`. From what I can tell, the change was made [here](https://github.com/swagger-api/swagger-ui/commit/d9f5691f657dc64842b892255fe4a67cb6246f1b#diff-2fd46510664042c900888b49b652478d9fb450bba334bfc6eb2e110bcd6c1f32L141-R151), but I am not sure if there was a specific reason for changing this logic. I see no issue in returning to checking `externalDocsUrl` as this is a variable already being assigned and the primary subject of the rendered `Link` component.

### How Has This Been Tested?
This was identified and tested using our implementation in the Department of Veteran Affair's [developer portal](https://github.com/department-of-veterans-affairs/developer-portal) repository. We were upgrading our version of `swagger-ui`  to the latest and noticed failing accessibility tests due to links being rendered without URLs in places where no `externalDocs` object was provided in the API object. Conversely, in places where the `externalDocs` object was provided, the link was rendered as expected. 

Without our accessibility tests, we wouldn't have been able to identify this issue because links were visually being shown when provided and not shown when not provided. The issue was, as explained, that the `Link` object was still being rendered even when no link was provided, which causes issues with screen readers. 

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
