### PR TITLE
Address autofocus issue #7711

### DIFF
--- a/src/core/components/auth/api-key-auth.jsx
+++ b/src/core/components/auth/api-key-auth.jsx
@@ -69,7 +69,7 @@ export default class ApiKeyAuth extends React.Component {
           <label>Value:</label>
           {
             value ? <code> ****** </code>
-                  : <Col><Input type="text" onChange={ this.onChange } autoFocus/></Col>
+                  : <Col><Input type="text" onChange={ this.onChange } /></Col>
           }
         </Row>
         {

--- a/src/core/components/auth/auths.jsx
+++ b/src/core/components/auth/auths.jsx
@@ -20,7 +20,7 @@ export default class Auths extends React.Component {
   componentDidMount() {
     var inputs = document.getElementsByClassName("modal-ux-content")[0].getElementsByTagName("input")
     for (let i = 0; i < inputs.length; i++) {
-      const element = inputs[i];
+      const element = inputs[i]
       if (element) {
         element.focus()
         break

--- a/src/core/components/auth/auths.jsx
+++ b/src/core/components/auth/auths.jsx
@@ -17,6 +17,17 @@ export default class Auths extends React.Component {
     this.state = {}
   }
 
+  componentDidMount() {
+    var inputs = document.getElementsByClassName("modal-ux-content")[0].getElementsByTagName("input")
+    for (let i = 0; i < inputs.length; i++) {
+      const element = inputs[i];
+      if (element) {
+        element.focus()
+        break
+      }
+    }
+  }
+
   onAuthChange =(auth) => {
     let { name } = auth
 
@@ -66,7 +77,9 @@ export default class Auths extends React.Component {
     })
 
     let nonOauthDefinitions = definitions.filter( schema => schema.get("type") !== "oauth2")
-    let oauthDefinitions = definitions.filter( schema => schema.get("type") === "oauth2")
+    let oauthDefinitions = definitions.filter(schema => schema.get("type") === "oauth2")
+
+
 
     return (
       <div className="auth-container">

--- a/src/core/components/auth/basic-auth.jsx
+++ b/src/core/components/auth/basic-auth.jsx
@@ -66,7 +66,7 @@ export default class BasicAuth extends React.Component {
           <label>Username:</label>
           {
             username ? <code> { username } </code>
-                     : <Col><Input type="text" required="required" name="username" onChange={ this.onChange } autoFocus/></Col>
+                     : <Col><Input type="text" required="required" name="username" onChange={ this.onChange } /></Col>
           }
         </Row>
         <Row>

--- a/src/core/components/auth/oauth2.jsx
+++ b/src/core/components/auth/oauth2.jsx
@@ -163,7 +163,7 @@ export default class Oauth2 extends React.Component {
                 {
                   isAuthorized ? <code> { this.state.username } </code>
                     : <Col tablet={10} desktop={10}>
-                      <input id="oauth_username" type="text" data-name="username" onChange={ this.onInputChange } autoFocus/>
+                      <input id="oauth_username" type="text" data-name="username" onChange={ this.onInputChange } />
                     </Col>
                 }
               </Row>

--- a/src/core/plugins/oas3/components/http-auth.jsx
+++ b/src/core/plugins/oas3/components/http-auth.jsx
@@ -74,7 +74,7 @@ export default class HttpAuth extends React.Component {
           <label>Username:</label>
           {
             username ? <code> { username } </code>
-                     : <Col><Input type="text" required="required" name="username" onChange={ this.onChange } autoFocus/></Col>
+                     : <Col><Input type="text" required="required" name="username" onChange={ this.onChange } /></Col>
           }
         </Row>
         <Row>
@@ -112,7 +112,7 @@ export default class HttpAuth extends React.Component {
               <label>Value:</label>
               {
                 value ? <code> ****** </code>
-              : <Col><Input type="text" onChange={ this.onChange } autoFocus/></Col>
+              : <Col><Input type="text" onChange={ this.onChange } /></Col>
           }
         </Row>
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Remove the hard-coded `autoFocus` attributes from the auth-related jsx files. Replace with JavaScript to set the focus to the first `input` element in the auth modal.



### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes #7711


### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I tested it with using the swagger.json linked to in the issue. Also the automated test that was added to test the autoFocus still passes after this change.


### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.

There is an existing test for this.
