### PR TITLE
Swagger UI should work without Node.js polyfills - rewrite generateCodeVerifier to avoid transitive dependency on Buffer (Node.js API)

### DIFF
--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -23,7 +23,6 @@ import { memoizedSampleFromSchema, memoizedCreateXMLExample } from "core/plugins
 import win from "./window"
 import cssEscape from "css.escape"
 import getParameterSchema from "../helpers/get-parameter-schema"
-import randomBytes from "randombytes"
 import shaJs from "sha.js"
 import YAML from "js-yaml"
 import { fromByteArray } from "base64-js";

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -26,6 +26,7 @@ import getParameterSchema from "../helpers/get-parameter-schema"
 import randomBytes from "randombytes"
 import shaJs from "sha.js"
 import YAML from "js-yaml"
+import { fromByteArray } from "base64-js";
 
 
 const DEFAULT_RESPONSE_KEY = "default"
@@ -889,11 +890,20 @@ export function paramToValue(param, paramValues) {
   return values[0]
 }
 
-// adapted from https://auth0.com/docs/flows/guides/auth-code-pkce/includes/create-code-verifier
 export function generateCodeVerifier() {
-  return b64toB64UrlEncoded(
-    randomBytes(32).toString("base64")
-  )
+  // Generate a 32 bits of randomness and encode as base64
+  //
+  // Avoid using the "randombytes" package - because it depends on a library
+  // that requires a polyfill for the Buffer package in Nodejs.
+
+  const arr = []
+  const maxValue = Math.pow(2,8) - 1;
+  for (var i = 0; i < 32; ++i) {
+    const randomByte = Math.floor(Math.random() * maxValue)
+    arr.push(randomByte)
+  }
+
+  return fromByteArray(arr)
 }
 
 export function createCodeChallenge(codeVerifier) {

--- a/test/unit/core/utils.js
+++ b/test/unit/core/utils.js
@@ -1899,7 +1899,7 @@ describe("utils", () => {
     it("should produce a string that's valid base64", () => {
       const codeVerifier = generateCodeVerifier()
 
-      expect(() => atob(codeVerifier)).not.toThrow();
+      expect(() => window.atob(codeVerifier)).not.toThrow();
     })
   })
 

--- a/test/unit/core/utils.js
+++ b/test/unit/core/utils.js
@@ -1899,6 +1899,7 @@ describe("utils", () => {
     it("should produce a string that's valid base64", () => {
       const codeVerifier = generateCodeVerifier()
 
+      // If decoding from base64 string doesn't throw, we're good.
       expect(() => window.atob(codeVerifier)).not.toThrow();
     })
   })

--- a/test/unit/core/utils.js
+++ b/test/unit/core/utils.js
@@ -1895,6 +1895,12 @@ describe("utils", () => {
       // Source: https://tools.ietf.org/html/rfc7636#section-4.1
       expect(codeVerifier.length).toBeGreaterThanOrEqual(43)
     })
+
+    it("should produce a string that's valid base64", () => {
+      const codeVerifier = generateCodeVerifier()
+
+      expect(() => atob(codeVerifier)).not.toThrow();
+    })
   })
 
   describe("createCodeChallenge", () => {


### PR DESCRIPTION
This PR rewrites generateCodeVerifier to not require the "randombytes" package.

### Motivation and Context

As of today, I cannot use `swagger-ui-react` in my Vite.js application without polyfills. When I try to build, I error out on a missing `Buffer` in `safe-buffer`. `src/core/utils.js` depends on `randombytes`, which depends on `safebuffer`. `safebuffer` uses `Buffer` - which is a Node.js API, and requires polyfilling outside of Node.js.

I'd like to avoid having to polyfill.

Additional changes may be required to make `swagger-ui-react` work out of the box with a non-polyfilled application, but this is a start. I'm making this as a PR to make a specific suggestion -- and hear whether avoiding polyfills is something you're interested in.

There are some references to `randombytes` in [model-example.jsx][model-example.jsx], but that looks like example code to me.

[model-example.jsx]: https://github.com/teodorlu/swagger-ui/tree/67cbd1784d6cfc276a1848784844988352cf6764/src/core/components/model-example.jsx


### How Has This Been Tested?

1. I've tested the function manually in a separate Node.js REPL
2. The unit test for `generateCodeVerifier` is still passing
3. I've added a unit test that checks that the output from `generateCodeVerifier` is a valid base64 string.


### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [x] Dependency changes (any modification to dependencies in `package.json`)
    - I've removed the dependency on `randombytes` from `src/core/utils.js`
    - `src/core/components/model-example.jsx` still uses `randombytes`. That looks like example code to me. I'm hoping it's possible to replace the sample code with something else, so that we can remove the dependency on `randombytes`. Suggestions welcome from maintainers that are more familiar with the Swagger UI codebase than I.
    - I haven't touched `randombytes` in package.json (yet)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
