### PR TITLE
feat: do not ask for client secret when using auth code with PKCE 

### DIFF
--- a/src/core/components/auth/oauth2.jsx
+++ b/src/core/components/auth/oauth2.jsx
@@ -130,7 +130,11 @@ export default class Oauth2 extends React.Component {
     const AUTH_FLOW_ACCESS_CODE = isOAS3() ? (oidcUrl ? "authorization_code" : "authorizationCode") : "accessCode"
     const AUTH_FLOW_APPLICATION = isOAS3() ? (oidcUrl ? "client_credentials" : "clientCredentials") : "application"
 
+    let authConfigs = authSelectors.getConfigs()
+    let isPkceCodeGrant = authConfigs.usePkceWithAuthorizationCodeGrant === "true" || authConfigs.usePkceWithAuthorizationCodeGrant === true
+
     let flow = schema.get("flow")
+    let flowToDisplay = isPkceCodeGrant ? flow + " with PKCE" : flow
     let scopes = schema.get("allowedScopes") || schema.get("scopes")
     let authorizedAuth = authSelectors.authorized().get(name)
     let isAuthorized = !!authorizedAuth
@@ -140,7 +144,7 @@ export default class Oauth2 extends React.Component {
 
     return (
       <div>
-        <h4>{name} (OAuth2, { schema.get("flow") }) <JumpToPath path={[ "securityDefinitions", name ]} /></h4>
+        <h4>{name} (OAuth2, { flowToDisplay }) <JumpToPath path={[ "securityDefinitions", name ]} /></h4>
         { !this.state.appName ? null : <h5>Application: { this.state.appName } </h5> }
         { description && <Markdown source={ schema.get("description") } /> }
 
@@ -149,7 +153,7 @@ export default class Oauth2 extends React.Component {
         { oidcUrl && <p>OpenID Connect URL: <code>{ oidcUrl }</code></p> }
         { ( flow === AUTH_FLOW_IMPLICIT || flow === AUTH_FLOW_ACCESS_CODE ) && <p>Authorization URL: <code>{ schema.get("authorizationUrl") }</code></p> }
         { ( flow === AUTH_FLOW_PASSWORD || flow === AUTH_FLOW_ACCESS_CODE || flow === AUTH_FLOW_APPLICATION ) && <p>Token URL:<code> { schema.get("tokenUrl") }</code></p> }
-        <p className="flow">Flow: <code>{ schema.get("flow") }</code></p>
+        <p className="flow">Flow: <code>{ flowToDisplay }</code></p>
 
         {
           flow !== AUTH_FLOW_PASSWORD ? null
@@ -208,7 +212,7 @@ export default class Oauth2 extends React.Component {
         }
 
         {
-          ( (flow === AUTH_FLOW_APPLICATION || flow === AUTH_FLOW_ACCESS_CODE || flow === AUTH_FLOW_PASSWORD) && <Row>
+          ( (flow === AUTH_FLOW_APPLICATION || flow === AUTH_FLOW_ACCESS_CODE || flow === AUTH_FLOW_PASSWORD) && !isPkceCodeGrant && <Row>
             <label htmlFor="client_secret">client_secret:</label>
             {
               isAuthorized ? <code> ****** </code>

--- a/test/e2e-cypress/static/documents/features/auth-code-flow-pkce-without-secret.yaml
+++ b/test/e2e-cypress/static/documents/features/auth-code-flow-pkce-without-secret.yaml
@@ -1,0 +1,25 @@
+openapi: 3.0.0
+
+info:
+  version: "1.0"
+  title: PKCE Flow
+
+paths:
+  /:
+    get:
+      summary: dummy operation
+      responses:
+        "200":
+          description: OK
+
+components:
+  securitySchemes:
+    testAuthCodeFlow:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: /oauth/authorize
+          tokenUrl: /oauth/token
+          scopes:
+            read: read whatever you want
+            write: write whatever you want

--- a/test/e2e-cypress/tests/features/auth-code-flow-pkce-without-secret.js
+++ b/test/e2e-cypress/tests/features/auth-code-flow-pkce-without-secret.js
@@ -1,0 +1,41 @@
+describe("Check client_secret for OAuth2 Authorization Code flow with and without PKCE (#6290)", () => {
+  it("should not display client_secret field for authorization code flow with PKCE", () => {
+    cy.visit(
+      "/?url=/documents/features/auth-code-flow-pkce-without-secret.yaml"
+    )
+      .window()
+      .then(win => {
+        // set auth config to use PKCE
+        let authConfigs = win.ui.authSelectors.getConfigs()
+        authConfigs.usePkceWithAuthorizationCodeGrant = true
+      })
+      .get("button.authorize")
+      .click()
+      .get("h4")
+      .contains("authorizationCode with PKCE")
+      .get(".flow")
+      .contains("authorizationCode with PKCE")
+      .get("#client_secret")
+      .should("not.exist")
+  })
+
+  it("should display client_secret field for authorization code flow without PKCE", () => {
+    cy.visit(
+      "/?url=/documents/features/auth-code-flow-pkce-without-secret.yaml"
+    )
+      .window()
+      .then(win => {
+        // set auth config to not use PKCE
+        let authConfigs = win.ui.authSelectors.getConfigs()
+        authConfigs.usePkceWithAuthorizationCodeGrant = false
+      })
+      .get("button.authorize")
+      .click()
+      .get("h4")
+      .contains("authorizationCode")
+      .get(".flow")
+      .contains("authorizationCode")
+      .get("#client_secret")
+      .should("exist")
+  })
+})


### PR DESCRIPTION
According to [OAuth 2.0 Security Best Current Practice](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics), the implicit grant should no longer be used, but be replaced by the authorization code grant with PKCE.
While the swagger-ui permits to use the PKCE grant type, the authorization dialog still prompts for a client secret. From a user perspective, this is confusing and the current pull request omits the client secret field if authorization code grant with PKCE is configured (see [#6290](https://github.com/swagger-api/swagger-ui/issues/6290)).

([from ch-egli PR](https://github.com/swagger-api/swagger-ui/pull/7438))

### Description

When the flag usePkceWithAuthorizationCodeGrant is set to true, the input field for the client secret will not be shown.
Moreover, we specify in the authorization dialogue, that the authorization code flow with PKCE is used.


### Motivation and Context
See the description above.
Fixes #6290


### How Has This Been Tested?

- generated a new dist and included it in different projects of Schweizerische Bundesbahnen (SBB)
- cypress e2e test added

### Screenshots (if appropriate):

![previous_oidc](https://user-images.githubusercontent.com/9528270/133210763-e413500e-0400-445a-8488-0d413735675b.png)
![new_oidc](https://user-images.githubusercontent.com/9528270/133210780-552df5de-7835-444a-a810-071d7f862015.png)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [x ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x ] are not breaking changes.

### Documentation
- [x ] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ x] My changes can and should be tested by unit and/or integration tests.
- [x ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x ] All new and existing tests passed.
