### PR TITLE
fix(lint): cumulative lint fixes prep for eslint@7

### DIFF
--- a/src/core/components/layout-utils.jsx
+++ b/src/core/components/layout-utils.jsx
@@ -56,7 +56,7 @@ export class Col extends React.Component {
     let classesAr = []
 
     for (let device in DEVICES) {
-      if (!DEVICES.hasOwnProperty(device)) {
+      if (!Object.prototype.hasOwnProperty.call(DEVICES, device)) {
         continue
       }
       let deviceClass = DEVICES[device]

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -141,7 +141,7 @@ export default function SwaggerUI(opts) {
     // known usage: Swagger-Editor validate plugin tests
     for (var key in constructorConfig.initialState) {
       if(
-        constructorConfig.initialState.hasOwnProperty(key)
+        Object.prototype.hasOwnProperty.call(constructorConfig.initialState, key)
         && constructorConfig.initialState[key] === undefined
       ) {
         delete storeConfigs.state[key]

--- a/src/core/plugins/download-url.js
+++ b/src/core/plugins/download-url.js
@@ -1,5 +1,3 @@
-/* global Promise */
-
 import { createSelector } from "reselect"
 import { Map } from "immutable"
 import win from "../window"

--- a/src/core/plugins/samples/fn.js
+++ b/src/core/plugins/samples/fn.js
@@ -76,7 +76,7 @@ const liftSampleHelper = (oldSchema, target, config = {}) => {
     }
     let props = objectify(oldSchema.properties)
     for (let propName in props) {
-      if (!props.hasOwnProperty(propName)) {
+      if (!Object.prototype.hasOwnProperty.call(props, propName)) {
         continue
       }
       if ( props[propName] && props[propName].deprecated ) {
@@ -133,7 +133,7 @@ export const sampleFromSchemaGeneric = (schema, config={}, exampleOverride = und
       }
       let props = objectify(schemaToAdd.properties)
       for (let propName in props) {
-        if (!props.hasOwnProperty(propName)) {
+        if (!Object.prototype.hasOwnProperty.call(props, propName)) {
           continue
         }
         if ( props[propName] && props[propName].deprecated ) {
@@ -386,7 +386,7 @@ export const sampleFromSchemaGeneric = (schema, config={}, exampleOverride = und
         return sample
       }
       for (let propName in sample) {
-        if (!sample.hasOwnProperty(propName)) {
+        if (!Object.prototype.hasOwnProperty.call(sample, propName)) {
           continue
         }
         if (schema && props[propName] && props[propName].readOnly && !includeReadOnly) {
@@ -416,7 +416,7 @@ export const sampleFromSchemaGeneric = (schema, config={}, exampleOverride = und
 
   if(type === "object") {
     for (let propName in props) {
-      if (!props.hasOwnProperty(propName)) {
+      if (!Object.prototype.hasOwnProperty.call(props, propName)) {
         continue
       }
       if ( props[propName] && props[propName].deprecated ) {

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -688,7 +688,7 @@ export const parseSearch = () => {
     let params = search.substr(1).split("&")
 
     for (let i in params) {
-      if (!params.hasOwnProperty(i)) {
+      if (!Object.prototype.hasOwnProperty.call(params, i)) {
         continue
       }
       i = params[i].split("=")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

cumulative linting fixes, mostly around this rule: https://eslint.org/docs/rules/no-prototype-builtins

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Major version update from eslint@4.x to eslint@7.x introduced new linting errors.

Closes #7071 , where the lint fixes are in this PR, with separate PR(s) for dependency updates

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`npm run lint-errors` passes locally with current `eslint@4.x` as well as upcoming `eslint@7.x`

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
