### PR TITLE
chore(security): use minimum 16.17.1-r0 in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM nginx:1.23.1-alpine
 
-RUN apk update && apk add --no-cache "nodejs>=14.17.6-r0"
+RUN apk update && apk add --no-cache "nodejs>=16.17.1-r0"
 
 LABEL maintainer="fehguy"
 


### PR DESCRIPTION
Refs https://github.com/swagger-api/swagger-ui/actions/runs/3224253196/jobs/5275194171