### PR TITLE
Pin swagger-client dependency to exact version

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "reselect": "^4.1.5",
     "serialize-error": "^8.1.0",
     "sha.js": "^2.4.11",
-    "swagger-client": "^3.18.4",
+    "swagger-client": "=3.18.4",
     "url-parse": "^1.5.8",
     "xml": "=1.0.1",
     "xml-but-prettier": "^1.0.1",


### PR DESCRIPTION
On at least 3 occasions, including this morning, updates to swagger-client have caused versions of swagger-ui to stop working.

This morning, [changes to swagger-client's usage of `btoa`](https://github.com/swagger-api/swagger-js/commit/4832f3249df3415b168fcd3ac45eb1a463c038b8) were [released](https://github.com/swagger-api/swagger-js/commits/v3.18.5). Our build, depending on swagger-ui-react 4.1.0, failed with errors about the absence of the btoa module. We traced these errors to swagger-ui's bundled `swagger-ui.js`, which included some code from an older swagger-client version that expected `btoa` to still be present.

Previous [issues include](https://github.com/swagger-api/swagger-ui/issues/7436) the removal of [isomorphic-form-data](https://github.com/swagger-api/swagger-js/pull/2154) around swagger-ui release 3.51.2, and the removal of [querystring-browser](https://github.com/swagger-api/swagger-js/pull/2288) around swagger-ui [release 3.52.5](https://github.com/swagger-api/swagger-ui/issues/7556)

By pinning the swagger-client dependency to an exact version, issues with transitive dependencies should be mitigated. Of course, other dependencies may still pose similar problems, but swagger-client has been the recurring theme so far.

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [x] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
