### PR TITLE
test(cypress): add wait time for bugs/5043 to resolve spec

### DIFF
--- a/test/e2e-cypress/tests/bugs/5043.js
+++ b/test/e2e-cypress/tests/bugs/5043.js
@@ -1,9 +1,8 @@
-import repeat from "lodash/repeat"
-
 describe("#5043: path-level $ref path items should inherit global consumes/produces", () => {
   it("should render consumes options correctly", () => {
     cy
       .visit("/?url=/documents/bugs/5043/swagger.yaml")
+      .wait(500) // HACK: wait for external spec ref to resolve (swagger.yaml->status.yaml)
       .get("#operations-pet-findPetsByStatus")
       .click()
       .get(".try-out__btn")
@@ -18,6 +17,7 @@ describe("#5043: path-level $ref path items should inherit global consumes/produ
   it("should render produces options correctly", () => {
     cy
       .visit("/?url=/documents/bugs/5043/swagger.yaml")
+      .wait(500) // HACK: wait for external spec ref to resolve (swagger.yaml->status.yaml)
       .get("#operations-pet-findPetsByStatus")
       .click()
       .get(".try-out__btn")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

After loading initial page and `swagger.yaml`, add a 500ms wait to the `cy` chain. The hypothesis is that the intermittent failures are due to insufficient time from when Cypress loads the page successfully and begins its assertions, and when the definition finishes resolving the external reference file. E.g. hopefully this allows sufficient time for the external reference `status.yaml` to resolve within `swagger.yaml`.  

Also, without success, attempted to import yaml into Cypress test without webpack modification (loaders), as well as tried loading a file from the static directory (and non /fixture directory) to use with `cy.fixture`. 


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

hopefully fixes #7768

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Cypress test still passes locally, albeit with extra delay time.

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
