### PR TITLE
Include description of oauth endpoints when parsing openapi

### DIFF
--- a/src/core/plugins/oas3/auth-extensions/wrap-selectors.js
+++ b/src/core/plugins/oas3/auth-extensions/wrap-selectors.js
@@ -43,7 +43,8 @@ export const definitionsToAuthorize = onlyOAS3(createSelector(
               authorizationUrl: flowVal.get("authorizationUrl"),
               tokenUrl: flowVal.get("tokenUrl"),
               scopes: flowVal.get("scopes"),
-              type: definition.get("type")
+              type: definition.get("type"),
+              description: definition.get("description")
             })
 
             list = list.push(new Map({

--- a/test/unit/core/plugins/oas3/wrap-auth-selectors.js
+++ b/test/unit/core/plugins/oas3/wrap-auth-selectors.js
@@ -21,6 +21,7 @@ describe("oas3 plugin - auth extensions - wrapSelectors", function(){
             return fromJS({
               "oauth2AuthorizationCode": {
                 "type": "oauth2",
+                "description": "Some Oauth2 endpoint",
                 "flows": {
                   "authorizationCode": {
                     "authorizationUrl": "http://google.com/",
@@ -105,7 +106,8 @@ describe("oas3 plugin - auth extensions - wrapSelectors", function(){
             scopes: {
               "myScope": "our only scope"
             },
-            type: "oauth2"
+            type: "oauth2",
+            description: "Some Oauth2 endpoint"
           }
         },
         {
@@ -201,7 +203,7 @@ describe("oas3 plugin - auth extensions - wrapSelectors", function(){
           //   OPTIONAL. JSON array containing a list of the OAuth 2.0 Grant Type values that
           //   this OP supports. Dynamic OpenID Providers MUST support the authorization_code
           //   and implicit Grant Type values and MAY support other Grant Types. If omitted,
-          //   the default value is ["authorization_code", "implicit"]. 
+          //   the default value is ["authorization_code", "implicit"].
           oidcNoGrant: {
             flow: "authorization_code",
             authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",


### PR DESCRIPTION
Fixes #5230 

### Description

This will display the description of oauth endpoints in the authorize dialog.

### Motivation and Context
It was just missing, probably a bug / never tested.

### How Has This Been Tested?
Tested against an OpenAPI definition created by spring + modified unit test to cover it.

### Screenshot

![Screenshot](https://user-images.githubusercontent.com/5981823/115269465-a1862e80-a13b-11eb-8176-c84d2af8804a.png)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
