### PR TITLE
fix: required properties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24194,9 +24194,9 @@
       "dev": true
     },
     "open": {
-      "version": "8.0.6",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.0.6.tgz",
-      "integrity": "sha512-vDOC0KwGabMPFtIpCO2QOnQeOz0N2rEkbuCuxICwLMUCrpv+A7NHrrzJ2dQReJmVluHhO4pYRh/Pn6s8t7Op6Q==",
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.0.7.tgz",
+      "integrity": "sha512-qoyG0kpdaWVoL5MiwTRQWujSdivwBOgfLadVEdpsZNHOK1+kBvmVtLYdgWr8G4cgBpG9zaxezn6jz6PPdQW5xg==",
       "dev": true,
       "requires": {
         "define-lazy-prop": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11738,9 +11738,9 @@
       }
     },
     "dompurify": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.7.tgz",
-      "integrity": "sha512-jdtDffdGNY+C76jvodNTu9jt5yYj59vuTUyx+wXdzcSwAGTYZDAQkQ7Iwx9zcGrA4ixC1syU4H3RZROqRxokxg=="
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.8.tgz",
+      "integrity": "sha512-9H0UL59EkDLgY3dUFjLV6IEUaHm5qp3mxSqWw7Yyx4Zhk2Jn2cmLe+CNPP3xy13zl8Bqg+0NehQzkdMoVhGRww=="
     },
     "domutils": {
       "version": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "classnames": "^2.3.1",
     "css.escape": "1.5.1",
     "deep-extend": "0.6.0",
-    "dompurify": "^2.2.7",
+    "dompurify": "^2.2.8",
     "ieee754": "^1.2.1",
     "immutable": "^3.x.x",
     "js-file-download": "^0.4.12",

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "npm-audit-ci-wrapper": "^3.0.0",
     "npm-run-all": "^4.1.5",
     "oauth2-server": "^2.4.1",
-    "open": "^8.0.6",
+    "open": "^8.0.7",
     "postcss": "=8.2.13",
     "postcss-loader": "=4.2.0",
     "postcss-preset-env": "=6.7.0",

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -429,7 +429,7 @@ function validateValueBySchema(value, schema, requiredByParam, bypassRequiredChe
   let minItems = schema.get("minItems")
   let pattern = schema.get("pattern")
 
-  const schemaRequiresValue = requiredByParam || requiredBySchema
+  const schemaRequiresValue = requiredByParam || requiredBySchema === true
   const hasValue = value !== undefined && value !== null
   const isValidEmpty = !schemaRequiresValue && !hasValue
 

--- a/test/e2e-cypress/static/documents/features/try-it-out-schema-required-override-allowed.yaml
+++ b/test/e2e-cypress/static/documents/features/try-it-out-schema-required-override-allowed.yaml
@@ -1,0 +1,34 @@
+swagger: '2.0'
+info:
+  version: '1.0'
+  title: "schema required properties should not be treated like required: true"
+paths:
+  '/v1/any-path':
+    put:
+      summary: lorem
+      operationId: setDeliveryLocation
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: ipsum
+          required: false
+          schema:
+            $ref: '#/definitions/TopModel'
+      responses:
+        '200':
+          description: successful operation
+definitions:
+  TopModel:
+    type: object
+    properties:
+      testProperty:
+        $ref: '#/definitions/NestedModel'
+  NestedModel:
+    type: object
+    required:
+      - validated
+    properties:
+      validated:
+        type: boolean

--- a/test/e2e-cypress/tests/features/try-it-out-schema-required-override-allowed.js
+++ b/test/e2e-cypress/tests/features/try-it-out-schema-required-override-allowed.js
@@ -1,0 +1,15 @@
+describe("Try It Out: schema required properties can be overriden", () => {
+  it("should execute", () => {
+    cy
+      .visit("?tryItOutEnabled=true&url=/documents/features/try-it-out-schema-required-override-allowed.yaml")
+      .get("#operations-default-setDeliveryLocation")
+      .click()
+      .get(".body-param__text")
+      .should("include.value", "testProperty")
+      .clear() // swagger-ui will auto insert "{}" into textarea
+      .get(".execute-wrapper > .btn")
+      .click()
+      .get(".curl-command")
+      .should("exist")
+  })
+})


### PR DESCRIPTION
schema required properties should not be treated like required: true.
this lead to objects that requires properies beeing treated as required itself

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->


Fixes #7205
Fixes #7086

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

browser

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
