### PR TITLE
Documentation: add SWAGGER_JSON_URL section

### DIFF
--- a/docs/usage/installation.md
+++ b/docs/usage/installation.md
@@ -75,6 +75,12 @@ Or you can provide your own swagger.json on your host
 docker run -p 80:8080 -e SWAGGER_JSON=/foo/swagger.json -v /bar:/foo swaggerapi/swagger-ui
 ```
 
+You can also provide a URL to a swagger.json on an external host:
+
+```
+docker run -p 80:8080 -e SWAGGER_JSON_URL=https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json swaggerapi/swagger-ui
+```
+
 The base URL of the web application can be changed by specifying the `BASE_URL` environment variable:
 
 ```

--- a/docs/usage/installation.md
+++ b/docs/usage/installation.md
@@ -78,7 +78,7 @@ docker run -p 80:8080 -e SWAGGER_JSON=/foo/swagger.json -v /bar:/foo swaggerapi/
 You can also provide a URL to a swagger.json on an external host:
 
 ```
-docker run -p 80:8080 -e SWAGGER_JSON_URL=https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json swaggerapi/swagger-ui
+docker run -p 80:8080 -e SWAGGER_JSON_URL=https://petstore3.swagger.io/api/v3/openapi.json swaggerapi/swagger-ui
 ```
 
 The base URL of the web application can be changed by specifying the `BASE_URL` environment variable:


### PR DESCRIPTION
### Description
Document the existing `SWAGGER_JSON_URL` parameter [here](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/installation.md#docker).

### Motivation and Context
Took me a little while to find the parameter, thought I'd be useful to document. See https://github.com/swagger-api/swagger-ui/issues/7951.

