### PR TITLE
fix: correct width of http request methods

### DIFF
--- a/src/style/_layout.scss
+++ b/src/style/_layout.scss
@@ -281,7 +281,7 @@
         font-weight: bold;
 
         min-width: 80px;
-        padding: 6px 15px;
+        padding: 6px;
 
         text-align: center;
 

--- a/src/style/_layout.scss
+++ b/src/style/_layout.scss
@@ -281,7 +281,7 @@
         font-weight: bold;
 
         min-width: 80px;
-        padding: 6px;
+        padding: 6px 0;
 
         text-align: center;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Remove unnecessary padding inside box of http methods.

### Motivation and Context
The box that contains methods DELETE and OPTIONS were too wide compared with others. see below:

![131522587-879ae6bc-f98f-4399-9474-85089c5bff8a](https://user-images.githubusercontent.com/12849040/134998475-4626c5ca-3100-413d-9e2d-bd382ebb84b7.png)

### How Has This Been Tested?
- Copy petstore.json from `./test/e2e-selenium/static/test-specs` to `./dev-helpers/`
- In `./dev-helpers/index.html` change url parameter of `ui` variable to: `./dev-helpers/petstore.json` 
- modify petstore.json to get "OPTIONS", "DELETE" and "POST" right next to each other.
- run `npm run dev` in terminal
- Open http://localhost:3200/
- Compare width

### Screenshots (if appropriate):
![Screenshot_1](https://user-images.githubusercontent.com/12849040/134998842-90b8ffbc-7c25-4825-b4ac-efbcd01a809d.png)



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
