### PR TITLE
fix(oauth2): handle redirect params properly

### DIFF
--- a/dev-helpers/oauth2-redirect.html
+++ b/dev-helpers/oauth2-redirect.html
@@ -12,7 +12,7 @@
         var isValid, qp, arr;
 
         if (/code|token|error/.test(window.location.hash)) {
-            qp = window.location.hash.substring(1);
+            qp = window.location.hash.substring(1).replace('?', '&');
         } else {
             qp = location.search.substring(1);
         }

--- a/dist/oauth2-redirect.html
+++ b/dist/oauth2-redirect.html
@@ -13,7 +13,7 @@
         var isValid, qp, arr;
 
         if (/code|token|error/.test(window.location.hash)) {
-            qp = window.location.hash.substring(1);
+            qp = window.location.hash.substring(1).replace('?', '&');
         } else {
             qp = location.search.substring(1);
         }


### PR DESCRIPTION
Given the following URL after user logged in using [casdoor](https://github.com/casdoor/casdoor), the UI app can not validate (checking the state param) the response bc an error parsing the params

```
redirect with hash
---
http://.../static/oauth2-redirect.html#token=eyJhbGci....?state=TW9....Sk=&token_type=bearer
```

before:
```js
        if (/code|token|error/.test(window.location.hash)) {
            qp = window.location.hash.substring(1);
        } else {
            qp = location.search.substring(1);
        }
```

after:
```js
        if (/code|token|error/.test(window.location.hash)) {
            qp = window.location.hash.substring(1).replace('?', '&');
        } else {
            qp = location.search.substring(1);
        }
```

btw, the default behavior on oauth2 would try to get the value for `access_token` property from the oauth response if you are using a different name for the TOKEN property, it should be specified under `components/securitySchemas/<key>/x-tokenName`

```js
components: {
        securitySchemes: {
          casdoor: {
            type: 'oauth2',
            'x-tokenName': 'awesomeTokenName', 
            flows: {
              implicit: {
                authorizationUrl: `http://blablabla/login/oauth/authorize`,
                scopes: {},
              },
            },
          },
        },
      }
```

related #6421