### PR TITLE
Add docker environment variable for useBasicAuthenticationWithAccessCodeGrant

### DIFF
--- a/docker/configurator/oauth.js
+++ b/docker/configurator/oauth.js
@@ -34,6 +34,10 @@ const oauthBlockSchema = {
   OAUTH_USE_PKCE: {
     type: "boolean",
     name: "usePkceWithAuthorizationCodeGrant"
+  },
+  OAUTH_USE_BASIC_AUTHENTICATION_WITH_ACCESS_CODE_GRANT: {
+    type: "boolean",
+    name: "useBasicAuthenticationWithAccessCodeGrant",
   }
 }
 

--- a/docs/usage/oauth2.md
+++ b/docs/usage/oauth2.md
@@ -10,7 +10,7 @@ appName | `OAUTH_APP_NAME` |application name, displayed in authorization popup. 
 scopeSeparator | `OAUTH_SCOPE_SEPARATOR` |scope separator for passing scopes, encoded before calling, default value is a space (encoded value `%20`). MUST be a string
 scopes | `OAUTH_SCOPES` |string array or scope separator (i.e. space) separated string of initially selected oauth scopes, default is empty array
 additionalQueryStringParams | `OAUTH_ADDITIONAL_PARAMS` |Additional query parameters added to `authorizationUrl` and `tokenUrl`. MUST be an object
-useBasicAuthenticationWithAccessCodeGrant | _Unavailable_ |Only activated for the `accessCode` flow.  During the `authorization_code` request to the `tokenUrl`, pass the [Client Password](https://tools.ietf.org/html/rfc6749#section-2.3.1) using the HTTP Basic Authentication scheme (`Authorization` header with `Basic base64encode(client_id + client_secret)`).  The default is `false`
+useBasicAuthenticationWithAccessCodeGrant | `OAUTH_USE_BASIC_AUTHENTICATION_WITH_ACCESS_CODE_GRANT` |Only activated for the `accessCode` flow.  During the `authorization_code` request to the `tokenUrl`, pass the [Client Password](https://tools.ietf.org/html/rfc6749#section-2.3.1) using the HTTP Basic Authentication scheme (`Authorization` header with `Basic base64encode(client_id + client_secret)`).  The default is `false`
 usePkceWithAuthorizationCodeGrant | `OAUTH_USE_PKCE` | Only applies to `authorizatonCode` flows. [Proof Key for Code Exchange](https://tools.ietf.org/html/rfc7636) brings enhanced security for OAuth public clients. The default is `false`
 
 ```javascript


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

This PR just adds a new environment variable for the Docker image, so that the `initOAuth` parameter `useBasicAuthenticationWithAccessCodeGrant` can be set.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Did not find an existing issue for this. Without the environment variable, one cannot use just the Docker image to achieve this, but must implement the initOAuth call oneself.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I tested the change in my own environment by patching the oauth.js with a Docker volume:

  swagger-ui:
    image: swaggerapi/swagger-ui
    environment:
      OAUTH_USE_BASIC_AUTHENTICATION_WITH_ACCESS_CODE_GRANT: "true"
    volumes:
      - $PWD/oauth.js:/usr/share/nginx/configurator/oauth.js:ro

This way I was able to authenticate against my API which supports only Basic client authentication.

### Screenshots (if appropriate):

Not applicable.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [x] My changes require a change to the project documentation.
- [x] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
