### PR TITLE
Revert "Improve Dockerfile: smaller image and default non-root user"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,13 +14,16 @@ ENV PORT 8080
 ENV BASE_URL ""
 ENV SWAGGER_JSON_URL ""
 
-COPY --chown=nginx:nginx --chmod=0666 ./docker/nginx.conf ./docker/cors.conf /etc/nginx/
+COPY ./docker/nginx.conf ./docker/cors.conf /etc/nginx/
 
 # copy swagger files to the `/js` folder
-COPY --chmod=0666 ./dist/* /usr/share/nginx/html/
-COPY --chmod=0555 ./docker/docker-entrypoint.d/ /docker-entrypoint.d/
-COPY --chmod=0666 ./docker/configurator /usr/share/nginx/configurator
+COPY ./dist/* /usr/share/nginx/html/
+COPY ./docker/docker-entrypoint.d/ /docker-entrypoint.d/
+COPY ./docker/configurator /usr/share/nginx/configurator
 
-RUN chmod 777 /usr/share/nginx/html/ /etc/nginx/ /var/cache/nginx/ /var/run/
+RUN chmod -R a+rw /usr/share/nginx && \
+    chmod -R a+rw /etc/nginx && \
+    chmod -R a+rw /var && \
+    chmod -R a+rw /var/run
 
 EXPOSE 8080


### PR DESCRIPTION
Reverts swagger-api/swagger-ui#7470

reason: breaks downstream deployment jobs to build and publish Docker