### PR TITLE
Revert "fix(oas3): set markdown line breaks to true"

### DIFF
--- a/src/core/plugins/oas3/wrap-components/markdown.jsx
+++ b/src/core/plugins/oas3/wrap-components/markdown.jsx
@@ -8,7 +8,6 @@ import { sanitizer } from "core/components/providers/markdown"
 const parser = new Remarkable("commonmark")
 parser.block.ruler.enable(["table"])
 parser.set({ linkTarget: "_blank" })
-parser.set({ breaks: true })
 
 export const Markdown = ({ source, className = "", getConfigs }) => {
   if(typeof source !== "string") {


### PR DESCRIPTION
Reverts swagger-api/swagger-ui#7942

Fixes #6849 

Per OpenAPI 3.0 spec [here](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md#rich-text-formatting), 

> Throughout the specification description fields are noted as supporting CommonMark markdown formatting. Where OpenAPI tooling renders rich text it MUST support, at a minimum, markdown syntax as described by [CommonMark 0.27](http://spec.commonmark.org/0.27/).


If a 2-line rendering is desired, [hard-line breaks](https://spec.commonmark.org/0.27/#hard-line-break) should be used, e.g. 2 white spaces, or a "\\" char, at the end of the line.

Note, this means that rendering of the description fields are indeed specified differently between OpenAPI 2.0 and OpenAPI 3.0.
