### PR TITLE
test(oath): for authorization bearer

### DIFF
--- a/test/e2e-cypress/static/documents/features/auth-bearer-flow.yaml
+++ b/test/e2e-cypress/static/documents/features/auth-bearer-flow.yaml
@@ -1,0 +1,20 @@
+openapi: 3.0.0
+info:
+  title: Bearer auth test
+  version: 1.0.0
+servers:
+  # - url: https://httpbin.org # live external url
+  - url: http://localhost:3231 # will need to mock
+paths:
+  /get:
+    get:
+      responses:
+        '200':
+          description: ok
+security:
+  - bearerAuth: []
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer

--- a/test/e2e-cypress/tests/features/auth-bearer-flow.js
+++ b/test/e2e-cypress/tests/features/auth-bearer-flow.js
@@ -1,0 +1,51 @@
+describe("OAuth2 Bearer flow", () => {
+  beforeEach(() => {
+    const staticResponse = {
+      statusCode: 200,
+      body: {
+        name: "not a random secret for test",
+      }
+    }
+    cy.intercept("GET", "/get*", staticResponse).as(
+      "tokenRequest"
+    )
+  })
+
+  it("should be focused on input field with aria-label", () => {
+    cy.visit(
+      "/?url=/documents/features/auth-bearer-flow.yaml"
+    )
+      .get("button.authorize")
+      .click()
+    cy.focused()
+      .should("have.attr", "aria-label").and("eq", "auth-bearer-value")
+  })
+  it("should make a header request with proper sample cURL header", () => {
+    cy.visit(
+      "/?url=/documents/features/auth-bearer-flow.yaml"
+    )
+      .get("button.authorize")
+      .click()
+      .get("section > input")
+      .type("secret_token")
+      .get(".auth-btn-wrapper > .authorize")
+      .click()
+      .get("button.close-modal")
+      .click()
+      // Try-it-out
+      .get("#operations-default-get_get")
+      .click()
+      .get(".btn.try-out__btn")
+      .click()
+      .get(".btn.execute")
+      .click()
+    cy.wait("@tokenRequest")
+      .its("request")
+      .its("headers")
+      .its("authorization")
+      .should("equal", "Bearer secret_token")
+      .get(".curl")
+      .contains("Authorization: Bearer secret_token")
+      .should("be.visible")
+  })
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Cypress E2E test for Oauth2 Authorization Bearer. Mocks Oauth2 server response.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

This PR provides the supporting tests to PR #7926 . There was previously a lack of test(s) for a simple Authorization Bearer use case.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

n/a

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
