### PR TITLE
fix: show client secret input for PKCE auth code flow

### DIFF
--- a/docs/usage/oauth2.md
+++ b/docs/usage/oauth2.md
@@ -11,7 +11,7 @@ scopeSeparator | `OAUTH_SCOPE_SEPARATOR` |scope separator for passing scopes, en
 scopes | `OAUTH_SCOPES` |string array or scope separator (i.e. space) separated string of initially selected oauth scopes, default is empty array
 additionalQueryStringParams | `OAUTH_ADDITIONAL_PARAMS` |Additional query parameters added to `authorizationUrl` and `tokenUrl`. MUST be an object
 useBasicAuthenticationWithAccessCodeGrant | `OAUTH_USE_BASIC_AUTH` |Only activated for the `accessCode` flow.  During the `authorization_code` request to the `tokenUrl`, pass the [Client Password](https://tools.ietf.org/html/rfc6749#section-2.3.1) using the HTTP Basic Authentication scheme (`Authorization` header with `Basic base64encode(client_id + client_secret)`).  The default is `false`
-usePkceWithAuthorizationCodeGrant | `OAUTH_USE_PKCE` | Only applies to `Authorization Code` flows. [Proof Key for Code Exchange](https://tools.ietf.org/html/rfc7636) brings enhanced security for OAuth public clients. The default is `false`
+usePkceWithAuthorizationCodeGrant | `OAUTH_USE_PKCE` | Only applies to `Authorization Code` flows. [Proof Key for Code Exchange](https://tools.ietf.org/html/rfc7636) brings enhanced security for OAuth public clients. The default is `false` <br/><br/>_Note:_ This option does not hide the client secret input because [neither PKCE nor client secrets are replacements for each other](https://oauth.net/2/pkce/).
 
 ```javascript
 const ui = SwaggerUI({...})

--- a/src/core/components/auth/oauth2.jsx
+++ b/src/core/components/auth/oauth2.jsx
@@ -212,7 +212,7 @@ export default class Oauth2 extends React.Component {
         }
 
         {
-          ( (flow === AUTH_FLOW_APPLICATION || flow === AUTH_FLOW_ACCESS_CODE && !isPkceCodeGrant || flow === AUTH_FLOW_PASSWORD) && <Row>
+          ( (flow === AUTH_FLOW_APPLICATION || flow === AUTH_FLOW_ACCESS_CODE || flow === AUTH_FLOW_PASSWORD) && <Row>
             <label htmlFor="client_secret">client_secret:</label>
             {
               isAuthorized ? <code> ****** </code>

--- a/test/e2e-cypress/tests/features/auth-code-flow-pkce-without-secret.js
+++ b/test/e2e-cypress/tests/features/auth-code-flow-pkce-without-secret.js
@@ -1,5 +1,5 @@
 describe("Check client_secret for OAuth2 Authorization Code flow with and without PKCE (#6290)", () => {
-  it("should not display client_secret field for authorization code flow with PKCE", () => {
+  it("should display client_secret field for authorization code flow with PKCE", () => {
     cy.visit(
       "/?url=/documents/features/auth-code-flow-pkce-without-secret.yaml"
     )
@@ -19,7 +19,7 @@ describe("Check client_secret for OAuth2 Authorization Code flow with and withou
       .get(".flow")
       .contains("authorizationCode with PKCE")
       .get("#client_secret")
-      .should("not.exist")
+      .should("exist")
   })
 
   it("should display client_secret field for authorization code flow without PKCE", () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

Show the client secret input always (for the authorization code flow) regardless of the PKCE flag.

Closes #7913



### Motivation and Context

PKCE and Client Secrets are allowed to coexist and neither is designed as a replacement for the other. [1] It is wrong to assume that a client secret must not or cannot be used in combination with PKCE. Quite the opposite, when possible both PKCE and client secret should be used. [2] So the premises of #6290 and #8146 are not correct.

Admittedly, for users of the PKCE mechanism WITHOUT a client secret it might be a minor nuisance to see the client secret input in the Swagger UI. But they can just leave it empty. On the other hand, for users of the PKCE mechanism WITH a client secret it is more than just a nuisance if the client secret input is not shown. The Swagger UI becomes unusable for them (unless they've set a default value for the client secret, which will be used hiddenly without being shown to the user).

Therefore the right course of action for now would be to revert #7438 to show the client secret input always regardless of PKCE. In the future a new flag could be introduced to hide the client secret input regardless of the PKCE flag.

[1] https://oauth.net/2/pkce/
[2] https://www.oauth.com/oauth2-servers/pkce/



### How Has This Been Tested?

If the flag `usePkceWithAuthorizationCodeGrant` is set and the loaded API spec contains OAuth2 with the authorization code flow (i.e. `AUTH_FLOW_ACCESS_CODE`), the client secret input appears and an access token can be obtained from an authorization server requiring both PKCE and client secret.


### Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/18560720/199060972-096d1f7c-e9e3-463d-9bf1-ac5948213d2f.png)



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [x] My changes require a change to the project documentation.
- [x] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.


