### PR TITLE
fix(sample-gen): oas3 form-data object should generate example

### DIFF
--- a/src/core/plugins/oas3/components/request-body.jsx
+++ b/src/core/plugins/oas3/components/request-body.jsx
@@ -165,14 +165,16 @@ const RequestBody = ({
               const useInitialValue = useInitialValFromSchemaSamples || useInitialValFromEnum
               
               let initialValue = ""
-              if(type === "array" && !useInitialValue) {
+              if (type === "array" && !useInitialValue) {
                 initialValue = []
-              } else if (useInitialValue) {
+              }
+              if (type === "object" || useInitialValue) {
                 // TODO: what about example or examples from requestBody could be passed as exampleOverride
                 initialValue = getSampleSchema(prop, false, {
                   includeWriteOnly: true
                 })
               }
+
               if (typeof initialValue !== "string" && type === "object") {
                initialValue = stringify(initialValue)
               }

--- a/test/e2e-cypress/static/documents/features/request-body/multipart/default-views.yaml
+++ b/test/e2e-cypress/static/documents/features/request-body/multipart/default-views.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.3
+info:
+  title: multipart/form-data schema object
+  version: 0.0.1
+paths:
+  /test:
+    post:
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+                parameters:
+                  "$ref": "#/components/schemas/TestBody"
+      responses:
+        200:
+          description: ok
+components:
+  schemas:
+    TestBody:
+      type: object
+      properties:
+        stuff:
+          type: string

--- a/test/e2e-cypress/tests/features/oas3-request-body-default-views.js
+++ b/test/e2e-cypress/tests/features/oas3-request-body-default-views.js
@@ -1,0 +1,16 @@
+describe("OAS3 default views", () => {
+  describe("multipart/form-data", () => {
+    it("should display calculated object string, when no examples provided (#7268)", () => {
+      cy.visit(
+        "/?url=/documents/features/request-body/multipart/default-views.yaml",
+      )
+        .get("#operations-default-post_test")
+        .click()
+        // Expand Try It Out
+        .get(".try-out__btn")
+        .click()
+        .get(".parameters-col_description textarea")
+        .should("contains.text", "\"stuff\": \"string\"")
+    })
+  })
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Add a `type === object` check, to always return a `getSampleSchema`, which matches original behavior that got missed in https://github.com/swagger-api/swagger-ui/pull/6874

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes #7268 

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

new Cypress test that asserts that a string value exists and matches (instead of empty string)

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
