### PR TITLE
fix(UI): allow summary path to be selectable

### DIFF
--- a/src/style/_layout.scss
+++ b/src/style/_layout.scss
@@ -317,6 +317,7 @@
     {
         flex-shrink: 0;
         max-width: calc(100% - 110px - 15rem);
+        user-select: text;
     }
 
     .opblock-summary-path__deprecated


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

This allows the user to select and copy the path within the summary.
<!--- Describe your changes in detail -->



### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->
Currently it is not possible to copy the API path from the swagger-ui and it must by typed by yourself.



### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Open any API, try to select the path with the Mouse + Drag.
I tried to test this with Cypress but seems to be a bit difficult.

### Screenshots (if appropriate):

![swagger](https://user-images.githubusercontent.com/11063025/156795281-a56bd218-9354-4e12-8249-ce23da7e560e.png)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [X] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [X] are not breaking changes.

### Documentation
- [X] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [X] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
