### PR TITLE
fix(sample-gen): parameter array missing items fallback

### DIFF
--- a/src/core/plugins/samples/fn.js
+++ b/src/core/plugins/samples/fn.js
@@ -500,6 +500,10 @@ export const sampleFromSchemaGeneric = (schema, config={}, exampleOverride = und
   }
 
   if(type === "array") {
+    if (!items) {
+      return
+    }
+
     let sampleArray
     if(respectXML) {
       items.xml = items.xml || schema?.xml || {}

--- a/test/e2e-cypress/static/documents/features/parameter-array-missing-items.yaml
+++ b/test/e2e-cypress/static/documents/features/parameter-array-missing-items.yaml
@@ -1,0 +1,24 @@
+openapi: 3.0.0
+info:
+  title: test
+  version: "1.0.0"
+paths:
+  /example1:
+    get:
+      description: test fetching
+      parameters:
+        - in: query
+          name: basicName
+          content: 
+            application/json:
+              schema:
+                type: object
+                properties:
+                  color:
+                    oneOf:
+                      - type: array # invalid definition b/c type: array is missing 'items'
+                      - type: string
+                      - type: integer
+      responses:
+        '200':
+          description: successfull fetch

--- a/test/e2e-cypress/tests/features/parameter-array-missing-items.js
+++ b/test/e2e-cypress/tests/features/parameter-array-missing-items.js
@@ -1,0 +1,10 @@
+describe("Parameter - Invalid definition with missing array 'items' (#7375)", () => {
+  it("should render gracefully with fallback to default value", () => {
+    cy.visit("/?url=/documents/features/parameter-array-missing-items.yaml")
+      .get("#operations-default-get_example1")
+      .click()
+      .get("tbody > tr > .parameters-col_description textarea")
+      .should("exist")
+      .should("contains.text", "{}")
+  })
+})


### PR DESCRIPTION
* fixes #7375

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Add a check that the expected array `items` exists before continuing sample generation.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes #7375 

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

new cypress test

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
