### PR TITLE
Instruct browser not to cache swagger-initializer.js

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -38,6 +38,11 @@ http {
       alias            /usr/share/nginx/html/;
       expires 1d;
 
+      location ~ swagger-initializer.js {
+        expires -1;
+        include cors.conf;
+      }
+
       location ~* \.(?:json|yml|yaml)$ {
         #SWAGGER_ROOT
         expires -1;


### PR DESCRIPTION
### Description

Instructs the browser to always request the swagger-initializer.js file from the server, which contains configuration data.

### Motivation and Context

Fixes #7959 

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I tested this by building the Docker image and verifying that the repro steps in #7959 now work as expected.

I was unable to add an e2e test because this was an nginx-related issue, and as far as I could tell we do not test the nginx server.

1. Run `docker build -t swagger .`
1. Run `docker run -p 8080:8080 -e URL=foo swagger`
1. Visit http://localhost:8080
   <details>
   <summary>Network Screenshot...</summary>
   <img width="455" alt="Screen Shot 2022-03-29 at 7 12 26 PM" src="https://user-images.githubusercontent.com/9969202/160736920-922d3225-5455-4c78-92ea-720e1cfa60e2.png">
   </detail>
1. Stop container. Run `docker run -p 8080:8080 -e URL=bar swagger`
1. Refresh page. The browser fetches the latest swagger-initializer.js file ✅
   <details>
   <summary>Network Screenshot...</summary>
   <img width="451" alt="Screen Shot 2022-03-29 at 7 13 13 PM" src="https://user-images.githubusercontent.com/9969202/160737008-384ff13a-f27c-46f2-88f6-bfd5b78ed761.png">
   </details>
1. Refresh page again. The browser uses the cached swagger-initializer.js file because there was no change. ✅
   <details>
   <summary>Network Screenshot...</summary>
   <img width="450" alt="Screen Shot 2022-03-29 at 7 13 47 PM" src="https://user-images.githubusercontent.com/9969202/160737070-cc31c5d7-a0ec-46a2-bcad-9e2aca41fe5b.png">
   </details>
1. Other `*.js` files are unaffected by the new nginx rule ✅ 
   <details>
   <summary>Network Screenshot...</summary>
   <img width="428" alt="Screen Shot 2022-03-29 at 6 49 02 PM" src="https://user-images.githubusercontent.com/9969202/160734613-3787c0f8-988b-426f-9165-f8e1607ca0c0.png">
   </details>

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
