### PR TITLE
fix: set yaml parser load option to JSON_SCHEMA

### DIFF
--- a/src/core/plugins/spec/actions.js
+++ b/src/core/plugins/spec/actions.js
@@ -1,4 +1,4 @@
-import YAML from "js-yaml"
+import YAML, { JSON_SCHEMA } from "js-yaml"
 import { Map } from "immutable"
 import parseUrl from "url-parse"
 import { serializeError } from "serialize-error"
@@ -62,7 +62,7 @@ export const parseToJson = (str) => ({specActions, specSelectors, errActions}) =
   try {
     str = str || specStr()
     errActions.clear({ source: "parser" })
-    json = YAML.load(str)
+    json = YAML.load(str, { schema: JSON_SCHEMA })
   } catch(e) {
     // TODO: push error to state
     console.error(e)

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -25,7 +25,7 @@ import cssEscape from "css.escape"
 import getParameterSchema from "../helpers/get-parameter-schema"
 import randomBytes from "randombytes"
 import shaJs from "sha.js"
-import YAML from "js-yaml"
+import YAML, { JSON_SCHEMA } from "js-yaml"
 
 
 const DEFAULT_RESPONSE_KEY = "default"
@@ -651,7 +651,7 @@ const getYamlSampleSchema = (schema, config, contentType, exampleOverride) => {
     yamlString = YAML.dump(YAML.load(jsonExample), {
 
       lineWidth: -1 // don't generate line folds
-    })
+    }, { schema: JSON_SCHEMA })
     if(yamlString[yamlString.length - 1] === "\n") {
       yamlString = yamlString.slice(0, yamlString.length - 1)
     }

--- a/test/e2e-cypress/static/documents/features/spec-parse-to-json.yaml
+++ b/test/e2e-cypress/static/documents/features/spec-parse-to-json.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.0
+
+info:
+  version: 1.0.0
+  title: Native date formats in YAML
+
+paths:
+  /foo:
+    get: 
+      description: Has date without quotes
+      responses:
+        '200':
+          description: Ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  without-quotes:
+                    type: string
+                    format: date
+                    example: 1999-11-31
+                  with-quotes:
+                    type: string
+                    format: date
+                    example: "1999-12-31"

--- a/test/e2e-cypress/tests/features/spec-parse-to-json.js
+++ b/test/e2e-cypress/tests/features/spec-parse-to-json.js
@@ -1,0 +1,23 @@
+/**
+ * @prettier
+ */
+
+describe("Parse YAML as YAML@1.2 with json_schema for all JSON-supported types", () => {
+  it("should have date string even without quotes", () => {
+    cy.visit("/?url=/documents/features/spec-parse-to-json.yaml")
+      .get("#operations-default-get_foo")
+      .click()
+      // Responses -> example value tab
+      .get(".language-json > :nth-child(3)")
+      .should("have.text", "\"without-quotes\"")
+      .get(".language-json > :nth-child(5)")
+      .should("have.text", "\"1999-11-31\"")
+      // Responses -> schema tab
+      .get(".model-example > .tab > :nth-child(2)")
+      .click()
+      .get(":nth-child(1) > :nth-child(2) > .model > :nth-child(1) > .prop > .property") // first element, without-quotes
+      .should("have.text", "example: 1999-11-31")
+      .get(":nth-child(2) > :nth-child(2) > .model > :nth-child(1) > .prop > .property") // second element, with quotes
+      .should("have.text", "example: 1999-12-31")
+  })
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Add a `JSON_SCHEMA` flag to `YAML.load()` to forcibly set a schema to use by `js-yaml@4`.

```
JSON_SCHEMA - all JSON-supported types: http://www.yaml.org/spec/1.2/spec.html#id2803231
```

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

fixes #8021 

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

New Cypress E2E tests

### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
