### PR TITLE
Fix formatting Validation Error for Map items

### DIFF
--- a/src/core/plugins/spec/selectors.js
+++ b/src/core/plugins/spec/selectors.js
@@ -485,11 +485,17 @@ export const validationErrors = (state, pathMethod) => {
   paramValues.forEach( (p) => {
     let errors = p.get("errors")
     if ( errors && errors.count() ) {
-      errors.forEach( e => result.push(e))
+      errors
+        .map( e => {
+          if (e instanceof Map) {
+            return `${e.get("propKey")} : ${e.get("error")}`
+          } else {
+            return e
+          }
+        })
+        .forEach( e => result.push(e))
     }
   })
-
-  return result
 }
 
 export const validateBeforeExecute = (state, pathMethod) => {

--- a/src/core/plugins/spec/selectors.js
+++ b/src/core/plugins/spec/selectors.js
@@ -496,6 +496,7 @@ export const validationErrors = (state, pathMethod) => {
         .forEach( e => result.push(e))
     }
   })
+  return result
 }
 
 export const validateBeforeExecute = (state, pathMethod) => {


### PR DESCRIPTION
### Description
In the validationError Array rendered there are string and maps.
The maps Item are not rendered correctly as you cam see in the image below

![image](https://user-images.githubusercontent.com/24287409/210406111-67d4891c-38aa-4441-bbee-1d8cdfe9d44b.png)

I've fixed the code to render properly these items

![image](https://user-images.githubusercontent.com/24287409/210406314-98e1e553-a845-426d-ac10-d8cdddc2729f.png)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [X] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [X] are not breaking changes.

### Documentation
- [X] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [X] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
