### PR TITLE
Enable running with a read-only filesystem

### DIFF
--- a/docker/configurator/index.js
+++ b/docker/configurator/index.js
@@ -35,15 +35,17 @@ if (startMarkerIndex < 0 || endMarkerIndex < 0) {
   process.exit(0)
 }
 
-fs.writeFileSync(
-  targetPath,
-  `${beforeStartMarkerContent}
-      ${START_MARKER}
-      const ui = SwaggerUIBundle({
-        ${indent(translator(process.env, { injectBaseConfig: true }), 8, 2)}
-      })
-      
-      ${indent(oauthBlockBuilder(process.env), 6, 2)}
-      ${END_MARKER}
-${afterEndMarkerContent}`
-)
+if (!process.env.READONLY_FILESYSTEM) {
+  fs.writeFileSync(
+    targetPath,
+    `${beforeStartMarkerContent}
+        ${START_MARKER}
+        const ui = SwaggerUIBundle({
+          ${indent(translator(process.env, { injectBaseConfig: true }), 8, 2)}
+        })
+        
+        ${indent(oauthBlockBuilder(process.env), 6, 2)}
+        ${END_MARKER}
+  ${afterEndMarkerContent}`
+  )
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Skip over startup tasks that rewrite files when the `READONLY_FILESYTEM` environment variable is set.

### Motivation and Context
Enables running in a Kubernetes cluster where the `PodSecurityPolicy` has `readOnlyRootFilesystem` set as true. This setting is recommended by a security warning from [kube-score](https://github.com/zegl/kube-score/), a static analyzer for Kubernetes manifests.

Fixes #5699 (https://github.com/swagger-api/swagger-ui/issues/5699), and is based on @abrownfi's commit referenced in the issue.

### How Has This Been Tested?
Ran a (somewhat cursory) check that it starts up and operates with the test data locally via Docker using the following command:

```sh
docker build -t swaggerapi/swagger-ui:robdesbois .
docker run \
  -e READONLY_FILESYSTEM=true \
  -p 8080:8080 \
  -u 101 \
  --read-only \
  --mount type=tmpfs,dst=/var/cache/nginx \
  --volume /home/robdesbois/projects/third-party/swagger-ui/nginx_tmp:/var/run \
  swaggerapi/swagger-ui:robdesbois
```

I haven't checked other areas of functionality. Clearly the config injections disabled by this functionality will not function - there's no runtime warning of any conflicts between this new flag and existing options.
Hoping to gauge how close this is before investing further in warnings, docs or tests.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [x] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
_**Unsure about needs here - guidance would be useful please.**_
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
