### PR TITLE
Overflow problem in response-inner div solved.

### DIFF
--- a/src/style/_layout.scss
+++ b/src/style/_layout.scss
@@ -595,7 +595,8 @@
 .responses-inner
 {
     padding: 20px;
-
+    overflow: hidden;
+    
     h5,
     h4
     {


### PR DESCRIPTION
### Description
When api response involves long string response, `responses-inner` div overflows.

### Screenshots about bug:
<img width="1433" alt="Screen Shot 2022-05-16 at 23 36 13" src="https://user-images.githubusercontent.com/50163185/168678452-a7182a97-7152-43d2-a68f-5b458a1c9ef7.png">

### Solution Description
After adding `overflow: hidden;` to `responses-inner` css class, bug fixed.

### Screenshots after solution applied:
<img width="1424" alt="Screen Shot 2022-05-16 at 23 39 37" src="https://user-images.githubusercontent.com/50163185/168678838-a91672cd-a4b2-49ff-807f-32863668142c.png">
