### PR TITLE
Remove redundant whitespaces in api key auth popup

### DIFF
--- a/src/core/components/auth/api-key-auth.jsx
+++ b/src/core/components/auth/api-key-auth.jsx
@@ -52,8 +52,7 @@ export default class ApiKeyAuth extends React.Component {
     return (
       <div>
         <h4>
-          <code>{ name || schema.get("name") }</code>&nbsp;
-          (apiKey)
+          <code>{ name || schema.get("name") }</code>&nbsp;(apiKey)
           <JumpToPath path={[ "securityDefinitions", name ]} />
         </h4>
         { value && <h6>Authorized</h6>}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
On the API key auth popup 2 spaces are displayed between `Bearer` and `(apiKey)`. Usually I just copy paste `Bearer  (apiKey)` from the popup to the textbox and the replace `(apiKey)` with the actual bearer token. Of cource, my requests receive 401 because the server interprets additional space as the token's first character. This PR removes extra whitespaces.

### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/22914850/135997832-05cf7ead-b926-4483-96ec-849d618a37c4.png)
![image](https://user-images.githubusercontent.com/22914850/135999592-b24df91d-0623-4235-9f0f-86bee50e5634.png)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [X] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [X] are not breaking changes.

### Documentation
- [X] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [X] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
