### PR TITLE
Fix #7052 circular reference

### DIFF
--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -51,7 +51,7 @@ export function arrayify (thing) {
 }
 
 export function fromJSOrdered(js) {
-  return fromJSOrderedWith(js,[]);
+  return fromJSOrderedWith(js,[])
 }
 
 function fromJSOrderedWith(js,stack) {
@@ -66,10 +66,10 @@ function fromJSOrderedWith(js,stack) {
   }
   // if this is a circular reference, return an empty representation instead
   if (~stack.indexOf(js)) {
-    return Array.isArray(js) ? new Im.List() : new Im.Map();
+    return Array.isArray(js) ? new Im.List() : new Im.Map()
   }
   
-  stack.push(js);
+  stack.push(js)
 
   if (Array.isArray(js)) {
     return Im.Seq(js).map((i) => fromJSOrderedWith(i,stack)).toList()
@@ -82,9 +82,9 @@ function fromJSOrderedWith(js,stack) {
 
   let result = Im.OrderedMap(js).map((i) => fromJSOrderedWith(i,stack))
 
-  stack.pop();
+  stack.pop()
   
-  return result;
+  return result
 }
 
 /**

--- a/test/unit/core/utils.js
+++ b/test/unit/core/utils.js
@@ -1037,7 +1037,7 @@ describe("utils", () => {
       const param = {
         value: "test"
       }
-      param.circular = param;
+      param.circular = param
 
       const result = fromJSOrdered(param).toJS()
       expect( result ).toEqual( { value: "test", circular: {} } )
@@ -1047,7 +1047,7 @@ describe("utils", () => {
       const param = [
         { value: "test"}
       ]
-      param[0].circular = param;
+      param[0].circular = param
 
       const result = fromJSOrdered(param).toJS()
       expect( result ).toEqual( [ { value: "test", circular: [] } ] )

--- a/test/unit/core/utils.js
+++ b/test/unit/core/utils.js
@@ -1032,6 +1032,26 @@ describe("utils", () => {
       const result = fromJSOrdered(param).toJS()
       expect( result ).toEqual( [1, 1, 2, 3, 5, 8] )
     })
+
+    it("should replace circular object references", () => {
+      const param = {
+        value: "test"
+      }
+      param.circular = param;
+
+      const result = fromJSOrdered(param).toJS()
+      expect( result ).toEqual( { value: "test", circular: {} } )
+    })
+
+    it("should replace circular array references", () => {
+      const param = [
+        { value: "test"}
+      ]
+      param[0].circular = param;
+
+      const result = fromJSOrdered(param).toJS()
+      expect( result ).toEqual( [ { value: "test", circular: [] } ] )
+    })
   })
 
   describe("getAcceptControllingResponse", () => {


### PR DESCRIPTION
Fixes #7052 by removing processing of circular references

### Description
Updated fromJSOrdered to handle circular references using the same implementation as "fromJS" in the "immutable-js" library: https://github.com/immutable-js/immutable-js/blob/master/src/fromJS.js

Rather than throw an error as "fromJS" does, this fix represents the circular reference with a Map or List depending on whether it's an array or object.  

### Motivation and Context
Fixes #7052

### How Has This Been Tested?
Added new unit tests and manually tested against the definition provided #7052 as well as my own circular reference case.

### Screenshots (if appropriate):

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
