### PR TITLE
fix audio rendering on non-get requests

### DIFF
--- a/src/core/components/response-body.jsx
+++ b/src/core/components/response-body.jsx
@@ -134,7 +134,8 @@ export default class ResponseBody extends React.PureComponent {
 
       // Audio
     } else if (/^audio\//i.test(contentType)) {
-      bodyEl = <pre className="microlight"><audio controls key={ url }><source src={ url } type={ contentType } /></audio></pre>
+      const audioUrl = window.URL.createObjectURL(content);
+      bodyEl = <pre className="microlight"> <audio controls key={ audioUrl }><source src={ audioUrl } type={ contentType } /></audio></pre>
     } else if (typeof content === "string") {
       bodyEl = <HighlightCode downloadable fileName={`${downloadName}.txt`} value={ content } getConfigs={ getConfigs } canCopy />
     } else if ( content.size > 0 ) {


### PR DESCRIPTION
Fixes #8378.

Audio from the response should be used in the audio element, rather than using potentially incomplete URL as the src. This is similar to how swagger-ui does it for images (we create url from content via createObjectURL).

Tested locally, works.