### PR TITLE
feat(ux): add copy to clipboard

### DIFF
--- a/src/core/components/copy-to-clipboard-btn.jsx
+++ b/src/core/components/copy-to-clipboard-btn.jsx
@@ -1,0 +1,26 @@
+import React from "react"
+import { CopyToClipboard } from "react-copy-to-clipboard"
+import PropTypes from "prop-types"
+
+/**
+ * @param {{ textToCopy: string }} props
+ * @returns {JSX.Element}
+ * @constructor
+ */
+export default class CopyToClipboardBtn extends React.Component {
+  render() {
+    return (
+      <div className="view-line-link copy-to-clipboard" title="Copy to clipboard">
+        <CopyToClipboard text={this.props.textToCopy}>
+          <svg width="15" height="16">
+            <use href="#copy" xlinkHref="#copy" />
+          </svg>
+        </CopyToClipboard>
+      </div>
+    )
+  }
+
+  static propTypes = {
+    textToCopy: PropTypes.string.isRequired,
+  }
+}

--- a/src/core/components/operation-summary.jsx
+++ b/src/core/components/operation-summary.jsx
@@ -58,6 +58,7 @@ export default class OperationSummary extends PureComponent {
     const OperationSummaryMethod = getComponent("OperationSummaryMethod")
     const OperationSummaryPath = getComponent("OperationSummaryPath")
     const JumpToPath = getComponent("JumpToPath", true)
+    const CopyToClipboardBtn = getComponent("CopyToClipboardBtn", true)
 
     const hasSecurity = security && !!security.count()
     const securityIsOptional = hasSecurity && security.size === 1 && security.first().isEmpty()
@@ -96,6 +97,7 @@ export default class OperationSummary extends PureComponent {
               }}
             />
         }
+        <CopyToClipboardBtn textToCopy={`${specPath.get(1)}`} />
         <JumpToPath path={specPath} />{/* TODO: use wrapComponents here, swagger-ui doesn't care about jumpToPath */}
       </div>
     )

--- a/src/core/components/svg-assets.jsx
+++ b/src/core/components/svg-assets.jsx
@@ -35,6 +35,12 @@ const SvgAssets = () =>
           <path d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"/>
         </symbol>
 
+        <symbol viewBox="0 0 15 16" id="copy">
+          <g transform='translate(2, -1)'>
+            <path fill='#ffffff' fillRule='evenodd' d='M2 13h4v1H2v-1zm5-6H2v1h5V7zm2 3V8l-3 3 3 3v-2h5v-2H9zM4.5 9H2v1h2.5V9zM2 12h2.5v-1H2v1zm9 1h1v2c-.02.28-.11.52-.3.7-.19.18-.42.28-.7.3H1c-.55 0-1-.45-1-1V4c0-.55.45-1 1-1h3c0-1.11.89-2 2-2 1.11 0 2 .89 2 2h3c.55 0 1 .45 1 1v5h-1V6H1v9h10v-2zM2 5h8c0-.55-.45-1-1-1H8c-.55 0-1-.45-1-1s-.45-1-1-1-1 .45-1 1-.45 1-1 1H3c-.55 0-1 .45-1 1z'></path>
+          </g>
+        </symbol>
+
       </defs>
     </svg>
   </div>

--- a/src/core/presets/base.js
+++ b/src/core/presets/base.js
@@ -63,6 +63,7 @@ import Info, {
 } from "core/components/info"
 import InfoContainer from "core/containers/info"
 import JumpToPath from "core/components/jump-to-path"
+import CopyToClipboardBtn from "core/components/copy-to-clipboard-btn"
 import Footer from "core/components/footer"
 import FilterContainer from "core/containers/filter"
 import ParamBody from "core/components/param-body"
@@ -113,6 +114,7 @@ export default function() {
       info: Info,
       InfoContainer,
       JumpToPath,
+      CopyToClipboardBtn,
       onlineValidatorBadge: OnlineValidatorBadge,
       operations: Operations,
       operation: Operation,

--- a/src/style/_buttons.scss
+++ b/src/style/_buttons.scss
@@ -205,3 +205,10 @@ button
     height: 18px;
   }
 }
+
+// overrides for copy to clipboard button
+.opblock .opblock-summary .view-line-link.copy-to-clipboard
+{
+    height: 26px;
+    position: unset;
+}

--- a/src/style/_layout.scss
+++ b/src/style/_layout.scss
@@ -376,6 +376,10 @@
             {
                 width: 18px;
                 margin: 0 5px;
+
+                &.copy-to-clipboard {
+                    width: 24px;
+                }
             }
         }
     }


### PR DESCRIPTION
Add a copy to the clipboard button based on the discussion [here](https://github.com/swagger-api/swagger-ui/pull/7890)

### Description
You click on the button and it copies the path to the clipboard (e.g. /pet/{petId}/uploadImage).


### Motivation and Context
Fixes #5799


### How Has This Been Tested?
1. Hover on any route path - this will make the button on the right (next to the authorize button) appear
2. Click on the button
3. Press ctrl + v anywhere to see what was copied



### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/7334618/178813597-7334673d-313d-4d99-9450-e44a91cddcd8.png)


## Checklist

### My PR contains... 
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
