### PR TITLE
ci(release): disable running e2e tests before the release

### DIFF
--- a/release/.release-it.json
+++ b/release/.release-it.json
@@ -3,7 +3,9 @@
     "before:bump": [
       "./release/check-for-breaking-changes.sh ${latestVersion} ${version}",
       "npm update swagger-client",
-      "npm test"
+      "npm run test-in-node",
+      "npm run test:unit-jest",
+      "npm run test:artifact"
     ],
     "after:bump": ["npm run build"],
     "after:release": "export GIT_TAG=v${version} && echo GIT_TAG=v${version} > release/.version"


### PR DESCRIPTION
CD pipeline is currently implemented in Jenkins,
and is no longer able to run the tests during the
release process, thus rendering the Jenkins CD
pipeline unable to issue a new release.

THis change disables running e2e tests before
the release.

CI pipeline implemented in GitHub Actions
guarantees that master is always releasable.

Refs #8401
