### PR TITLE
Amend documentation for Docker mounting local files

### DIFF
--- a/docs/usage/installation.md
+++ b/docs/usage/installation.md
@@ -72,7 +72,7 @@ Will start nginx with Swagger UI on port 80.
 Or you can provide your own swagger.json on your host
 
 ```
-docker run -p 80:8080 -e SWAGGER_JSON=/foo/swagger.json -v /bar:/foo swaggerapi/swagger-ui
+docker run -p 80:8080 -e SWAGGER_JSON=swagger.json -v /bar/swagger.json:/usr/share/nginx/html/swagger.json swaggerapi/swagger-ui
 ```
 
 The base URL of the web application can be changed by specifying the `BASE_URL` environment variable:


### PR DESCRIPTION



### Description


When using the previous command, this no longer appears to work,
resulting an HTTP 403 when browsing to the file.

We appear to need to mount/copy the OpenAPI specification into the Nginx
web root to be able to serve it correctly.


### Motivation and Context







### How Has This Been Tested?




Locally, on:

```
Docker version 20.10.12, build e91ed5707e
```


### Screenshots (if appropriate):



## Checklist



### My PR contains...

- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [x] My changes require a change to the project documentation.
- [x] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.

