### PR TITLE
Filter Parameters when "in" is "header"

### DIFF
--- a/src/core/components/parameters/parameters.jsx
+++ b/src/core/components/parameters/parameters.jsx
@@ -129,7 +129,7 @@ export default class Parameters extends Component {
         return acc
       }, {}))
       .reduce((acc, x) => acc.concat(x), [])
-      .filter(parameter => !(parameter.get("in") == 'header' && ["Accept", "Content-Type", "Authorization"].includes(parameter.get("name"))))
+      .filter(parameter => !(parameter.get("in") == "header" && ["Accept", "Content-Type", "Authorization"].includes(parameter.get("name"))))
 
     const retainRequestBodyValueFlagForOperation = (f) => oas3Actions.setRetainRequestBodyValueFlag({ value: f, pathMethod })
     return (

--- a/src/core/components/parameters/parameters.jsx
+++ b/src/core/components/parameters/parameters.jsx
@@ -129,6 +129,7 @@ export default class Parameters extends Component {
         return acc
       }, {}))
       .reduce((acc, x) => acc.concat(x), [])
+      .filter(parameter => !(parameter.get("in") == 'header' && ["Accept", "Content-Type", "Authorization"].includes(parameter.get("name"))))
 
     const retainRequestBodyValueFlagForOperation = (f) => oas3Actions.setRetainRequestBodyValueFlag({ value: f, pathMethod })
     return (


### PR DESCRIPTION
Fixes issue #7486 

### Description
Filter out parameters where "in" is "header" and "name" is one of "Accept", "Content-Type", "Authorization"

### How Has This Been Tested?
[JSON](http://myjson.dit.upm.es/api/bins/k4p) used for local testing: 

> {
>   "openapi": "3.0.3",
>   "info": {
>     "title": "Test",
>     "version": "1.0.0"
>   },
>   "servers": [
>     {
>       "url": "https://api.example.com/v2"
>     }
>   ],
>   "security": [
>     {
>       "openId": [
> 
>       ]
>     }
>   ],
>   "paths": {
>     "/": {
>       "get": {
>         "tags": [
>           "Content"
>         ],
>         "parameters": [
>           {
>             "name": "Authorization",
>             "in": "header",
>             "required": true,
>             "schema": {
>               "type": "string"
>             }
>           },
>           {
>             "name": "Accept",
>             "in": "header",
>             "required": true,
>             "schema": {
>               "type": "string"
>             }
>           },
>           {
>             "name": "Content-Type",
>             "in": "header",
>             "required": true,
>             "schema": {
>               "type": "string"
>             }
>           },
>           {
>             "name": "NotAuthorization",
>             "in": "header",
>             "required": true,
>             "schema": {
>               "type": "string"
>             }
>           }
>         ],
>         "responses": {
>           "200": {
>             "description": "All services of Content Storage Service"
>           }
>         }
>       }
>     }
>   },
>   "components": {
>     "securitySchemes": {
>       "openId": {
>         "type": "openIdConnect",
>         "openIdConnectUrl": "/.well-known/openid-configuration"
>       }
>     }
>   }
> }



### Screenshots when testing with above json:
![image](https://user-images.githubusercontent.com/36417662/138183515-9fc76245-7abc-4823-bf6f-6d61935e4bc3.png)
