### PR TITLE
fix(swagger-ui-react): fix prop type for plugins

### DIFF
--- a/flavors/swagger-ui-react/index.jsx
+++ b/flavors/swagger-ui-react/index.jsx
@@ -106,7 +106,10 @@ SwaggerUI.propTypes = {
     PropTypes.oneOf(["get", "put", "post", "delete", "options", "head", "patch", "trace"])
   ),
   queryConfigEnabled: PropTypes.bool,
-  plugins: PropTypes.arrayOf(PropTypes.object),
+  plugins: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.object),
+    PropTypes.func,
+  ]),
   displayOperationId: PropTypes.bool,
   showMutatedRequest: PropTypes.bool,
   defaultModelExpandDepth: PropTypes.number,


### PR DESCRIPTION
### Description
Plugins can be an array of functions and/or and array of objects. Prop type validation is failing for functions.

### Motivation and Context
Functions are already supported by prop type validation is throwing a warning.

### How Has This Been Tested?
I did a create a package locally with the changes and tested it with an array of functions and objects.

## Checklist

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [X] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [X] are not breaking changes.

### Documentation
- [X] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [X] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
