### PR TITLE
fix: Export ./dist/swagger-ui.css

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "./dist/swagger-ui.js",
   "module": "./dist/swagger-ui-es-bundle-core.js",
   "exports": {
-    "./swagger-ui.css": "./swagger-ui.css",
+    "./dist/swagger-ui.css": "./dist/swagger-ui.css",
     ".": {
       "import": "./dist/swagger-ui-es-bundle-core.js",
       "require": "./dist/swagger-ui.js"


### PR DESCRIPTION
### Description
This PR corrects the CSS export in `package.json` from `./swagger-ui.css` to `./dist/swagger-ui.css`.

### Motivation and Context
v4.6.0 has an incorrect export in `package.json` for `./dist/swagger-ui.css` which causes the following error when importing the file:

```
Module not found: Error: Package path ./dist/swagger-ui.css is not exported from package
node_modules/swagger-ui (see exports field in node_modules/swagger-ui/package.json)
```

### How Has This Been Tested?
This was tested in our Vue SPA which imports swagger-ui by switching to our fork and changing the export to the correct path for the CSS file. With the path in v4.6.0, the application doesn't build at all, whereas with the corrected path, it all works again.

Changing the import from `import 'swagger-ui/dist/swagger-ui.css';` to `import 'swagger-ui/swagger-ui.css';` results in `Module not found: Error: Can't resolve 'swagger-ui/swagger-ui.css'`, whereas fixing the export in `package.json` results in the original import line working, thus I believe this is the correct fix for the issue.

## Checklist

### My PR contains... 
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.

(I don't think this really needs a test, since it's just a broken export.)