### PR TITLE
fix(param-body): onChange the body box should not switch to Highlight…

### DIFF
--- a/src/core/components/param-body.jsx
+++ b/src/core/components/param-body.jsx
@@ -86,7 +86,7 @@ export default class ParamBody extends PureComponent {
     const {consumesValue} = this.props
     const isXml = /xml/i.test(consumesValue)
     const inputValue = e.target.value
-    this.onChange(inputValue, {isXml})
+    this.onChange(inputValue, {isXml, isEditBox: this.state.isEditBox})
   }
 
   toggleIsEditBox = () => this.setState( state => ({isEditBox: !state.isEditBox}))


### PR DESCRIPTION
…Code back and forth

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
ParamBody is rendered multiple times, when the `handleOnChange` is emitted by key stroke the `isEditBox` state is set to undefined, instead it should stay the same. This results in switching back and forth between the HiglightCode and TextArea, this will result in react loosing track of the component and so rerendering it!

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes #7477 

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

browser

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
