### PR TITLE
feat: basic hierarchical-tags plugin

### DIFF
--- a/src/core/index.js
+++ b/src/core/index.js
@@ -53,6 +53,8 @@ export default function SwaggerUI(opts) {
     showExtensions: false,
     showCommonExtensions: false,
     withCredentials: undefined,
+    hierarchicalTagsEnabled: true, // TODO: switch to false
+    hierarchicalTagDelimiter: "|",
     supportedSubmitMethods: [
       "get",
       "put",
@@ -107,6 +109,10 @@ export default function SwaggerUI(opts) {
       spec: {
         spec: "",
         url: constructorConfig.url
+      },
+      hierarchicalTags: {
+        enabled: constructorConfig.hierarchicalTagsEnabled,
+        delimiter: constructorConfig.hierarchicalTagDelimiter
       }
     }, constructorConfig.initialState)
   }

--- a/src/core/plugins/hierarchical-tags/index.js
+++ b/src/core/plugins/hierarchical-tags/index.js
@@ -1,0 +1,11 @@
+import spec from "./spec-extension"
+import * as selectors from "./selectors"
+
+export default () => ({
+  statePlugins: {
+    hierarchicalTags: {
+      selectors
+    },
+    spec
+  }
+})

--- a/src/core/plugins/hierarchical-tags/selectors.js
+++ b/src/core/plugins/hierarchical-tags/selectors.js
@@ -1,0 +1,14 @@
+import { createSelector } from "reselect"
+import { Map } from "immutable"
+
+const state = state => state || Map()
+
+export const isEnabled = createSelector(
+  state,
+  state => state.get("enabled", false)
+)
+
+export const getTagDelimiter = createSelector(
+  state,
+  state => state.get( "delimiter", "|")
+)

--- a/src/core/plugins/hierarchical-tags/spec-extension/index.js
+++ b/src/core/plugins/hierarchical-tags/spec-extension/index.js
@@ -1,0 +1,6 @@
+import * as selectors from "./selectors"
+import * as wrapSelectors from "./wrap-selectors"
+export default {
+  selectors,
+  wrapSelectors
+}

--- a/src/core/plugins/hierarchical-tags/spec-extension/selectors.js
+++ b/src/core/plugins/hierarchical-tags/spec-extension/selectors.js
@@ -1,0 +1,55 @@
+import { taggedOperations } from "../../spec/selectors"
+import { OrderedMap } from "immutable"
+
+export const hierarchicalTaggedOperations = (state) => (system) => {
+  system = system.getSystem()
+  const delimiter = system.hierarchicalTagsSelectors.getTagDelimiter()
+  const filter = system.layoutSelectors.currentFilter()
+
+  let taggedOperationsMap = taggedOperations(state)(system)
+
+  if (filter) {
+    if (filter !== true && filter !== "true" && filter !== "false") {
+      taggedOperationsMap = system.fn.opsFilter(taggedOperationsMap, filter)
+    }
+  }
+
+  let hierarchicalTaggedOperations = OrderedMap()
+
+  const addTagIn = (nestedTagPath, value) => {
+    value = value.set("tags", OrderedMap())
+    const visitedTags = []
+    let currentTag = nestedTagPath.shift()
+    while(currentTag !== undefined) {
+      const isRootTag = visitedTags.length === 0
+      const isNewRootTag = isRootTag && !hierarchicalTaggedOperations.has(currentTag)
+
+      if(isNewRootTag) {
+        hierarchicalTaggedOperations = hierarchicalTaggedOperations.set(
+          currentTag,
+          value
+        )
+        visitedTags.push(currentTag)
+        currentTag = nestedTagPath.shift()
+        continue
+      }
+
+      const hierarchicalUpdatePath = visitedTags
+        .reduce((acc, x) => acc.concat([x, "tags"]), [])
+      hierarchicalUpdatePath.push(currentTag)
+
+      hierarchicalTaggedOperations = hierarchicalTaggedOperations.mergeDeepIn(
+        hierarchicalUpdatePath,
+        nestedTagPath.length === 0 ? value : OrderedMap({tags: OrderedMap()})
+      )
+
+      visitedTags.push(currentTag)
+      currentTag = nestedTagPath.shift()
+    }
+  }
+
+  taggedOperationsMap.forEach((v, k) => {
+    addTagIn(k.split(delimiter), v)
+  })
+  return hierarchicalTaggedOperations
+}

--- a/src/core/plugins/hierarchical-tags/spec-extension/wrap-selectors.js
+++ b/src/core/plugins/hierarchical-tags/spec-extension/wrap-selectors.js
@@ -1,0 +1,8 @@
+export const taggedOperations = (oriSelector, system) => (...args) => {
+  const { hierarchicalTagsSelectors, specSelectors } = system.getSystem()
+  if(!hierarchicalTagsSelectors.isEnabled()) {
+    return oriSelector(...args)
+  }
+
+  return specSelectors.hierarchicalTaggedOperations()
+}

--- a/src/core/presets/base.js
+++ b/src/core/presets/base.js
@@ -12,6 +12,7 @@ import configsPlugin from "core/plugins/configs"
 import deepLinkingPlugin from "core/plugins/deep-linking"
 import filter from "core/plugins/filter"
 import onComplete from "core/plugins/on-complete"
+import hierarchicalTags from "core/plugins/hierarchical-tags"
 
 import OperationContainer from "core/containers/OperationContainer"
 
@@ -191,6 +192,7 @@ export default function() {
     downloadUrlPlugin,
     deepLinkingPlugin,
     filter,
-    onComplete
+    onComplete,
+    hierarchicalTags
   ]
 }


### PR DESCRIPTION
added basic integration into swagger-ui ecosystem
Logic will be improved when we have recursive rendering in place.

plugin will be enabled on default

this should just render the root tag because recursive rendering is not in place:
http://localhost:3200/?url=https://gist.githubusercontent.com/mathis-m/447872fc1103d809faf7b5e46af6af76/raw/9b1aa4657026c891e81fb123be8425351f3a85a2/HierarchicalTagsPlugin.yaml

