### PR TITLE
Fix #5384 - change oauth2RedirectUrl default value

### DIFF
--- a/src/core/index.js
+++ b/src/core/index.js
@@ -31,7 +31,7 @@ export default function SwaggerUI(opts) {
     maxDisplayedTags: null,
     filter: null,
     validatorUrl: "https://validator.swagger.io/validator",
-    oauth2RedirectUrl: `${window.location.protocol}//${window.location.host}/oauth2-redirect.html`,
+    oauth2RedirectUrl: `${window.location.href.replace(/index\.html$/, "")}/oauth2-redirect.html`,
     persistAuthorization: false,
     configs: {},
     custom: {},

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -31,7 +31,7 @@ export default function SwaggerUI(opts) {
     maxDisplayedTags: null,
     filter: null,
     validatorUrl: "https://validator.swagger.io/validator",
-    oauth2RedirectUrl: `${window.location.href.replace(/index\.html$/, "")}/oauth2-redirect.html`,
+    oauth2RedirectUrl: `${window.location.protocol}//${window.location.host}${window.location.pathname.replace(/index\.html$/, "")}oauth2-redirect.html`,
     persistAuthorization: false,
     configs: {},
     custom: {},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Changed default `oauth2RedirectUrl` value.
Behavior is changed for cases, when Swagger UI is used inside Docker container with `BASE_URL` set to anything except `/`.
For default usecase behavior remains the same.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->
Fixes #5384
Fixes #6591
Maybe related to #4676


### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually.

I tested if redirect uri will be generated properly or not within single docker container,
with configured forward rules to different paths.

Example:
 - base url - `http://localhost:9004/` (default `BASE_URL="/"`)
   - before my fix - `http://localhost:9004/oauth2-redirect.html`
   - after - `http://localhost:9004/oauth2-redirect.html` (same result)
   
 - base url - `http://localhost:9004/index.html` (also default `BASE_URL="/"`)
   - before - `http://localhost:9004/oauth2-redirect.html`
   - after - `http://localhost:9004/oauth2-redirect.html` (same result)
   
 - base url - `http://localhost:9004/swagger-ui/` (`BASE_URL="/swagger-ui/"`)
   - before - `http://localhost:9004/oauth2-redirect.html` - wrong URL, 404
   - after - `http://localhost:9004/swagger-ui/oauth2-redirect.html` - right URL, auth works
   
 - base url - `http://localhost:9004/swagger-ui/index.html` (`BASE_URL="/swagger-ui/"`)
   - before my fix - `http://localhost:9004/oauth2-redirect.html` - also wrong
   - after - `http://localhost:9004/swagger-ui/oauth2-redirect.html` - right URL, `index.html` is cut off before appending `oauth2-redirect.html`

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [x] My changes require a change to the project documentation.
  - even if this PR will not be accepted I think `oauth2RedirectUrl` defaults should be documented
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
