### PR TITLE
Add a tool that can help users quickly try this app?

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Swagger UI Version | Release Date | OpenAPI Spec compatibility | Notes
 ## Documentation
 
 #### Usage
+- Run in cloud without installation [![TeamCode try-it-now](https://static01.teamcode.com/badge/demo.svg)](https://www.teamcode.com/tin/clone?applicationId=270139780752936960)
 - [Installation](docs/usage/installation.md)
 - [Configuration](docs/usage/configuration.md)
 - [CORS](docs/usage/cors.md)


### PR DESCRIPTION
Hello, we are TeamCode. We have created a Tin application for your app, which help your users to quickly run and try your app without having to install and configure the environment. You don't need to pay for this service. Hope it can help you better promote the app. Thx.
 you can try it: https://www.teamcode.com/tin/clone?applicationId=270139780752936960
 Read the guide: https://www.teamcode.com/docs/en-US/tin/clone-tin

This is the entire usage process：
1. Users click the badge Running in Cloud. 
2. Sign up first if they have not logged in. 
3. After that, they will be directed to the Clone page and start to build & run this app.