### PR TITLE
fix(syntaxHighlighter): request and response examples for json cases

### DIFF
--- a/src/core/components/param-body.jsx
+++ b/src/core/components/param-body.jsx
@@ -2,6 +2,7 @@ import React, { PureComponent } from "react"
 import PropTypes from "prop-types"
 import { fromJS, List } from "immutable"
 import { getSampleSchema } from "core/utils"
+import { getKnownSyntaxHighlighterLanguage } from "core/utils/jsonParse"
 
 const NOOP = Function.prototype
 
@@ -113,14 +114,9 @@ export default class ParamBody extends PureComponent {
 
     let { value, isEditBox } = this.state
     let language = null
-
-    try {
-      let testValueForJson = JSON.parse(value)
-      if (testValueForJson) {
-        language = "json"
-      }
-    } catch(e) {
-      // do nothing
+    let testValueForJson = getKnownSyntaxHighlighterLanguage(value)
+    if (testValueForJson) {
+      language = "json"
     }
 
     return (

--- a/src/core/components/param-body.jsx
+++ b/src/core/components/param-body.jsx
@@ -112,6 +112,16 @@ export default class ParamBody extends PureComponent {
     let consumes = this.props.consumes && this.props.consumes.size ? this.props.consumes : ParamBody.defaultProp.consumes
 
     let { value, isEditBox } = this.state
+    let language = null
+
+    try {
+      let testValueForJson = JSON.parse(value)
+      if (testValueForJson) {
+        language = "json"
+      }
+    } catch(e) {
+      // do nothing
+    }
 
     return (
       <div className="body-param" data-param-name={param.get("name")} data-param-in={param.get("in")}>
@@ -119,8 +129,9 @@ export default class ParamBody extends PureComponent {
           isEditBox && isExecute
             ? <TextArea className={ "body-param__text" + ( errors.count() ? " invalid" : "")} value={value} onChange={ this.handleOnChange }/>
             : (value && <HighlightCode className="body-param__example"
-                               getConfigs={ getConfigs }
-                               value={ value }/>)
+                          language={ language }
+                          getConfigs={ getConfigs }
+                          value={ value }/>)
         }
         <div className="body-param-options">
           {

--- a/src/core/components/response-body.jsx
+++ b/src/core/components/response-body.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types"
 import formatXml from "xml-but-prettier"
 import toLower from "lodash/toLower"
 import { extractFileNameFromContentDispositionHeader } from "core/utils"
+import { getKnownSyntaxHighlighterLanguage } from "core/utils/jsonParse"
 import win from "core/window"
 
 export default class ResponseBody extends React.PureComponent {
@@ -95,9 +96,12 @@ export default class ResponseBody extends React.PureComponent {
     } else if (/json/i.test(contentType)) {
       // JSON
       let language = null
+      let testValueForJson = getKnownSyntaxHighlighterLanguage(content)
+      if (testValueForJson) {
+        language = "json"
+      }
       try {
         body = JSON.stringify(JSON.parse(content), null, "  ")
-        language = "json"
       } catch (error) {
         body = "can't parse JSON.  Raw result:\n\n" + content
       }

--- a/src/core/components/response.jsx
+++ b/src/core/components/response.jsx
@@ -10,8 +10,19 @@ const getExampleComponent = ( sampleResponse, HighlightCode, getConfigs ) => {
   if (
     sampleResponse !== undefined &&
     sampleResponse !== null
-  ) { return <div>
-      <HighlightCode className="example" getConfigs={ getConfigs } value={ stringify(sampleResponse) } />
+  ) {
+    let language = null
+
+    try {
+      let testValueForJson = JSON.parse(sampleResponse)
+      if (testValueForJson) {
+        language = "json"
+      }
+    } catch (e) {
+      // do nothing
+    }
+     return <div>
+      <HighlightCode className="example" getConfigs={ getConfigs } language={language} value={ stringify(sampleResponse) } />
     </div>
   }
   return null

--- a/src/core/components/response.jsx
+++ b/src/core/components/response.jsx
@@ -4,6 +4,7 @@ import ImPropTypes from "react-immutable-proptypes"
 import cx from "classnames"
 import { fromJS, Seq, Iterable, List, Map } from "immutable"
 import { getExtensions, getSampleSchema, fromJSOrdered, stringify } from "core/utils"
+import { getKnownSyntaxHighlighterLanguage } from "core/utils/jsonParse"
 
 
 const getExampleComponent = ( sampleResponse, HighlightCode, getConfigs ) => {
@@ -12,17 +13,12 @@ const getExampleComponent = ( sampleResponse, HighlightCode, getConfigs ) => {
     sampleResponse !== null
   ) {
     let language = null
-
-    try {
-      let testValueForJson = JSON.parse(sampleResponse)
-      if (testValueForJson) {
-        language = "json"
-      }
-    } catch (e) {
-      // do nothing
+    let testValueForJson = getKnownSyntaxHighlighterLanguage(sampleResponse)
+    if (testValueForJson) {
+      language = "json"
     }
-     return <div>
-      <HighlightCode className="example" getConfigs={ getConfigs } language={language} value={ stringify(sampleResponse) } />
+    return <div>
+      <HighlightCode className="example" getConfigs={ getConfigs } language={ language } value={ stringify(sampleResponse) } />
     </div>
   }
   return null

--- a/src/core/plugins/oas3/components/request-body.jsx
+++ b/src/core/plugins/oas3/components/request-body.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types"
 import ImPropTypes from "react-immutable-proptypes"
 import { Map, OrderedMap, List } from "immutable"
 import { getCommonExtensions, getSampleSchema, stringify, isEmptyValue } from "core/utils"
+import { getKnownSyntaxHighlighterLanguage } from "core/utils/jsonParse"
 
 export const getDefaultRequestBodyValue = (requestBody, mediaType, activeExamplesKey) => {
   const mediaTypeValue = requestBody.getIn(["content", mediaType])
@@ -236,14 +237,9 @@ const RequestBody = ({
     activeExamplesKey,
   )
   let language = null
-
-  try {
-    let testValueForJson = JSON.parse(sampleRequestBody)
-    if (testValueForJson) {
-      language = "json"
-    }
-  } catch (e) {
-    // do nothing
+  let testValueForJson = getKnownSyntaxHighlighterLanguage(sampleRequestBody)
+  if (testValueForJson) {
+    language = "json"
   }
 
   return <div>

--- a/src/core/plugins/oas3/components/request-body.jsx
+++ b/src/core/plugins/oas3/components/request-body.jsx
@@ -235,6 +235,16 @@ const RequestBody = ({
     contentType,
     activeExamplesKey,
   )
+  let language = null
+
+  try {
+    let testValueForJson = JSON.parse(sampleRequestBody)
+    if (testValueForJson) {
+      language = "json"
+    }
+  } catch (e) {
+    // do nothing
+  }
 
   return <div>
     { requestBodyDescription &&
@@ -279,6 +289,7 @@ const RequestBody = ({
             <HighlightCode
               className="body-param__example"
               getConfigs={getConfigs}
+              language={language}
               value={stringify(requestBodyValue) || sampleRequestBody}
             />
           }

--- a/src/core/utils/jsonParse.js
+++ b/src/core/utils/jsonParse.js
@@ -1,0 +1,15 @@
+export function canJsonParse(str) {
+  try {
+    let testValueForJson = JSON.parse(str)
+    return testValueForJson ? true : false
+  } catch (e) {
+    // exception: string is not valid json
+    return null
+  }
+}
+
+export function getKnownSyntaxHighlighterLanguage(val) {
+  // to start, only check for json. can expand as needed in future
+  const isValidJson = canJsonParse(val)
+  return isValidJson ? "json" : null
+}

--- a/test/e2e-cypress/static/documents/features/syntax-highlighting-json-oas2.yaml
+++ b/test/e2e-cypress/static/documents/features/syntax-highlighting-json-oas2.yaml
@@ -1,0 +1,97 @@
+swagger: '2.0'
+info:
+  description: sample OAS 2 definition to test syntax highlighting
+  version: 1.0.0
+  title: json syntax highlighting
+host: "localhost:3200"
+basePath: /v1
+schemes:
+  - https
+  - http
+paths:
+  /setServices:
+    post:
+      summary: "simple service"
+      produces:
+      - application/json
+      parameters:
+      - in: body
+        name: body
+        required: true
+        schema:
+         $ref: '#/definitions/setServicesBody' 
+      responses:
+        200:
+          description: OK
+          schema:
+           $ref: '#/definitions/setServicesResponse'
+        404:
+          description: "Page not found"
+definitions:
+  setServicesBody:
+    type: object
+    required:
+      - appid
+      - key
+      - userid
+      - station_objectid
+      - details
+    properties:
+      appid:
+        type: string
+        example: "Website"
+        description: "application ID"
+      userid:
+        type: integer
+        example: "79daf5b4-aa4b-1452-eae5-42c231477ba7"
+        description: "user id available to test"
+      station_objectid:
+        type: string
+        example: "22a124b4-594b-4452-bdf5-fc3ef1477ba7"
+        description: "station id available to test"
+      details:
+        type: array
+        items:
+          type: object
+          properties:
+            station_serviceid:
+              type: integer
+              example: "34"
+              description: "optional service id"
+            name:
+              type: string
+              example: "hooray"
+            amount:
+              type: string
+              example: "0.00"
+            quantity:
+              type: integer
+              example: "999999"
+            date:
+              type: string
+              format: date-time
+              example: "2020-11-12 18:52:29"
+  setServicesResponse:
+    type: object
+    properties:
+      status:
+        type: boolean
+        example: true
+      count:
+        type: boolean
+        example: 1
+      response:
+        type: object
+        properties:
+          status:
+            type: integer
+            example: 200
+          station_serviceid:
+            type: integer
+            example: "3"
+          userid:
+            type: integer
+            example: "5ff06f632bb165394501b05d3a833355"
+          statusId:
+            type: string
+            example: "f0009babde9dbe204540d79cf754408e"

--- a/test/e2e-cypress/static/documents/features/syntax-highlighting-json-oas3.yaml
+++ b/test/e2e-cypress/static/documents/features/syntax-highlighting-json-oas3.yaml
@@ -1,0 +1,94 @@
+openapi: 3.0.1
+info:
+  title: json syntax highlighting
+  description: sample OAS 3 definition to test syntax highlighting
+  version: 1.0.0
+servers:
+- url: https://localhost:3200/v1
+- url: http://localhost:3200/v1
+paths:
+  /setServices:
+    post:
+      summary: simple service
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: '#/components/schemas/setServicesBody'
+        required: true
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/setServicesResponse'
+        404:
+          description: Page not found
+          content: {}
+      x-codegen-request-body-name: body
+components:
+  schemas:
+    setServicesBody:
+      required:
+      - appid
+      - details
+      - station_objectid
+      - userid
+      type: object
+      properties:
+        appid:
+          type: string
+          description: application ID
+          example: Website
+        userid:
+          type: integer
+          description: user id available to test
+        station_objectid:
+          type: string
+          description: station id available to test
+          example: 22a124b4-594b-4452-bdf5-fc3ef1477ba7
+        details:
+          type: array
+          items:
+            type: object
+            properties:
+              station_serviceid:
+                type: integer
+                description: optional service id
+                example: 34
+              name:
+                type: string
+                example: hooray
+              amount:
+                type: string
+                example: "0.00"
+              quantity:
+                type: integer
+                example: 999999
+              date:
+                type: string
+                format: date-time
+    setServicesResponse:
+      type: object
+      properties:
+        status:
+          type: boolean
+          example: true
+        count:
+          type: boolean
+          example: false
+        response:
+          type: object
+          properties:
+            status:
+              type: integer
+              example: 200
+            station_serviceid:
+              type: integer
+              example: 3
+            userid:
+              type: integer
+            statusId:
+              type: string
+              example: f0009babde9dbe204540d79cf754408e

--- a/test/e2e-cypress/tests/features/syntax-highlighting-json.js
+++ b/test/e2e-cypress/tests/features/syntax-highlighting-json.js
@@ -1,24 +1,40 @@
 /**
  * @prettier
  */
-describe("Syntax Highlighting for JSON content", () => {
+describe("Syntax Highlighting for JSON value cases", () => {
   // expect span contains entire string sample
   // fail case is if the string sample gets broken up into segments
-  // due syntax highlighting attempting to escape characters
+  // due react-syntax-highlighter attempting to escape characters into multiple segments
   describe("OAS 2", () => {
-    it("param body: should use json language if content is json", () => {
+    it("should render full syntax highlighted string in Request (param body) example", () => {
       cy.visit("/?url=/documents/features/syntax-highlighting-json-oas2.yaml")
       .get("#operations-default-post_setServices")
       .click()
       .get(".body-param__example > .language-json > :nth-child(10)")
       .should("have.text", "\"79daf5b4-aa4b-1452-eae5-42c231477ba7\"")
     })
-    it("response: should use json language if content is json", () => {
+    it("should render full syntax highlighted string in Response example", () => {
       cy.visit("/?url=/documents/features/syntax-highlighting-json-oas2.yaml")
       .get("#operations-default-post_setServices")
       .click()
       .get(".example > .language-json > :nth-child(28)")
-        .should("have.text", "\"5ff06f632bb165394501b05d3a833355\"") // span contains entire long string
+        .should("have.text", "\"5ff06f632bb165394501b05d3a833355\"")
+    })
+  })
+  describe("OAS 3", () => {
+    it("should render full syntax highlighted string in Request example", () => {
+      cy.visit("/?url=/documents/features/syntax-highlighting-json-oas3.yaml")
+        .get("#operations-default-post_setServices")
+        .click()
+        .get(".body-param__example > .language-json > :nth-child(15)")
+        .should("have.text", "\"22a124b4-594b-4452-bdf5-fc3ef1477ba7\"")
+    })
+    it("should render full syntax highlighted string in Response example", () => {
+      cy.visit("/?url=/documents/features/syntax-highlighting-json-oas3.yaml")
+        .get("#operations-default-post_setServices")
+        .click()
+        .get(".example > .language-json > :nth-child(33)")
+        .should("have.text", "\"f0009babde9dbe204540d79cf754408e\"")
     })
   })
 })

--- a/test/e2e-cypress/tests/features/syntax-highlighting-json.js
+++ b/test/e2e-cypress/tests/features/syntax-highlighting-json.js
@@ -1,0 +1,24 @@
+/**
+ * @prettier
+ */
+describe("Syntax Highlighting for JSON content", () => {
+  // expect span contains entire string sample
+  // fail case is if the string sample gets broken up into segments
+  // due syntax highlighting attempting to escape characters
+  describe("OAS 2", () => {
+    it("param body: should use json language if content is json", () => {
+      cy.visit("/?url=/documents/features/syntax-highlighting-json-oas2.yaml")
+      .get("#operations-default-post_setServices")
+      .click()
+      .get(".body-param__example > .language-json > :nth-child(10)")
+      .should("have.text", "\"79daf5b4-aa4b-1452-eae5-42c231477ba7\"")
+    })
+    it("response: should use json language if content is json", () => {
+      cy.visit("/?url=/documents/features/syntax-highlighting-json-oas2.yaml")
+      .get("#operations-default-post_setServices")
+      .click()
+      .get(".example > .language-json > :nth-child(28)")
+        .should("have.text", "\"5ff06f632bb165394501b05d3a833355\"") // span contains entire long string
+    })
+  })
+})


### PR DESCRIPTION
* OAS 2 request and response examples
* OAS 3 request and response examples

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

* Check for json content across OAS2 and OAS3 request and response examples. If json, apply known "json" language to (syntax highlighter) `HighlightCode` props.
* New utils helper, `jsonParse.js`. Helps with `try/catch` boilerplate with use of `JSON.parse()`

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Extends Fixes #6508 

If `json` language is not provided, react-syntax-highlighter may try to escape certain character and/or long strings into multiple string segments. This results in unexpected multi-color render within the desired string.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

New Cypress tests with OAS2 and OAS3 samples. Note, the fail case would be instead of a single string within a single `<span>`, a broken example would have the string broken up into segments, each contained within its own `<span>`

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
