### PR TITLE
fix(syntax-highlight): fix of fix that caused highlight code scrolling errors

### DIFF
--- a/src/core/components/curl.jsx
+++ b/src/core/components/curl.jsx
@@ -1,28 +1,30 @@
 import React from "react"
 import PropTypes from "prop-types"
 import { CopyToClipboard } from "react-copy-to-clipboard"
-import {SyntaxHighlighter, getStyle} from "core/syntax-highlighting"
 import get from "lodash/get"
 import { requestSnippetGenerator_curl_bash } from "../plugins/request-snippets/fn"
 
 export default class Curl extends React.Component {
   static propTypes = {
     getConfigs: PropTypes.func.isRequired,
+    getComponent: PropTypes.func.isRequired,
+    fn: PropTypes.object.isRequired,
     request: PropTypes.object.isRequired
   }
 
   render() {
-    let { request, getConfigs } = this.props
+    let { request, getConfigs, fn, getComponent } = this.props
     let curl = requestSnippetGenerator_curl_bash(request)
 
     const config = getConfigs()
+    const SyntaxHighlighter = getComponent("SyntaxHighlighter")
 
     const curlBlock = get(config, "syntaxHighlight.activated")
       ? <SyntaxHighlighter
           language="bash"
           className="curl microlight"
           onWheel={this.preventYScrollingBeyondElement}
-          style={getStyle(get(config, "syntaxHighlight.theme"))}
+          style={fn.getStyle(get(config, "syntaxHighlight.theme"))}
           >
           {curl}
         </SyntaxHighlighter>

--- a/src/core/components/example.jsx
+++ b/src/core/components/example.jsx
@@ -11,7 +11,7 @@ export default function Example(props) {
   const { example, showValue, getComponent, getConfigs } = props
 
   const Markdown = getComponent("Markdown", true)
-  const HighlightCode = getComponent("highlightCode")
+  const HighlightCode = getComponent("highlightCode", true)
 
   if(!example) return null
 

--- a/src/core/components/live-response.jsx
+++ b/src/core/components/live-response.jsx
@@ -70,7 +70,7 @@ export default class LiveResponse extends React.Component {
     const hasHeaders = returnObject.length !== 0
     const Markdown = getComponent("Markdown", true)
     const RequestSnippets = getComponent("RequestSnippets", true)
-    const Curl = getComponent("curl")
+    const Curl = getComponent("curl", true)
 
     return (
       <div>

--- a/src/core/components/model-example.jsx
+++ b/src/core/components/model-example.jsx
@@ -59,7 +59,7 @@ export default class ModelExample extends React.Component {
     let { getComponent, specSelectors, schema, example, isExecute, getConfigs, specPath, includeReadOnly, includeWriteOnly } = this.props
     let { defaultModelExpandDepth } = getConfigs()
     const ModelWrapper = getComponent("ModelWrapper")
-    const HighlightCode = getComponent("highlightCode")
+    const HighlightCode = getComponent("highlightCode", true)
     const exampleTabId = randomBytes(5).toString("base64")
     const examplePanelId = randomBytes(5).toString("base64")
     const modelTabId = randomBytes(5).toString("base64")

--- a/src/core/components/param-body.jsx
+++ b/src/core/components/param-body.jsx
@@ -104,7 +104,7 @@ export default class ParamBody extends PureComponent {
 
     const Button = getComponent("Button")
     const TextArea = getComponent("TextArea")
-    const HighlightCode = getComponent("highlightCode")
+    const HighlightCode = getComponent("highlightCode", true)
     const ContentType = getComponent("contentType")
     // for domains where specSelectors not passed
     let parameter = specSelectors ? specSelectors.parameterWithMetaByIdentity(pathMethod, param) : param
@@ -140,11 +140,11 @@ export default class ParamBody extends PureComponent {
           }
           <label htmlFor="">
             <span>Parameter content type</span>
-            <ContentType 
-              value={ consumesValue } 
-              contentTypes={ consumes } 
-              onChange={onChangeConsumes} 
-              className="body-param-content-type" 
+            <ContentType
+              value={ consumesValue }
+              contentTypes={ consumes }
+              onChange={onChangeConsumes}
+              className="body-param-content-type"
               ariaLabel="Parameter content type" />
           </label>
         </div>

--- a/src/core/components/response-body.jsx
+++ b/src/core/components/response-body.jsx
@@ -53,7 +53,7 @@ export default class ResponseBody extends React.PureComponent {
   render() {
     let { content, contentType, url, headers={}, getConfigs, getComponent } = this.props
     const { parsedContent } = this.state
-    const HighlightCode = getComponent("highlightCode")
+    const HighlightCode = getComponent("highlightCode", true)
     const downloadName = "response_" + new Date().getTime()
     let body, bodyEl
     url = url || ""

--- a/src/core/components/response.jsx
+++ b/src/core/components/response.jsx
@@ -102,7 +102,7 @@ export default class Response extends React.Component {
     let links = response.get("links")
     const ResponseExtension = getComponent("ResponseExtension")
     const Headers = getComponent("headers")
-    const HighlightCode = getComponent("highlightCode")
+    const HighlightCode = getComponent("highlightCode", true)
     const ModelExample = getComponent("modelExample")
     const Markdown = getComponent("Markdown", true)
     const OperationLink = getComponent("operationLink")

--- a/src/core/plugins/request-snippets/request-snippets.jsx
+++ b/src/core/plugins/request-snippets/request-snippets.jsx
@@ -2,7 +2,6 @@ import React from "react"
 import { CopyToClipboard } from "react-copy-to-clipboard"
 import PropTypes from "prop-types"
 import get from "lodash/get"
-import {SyntaxHighlighter, getStyle} from "core/syntax-highlighting"
 
 export class RequestSnippets extends React.Component {
   constructor() {
@@ -17,69 +16,72 @@ export class RequestSnippets extends React.Component {
     request: PropTypes.object.isRequired,
     requestSnippetsSelectors: PropTypes.object.isRequired,
     getConfigs: PropTypes.object.isRequired,
+    getComponent: PropTypes.object.isRequired,
     requestSnippetsActions: PropTypes.object.isRequired,
+    fn: PropTypes.object.isRequired,
   }
   render() {
-      const {request, getConfigs, requestSnippetsSelectors } = this.props
-      const snippetGenerators = requestSnippetsSelectors.getSnippetGenerators()
-      const activeLanguage = this.state.activeLanguage || snippetGenerators.keySeq().first()
-      const activeGenerator = snippetGenerators.get(activeLanguage)
-      const snippet = activeGenerator.get("fn")(request)
-      const onGenChange = (key) => {
-        const needsChange = activeLanguage !== key
-        if(needsChange) {
-          this.setState({
-            activeLanguage: key
-          })
-        }
+    const {request, getConfigs, requestSnippetsSelectors, fn, getComponent } = this.props
+    const snippetGenerators = requestSnippetsSelectors.getSnippetGenerators()
+    const activeLanguage = this.state.activeLanguage || snippetGenerators.keySeq().first()
+    const activeGenerator = snippetGenerators.get(activeLanguage)
+    const snippet = activeGenerator.get("fn")(request)
+    const onGenChange = (key) => {
+      const needsChange = activeLanguage !== key
+      if(needsChange) {
+        this.setState({
+          activeLanguage: key
+        })
       }
-      const style = {
-        cursor: "pointer",
-        lineHeight: 1,
-        display: "inline-flex",
-        backgroundColor: "rgb(250, 250, 250)",
-        paddingBottom: "0",
-        paddingTop: "0",
-        border: "1px solid rgb(51, 51, 51)",
-        borderRadius: "4px 4px 0 0",
-        boxShadow: "none",
-        borderBottom: "none"
+    }
+    const style = {
+      cursor: "pointer",
+      lineHeight: 1,
+      display: "inline-flex",
+      backgroundColor: "rgb(250, 250, 250)",
+      paddingBottom: "0",
+      paddingTop: "0",
+      border: "1px solid rgb(51, 51, 51)",
+      borderRadius: "4px 4px 0 0",
+      boxShadow: "none",
+      borderBottom: "none"
+    }
+    const activeStyle = {
+      cursor: "pointer",
+      lineHeight: 1,
+      display: "inline-flex",
+      backgroundColor: "rgb(51, 51, 51)",
+      boxShadow: "none",
+      border: "1px solid rgb(51, 51, 51)",
+      paddingBottom: "0",
+      paddingTop: "0",
+      borderRadius: "4px 4px 0 0",
+      marginTop: "-5px",
+      marginRight: "-5px",
+      marginLeft: "-5px",
+      zIndex: "9999",
+      borderBottom: "none"
+    }
+    const getBtnStyle = (key) => {
+      if (key === activeLanguage) {
+        return activeStyle
       }
-      const activeStyle = {
-        cursor: "pointer",
-        lineHeight: 1,
-        display: "inline-flex",
-        backgroundColor: "rgb(51, 51, 51)",
-        boxShadow: "none",
-        border: "1px solid rgb(51, 51, 51)",
-        paddingBottom: "0",
-        paddingTop: "0",
-        borderRadius: "4px 4px 0 0",
-        marginTop: "-5px",
-        marginRight: "-5px",
-        marginLeft: "-5px",
-        zIndex: "9999",
-        borderBottom: "none"
-      }
-      const getBtnStyle = (key) => {
-        if (key === activeLanguage) {
-          return activeStyle
-        }
-        return style
-      }
-      const config = getConfigs()
+      return style
+    }
+    const config = getConfigs()
+    const SyntaxHighlighter = getComponent("SyntaxHighlighter")
 
-      const SnippetComponent = config?.syntaxHighlight?.activated
-        ? <SyntaxHighlighter
-          language={activeGenerator.get("syntax")}
-          className="curl microlight"
-          onWheel={function(e) {return this.preventYScrollingBeyondElement(e)}}
-          style={getStyle(get(config, "syntaxHighlight.theme"))}
-        >
-          {snippet}
-        </SyntaxHighlighter>
-        :
-        <textarea readOnly={true} className="curl" value={snippet}></textarea>
+    const SnippetComponent = config?.syntaxHighlight?.activated
+      ? <SyntaxHighlighter
+        language={activeGenerator.get("syntax")}
+        className="curl microlight"
+        onWheel={function(e) {return this.preventYScrollingBeyondElement(e)}}
+        style={fn.getStyle(get(config, "syntaxHighlight.theme"))}
+      >
+        {snippet}
+      </SyntaxHighlighter>
+      :
+      <textarea readOnly={true} className="curl" value={snippet}></textarea>
 
     const expanded = this.state.expanded === undefined ? this.props?.requestSnippetsSelectors?.getDefaultExpanded() : this.state.expanded
     return (

--- a/src/core/plugins/syntax-highlight/fn.js
+++ b/src/core/plugins/syntax-highlight/fn.js
@@ -1,0 +1,20 @@
+import agate from "react-syntax-highlighter/dist/cjs/styles/hljs/agate"
+import arta from "react-syntax-highlighter/dist/cjs/styles/hljs/arta"
+import monokai from "react-syntax-highlighter/dist/cjs/styles/hljs/monokai"
+import nord from "react-syntax-highlighter/dist/cjs/styles/hljs/nord"
+import obsidian from "react-syntax-highlighter/dist/cjs/styles/hljs/obsidian"
+import tomorrowNight from "react-syntax-highlighter/dist/cjs/styles/hljs/tomorrow-night"
+
+const internalStylePreset = {agate, arta, monokai, nord, obsidian, "tomorrow-night": tomorrowNight}
+
+export default system => ({
+  getAvailableStyles: () => internalStylePreset,
+  getStyle: name => {
+    const styles = system.getSystem().fn.getAvailableStyles()
+    if (!Object.keys(styles).includes(name)) {
+      console.warn(`Request style '${name}' is not available, returning default instead`)
+      return agate
+    }
+    return styles[name]
+  }
+})

--- a/src/core/plugins/syntax-highlight/index.js
+++ b/src/core/plugins/syntax-highlight/index.js
@@ -1,0 +1,9 @@
+import buildFn from "./fn"
+import { SyntaxHighlighter } from "./syntax-highlight"
+
+export default (system) => ({
+  components: {
+    SyntaxHighlighter
+  },
+  fn: buildFn(system),
+})

--- a/src/core/plugins/syntax-highlight/syntax-highlight.js
+++ b/src/core/plugins/syntax-highlight/syntax-highlight.js
@@ -9,13 +9,6 @@ import http from "react-syntax-highlighter/dist/esm/languages/hljs/http"
 import powershell from "react-syntax-highlighter/dist/esm/languages/hljs/powershell"
 import javascript from "react-syntax-highlighter/dist/esm/languages/hljs/javascript"
 
-import agate from "react-syntax-highlighter/dist/esm/styles/hljs/agate"
-import arta from "react-syntax-highlighter/dist/esm/styles/hljs/arta"
-import monokai from "react-syntax-highlighter/dist/esm/styles/hljs/monokai"
-import nord from "react-syntax-highlighter/dist/esm/styles/hljs/nord"
-import obsidian from "react-syntax-highlighter/dist/esm/styles/hljs/obsidian"
-import tomorrowNight from "react-syntax-highlighter/dist/esm/styles/hljs/tomorrow-night"
-
 SyntaxHighlighter.registerLanguage("json", json)
 SyntaxHighlighter.registerLanguage("js", js)
 SyntaxHighlighter.registerLanguage("xml", xml)
@@ -25,15 +18,6 @@ SyntaxHighlighter.registerLanguage("bash", bash)
 SyntaxHighlighter.registerLanguage("powershell", powershell)
 SyntaxHighlighter.registerLanguage("javascript", javascript)
 
-const styles = {agate, arta, monokai, nord, obsidian, "tomorrow-night": tomorrowNight}
-export const availableStyles = Object.keys(styles)
-
-export const getStyle = name => {
-    if (!availableStyles.includes(name)) {
-        console.warn(`Request style '${name}' is not available, returning default instead`)
-        return agate
-    }
-    return styles[name]
+export {
+  SyntaxHighlighter
 }
-
-export {SyntaxHighlighter, styles}

--- a/src/core/presets/base.js
+++ b/src/core/presets/base.js
@@ -4,6 +4,7 @@ import spec from "core/plugins/spec"
 import view from "core/plugins/view"
 import samples from "core/plugins/samples"
 import requestSnippets from "core/plugins/request-snippets"
+import syntaxHighlight from "core/plugins/syntax-highlight"
 import logs from "core/plugins/logs"
 import swaggerJs from "core/plugins/swagger-js"
 import auth from "core/plugins/auth"
@@ -193,6 +194,7 @@ export default function() {
     deepLinkingPlugin,
     filter,
     onComplete,
-    requestSnippets
+    requestSnippets,
+    syntaxHighlight
   ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
@char0n 
### Description
<!--- Describe your changes in detail -->
#7519 voiding the preventScroll handler as SyntaxHighlighter does not provide ref support.
#7551 fixes extensability of plugin SyntaxHighlighter 
Refs https://github.com/swagger-api/swagger-ui/issues/7552

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->
Fixes #7497
Fixes #7519 voiding the preventScroll handler



### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

browser

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [x] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
