### PR TITLE
test(cypress): fix tests flakyness by stubbing httpbin.org responses

### DIFF
--- a/test/e2e-cypress/tests/bugs/6183.js
+++ b/test/e2e-cypress/tests/bugs/6183.js
@@ -1,8 +1,8 @@
 describe("When trying it out", () => {
   it("should render the response headers as comma separated lists", () => {
     cy.intercept({
-      method: "POST",
-      url: "/post",
+      method: "GET",
+      url: "/response-headers",
       hostname: "httpbin.org",
     }, {})
 

--- a/test/e2e-cypress/tests/bugs/6183.js
+++ b/test/e2e-cypress/tests/bugs/6183.js
@@ -1,10 +1,28 @@
 describe("When trying it out", () => {
   it("should render the response headers as comma separated lists", () => {
-    cy.intercept({
-      method: "GET",
-      url: "/response-headers",
-      hostname: "httpbin.org",
-    }, {})
+    cy.intercept(
+      {
+        method: "GET",
+        url: /^\/response-headers/,
+        hostname: "httpbin.org",
+      },
+      {
+        body: {
+          "Access-Control-Expose-Headers": "X-Header1, X-Header2, X-Header3, Access-Control-Expose-Headers",
+          "Content-Length": "289",
+          "Content-Type": "application/json",
+          "X-Header1": "value1,value2",
+          "X-Header2": "value3,value4",
+          "X-Header3": ["value5", "value6"]
+        },
+        headers: {
+          "access-control-expose-headers": "X-Header1,X-Header2,X-Header3,Access-Control-Expose-Headers",
+          "content-type": "application/json",
+          "x-header1": "value1,value2",
+          "x-header2": "value3,value4",
+          "x-header3": "value5,value6",
+        }
+    })
 
     cy.visit("/?url=/documents/bugs/6183.yaml")
       .get("#operations-default-get_response_headers")

--- a/test/e2e-cypress/tests/bugs/6183.js
+++ b/test/e2e-cypress/tests/bugs/6183.js
@@ -1,5 +1,11 @@
 describe("When trying it out", () => {
   it("should render the response headers as comma separated lists", () => {
+    cy.intercept({
+      method: "POST",
+      url: "/post",
+      hostname: "httpbin.org",
+    }, {})
+
     cy.visit("/?url=/documents/bugs/6183.yaml")
       .get("#operations-default-get_response_headers")
       .click()

--- a/test/e2e-cypress/tests/features/oas3-multiple-media-type.js
+++ b/test/e2e-cypress/tests/features/oas3-multiple-media-type.js
@@ -8,6 +8,12 @@ describe("OpenAPI 3.0 Multiple Media Types with different schemas", () => {
   const mediaTypeJson = "application/json"
 
   beforeEach(() => {
+    cy.intercept({
+      method: "POST",
+      url: "/post",
+      hostname: "httpbin.org",
+    }, {})
+
     cy.visit(
       "/?url=/documents/features/oas3-multiple-media-type.yaml"
     )

--- a/test/e2e-cypress/tests/features/oas3-request-body-required.js
+++ b/test/e2e-cypress/tests/features/oas3-request-body-required.js
@@ -4,44 +4,59 @@
 
 describe("OpenAPI 3.0 Validation for Required Request Body and Request Body Fields", () => {
   describe("Request Body required bug/5181", () => {
-    it("on execute, if empty value, SHOULD render class 'invalid' and should NOT render cURL component", () => {
-      cy.visit(
-        "/?url=/documents/bugs/5181.yaml"
+    beforeEach(() => {
+      cy.intercept(
+        {
+          method: "POST",
+          url: "/anything/foos",
+          hostname: "httpbin.org",
+        },
+        {}
       )
+    })
+
+    it("on execute, if empty value, SHOULD render class 'invalid' and should NOT render cURL component", () => {
+      cy.visit("/?url=/documents/bugs/5181.yaml")
         .get("#operations-default-post_foos")
         .click()
         // Expand Try It Out
         .get(".try-out__btn")
         .click()
         // get input
-        .get(".opblock-body .opblock-section .opblock-section-request-body .parameters:nth-child(1) > .parameters-col_description input")
+        .get(
+          ".opblock-body .opblock-section .opblock-section-request-body .parameters:nth-child(1) > .parameters-col_description input"
+        )
         .should("not.have.class", "invalid")
         // Execute
         .get(".execute.opblock-control__btn")
         .click()
         // class "invalid" should now exist (and render red, which we won't check)
-        .get(".opblock-body .opblock-section .opblock-section-request-body .parameters:nth-child(1) > .parameters-col_description input")
+        .get(
+          ".opblock-body .opblock-section .opblock-section-request-body .parameters:nth-child(1) > .parameters-col_description input"
+        )
         .should("have.class", "invalid")
         // cURL component should not exist
         .get(".responses-wrapper .curl-command")
         .should("not.exist")
     })
     it("on execute, if value exists, should NOT render class 'invalid' and SHOULD render cURL component", () => {
-      cy.visit(
-        "/?url=/documents/bugs/5181.yaml"
-      )
+      cy.visit("/?url=/documents/bugs/5181.yaml")
         .get("#operations-default-post_foos")
         .click()
         // Expand Try It Out
         .get(".try-out__btn")
         .click()
         // get input
-        .get(".opblock-body .opblock-section .opblock-section-request-body .parameters:nth-child(1) > .parameters-col_description input")
+        .get(
+          ".opblock-body .opblock-section .opblock-section-request-body .parameters:nth-child(1) > .parameters-col_description input"
+        )
         .type("abc")
         // Execute
         .get(".execute.opblock-control__btn")
         .click()
-        .get(".opblock-body .opblock-section .opblock-section-request-body .parameters:nth-child(1) > .parameters-col_description input")
+        .get(
+          ".opblock-body .opblock-section .opblock-section-request-body .parameters:nth-child(1) > .parameters-col_description input"
+        )
         .should("not.have.class", "invalid")
         // cURL component should exist
         .get(".responses-wrapper .curl-command")
@@ -51,45 +66,49 @@ describe("OpenAPI 3.0 Validation for Required Request Body and Request Body Fiel
 
   describe("Request Body required fields - application/json", () => {
     it("on execute, if empty value, SHOULD render class 'invalid' and should NOT render cURL component", () => {
-      cy.visit(
-        "/?url=/documents/features/petstore-only-pet.openapi.yaml"
-      )
+      cy.visit("/?url=/documents/features/petstore-only-pet.openapi.yaml")
         .get("#operations-pet-addPet")
         .click()
         // Expand Try It Out
         .get(".try-out__btn")
         .click()
         // get and clear textarea
-        .get(".opblock-body .opblock-section .opblock-section-request-body .body-param textarea")
+        .get(
+          ".opblock-body .opblock-section .opblock-section-request-body .body-param textarea"
+        )
         .should("not.have.class", "invalid")
         .clear()
         // Execute
         .get(".execute.opblock-control__btn")
         .click()
         // class "invalid" should now exist (and render red, which we won't check)
-        .get(".opblock-body .opblock-section .opblock-section-request-body .body-param textarea")
+        .get(
+          ".opblock-body .opblock-section .opblock-section-request-body .body-param textarea"
+        )
         .should("have.class", "invalid")
         // cURL component should not exist
         .get(".responses-wrapper .curl-command")
         .should("not.exist")
     })
     it("on execute, if value exists, even if just single space, should NOT render class 'invalid' and SHOULD render cURL component that contains the single space", () => {
-      cy.visit(
-        "/?url=/documents/features/petstore-only-pet.openapi.yaml"
-      )
+      cy.visit("/?url=/documents/features/petstore-only-pet.openapi.yaml")
         .get("#operations-pet-addPet")
         .click()
         // Expand Try It Out
         .get(".try-out__btn")
         .click()
         // get, clear, then modify textarea
-        .get(".opblock-body .opblock-section .opblock-section-request-body .body-param textarea")
+        .get(
+          ".opblock-body .opblock-section .opblock-section-request-body .body-param textarea"
+        )
         .clear()
         .type(" ")
         // Execute
         .get(".execute.opblock-control__btn")
         .click()
-        .get(".opblock-body .opblock-section .opblock-section-request-body .body-param textarea")
+        .get(
+          ".opblock-body .opblock-section .opblock-section-request-body .body-param textarea"
+        )
         .should("not.have.class", "invalid")
         // cURL component should exist
         .get(".responses-wrapper .curl-command")
@@ -99,57 +118,67 @@ describe("OpenAPI 3.0 Validation for Required Request Body and Request Body Fiel
     })
   })
 
-  /* 
-  petstore ux notes: 
+  /*
+  petstore ux notes:
   - required field, but if example value exists, will populate the field. So this test will clear the example value.
   - "add item" will insert an empty array, and display an input text box. This establishes a value for the field.
   */
   describe("Request Body required fields - application/x-www-form-urlencoded", () => {
     it("on execute, if empty value, SHOULD render class 'invalid' and should NOT render cURL component", () => {
-      cy.visit(
-        "/?url=/documents/features/petstore-only-pet.openapi.yaml"
-      )
+      cy.visit("/?url=/documents/features/petstore-only-pet.openapi.yaml")
         .get("#operations-pet-addPet")
         .click()
-        .get(".opblock-section .opblock-section-request-body .body-param-content-type > select")
+        .get(
+          ".opblock-section .opblock-section-request-body .body-param-content-type > select"
+        )
         .select("application/x-www-form-urlencoded")
         // Expand Try It Out
         .get(".try-out__btn")
         .click()
         // get and clear input populated from example value
-        .get(".opblock-body .opblock-section .opblock-section-request-body .parameters:nth-child(2) > .parameters-col_description input")
+        .get(
+          ".opblock-body .opblock-section .opblock-section-request-body .parameters:nth-child(2) > .parameters-col_description input"
+        )
         .clear()
         // Execute
         .get(".execute.opblock-control__btn")
         .click()
         // class "invalid" should now exist (and render red, which we won't check)
-        .get(".opblock-body .opblock-section .opblock-section-request-body .parameters:nth-child(2) > .parameters-col_description input")
+        .get(
+          ".opblock-body .opblock-section .opblock-section-request-body .parameters:nth-child(2) > .parameters-col_description input"
+        )
         .should("have.class", "invalid")
         // cURL component should not exist
         .get(".responses-wrapper .curl-command")
         .should("not.exist")
     })
     it("on execute, if all values exist, even if array exists but is empty, should NOT render class 'invalid' and SHOULD render cURL component", () => {
-      cy.visit(
-        "/?url=/documents/features/petstore-only-pet.openapi.yaml"
-      )
+      cy.visit("/?url=/documents/features/petstore-only-pet.openapi.yaml")
         .get("#operations-pet-addPet")
         .click()
-        .get(".opblock-section .opblock-section-request-body .body-param-content-type > select")
+        .get(
+          ".opblock-section .opblock-section-request-body .body-param-content-type > select"
+        )
         .select("application/x-www-form-urlencoded")
         // Expand Try It Out
         .get(".try-out__btn")
         .click()
         // add item to get input
-        .get(".opblock-body .opblock-section .opblock-section-request-body .parameters:nth-child(4) > .parameters-col_description button")
+        .get(
+          ".opblock-body .opblock-section .opblock-section-request-body .parameters:nth-child(4) > .parameters-col_description button"
+        )
         .click()
         // Execute
         .get(".execute.opblock-control__btn")
         .click()
-        .get(".opblock-body .opblock-section .opblock-section-request-body .parameters:nth-child(2) > .parameters-col_description input")
+        .get(
+          ".opblock-body .opblock-section .opblock-section-request-body .parameters:nth-child(2) > .parameters-col_description input"
+        )
         .should("have.value", "doggie")
         .should("not.have.class", "invalid")
-        .get(".opblock-body .opblock-section .opblock-section-request-body .parameters:nth-child(4) > .parameters-col_description input")
+        .get(
+          ".opblock-body .opblock-section .opblock-section-request-body .parameters:nth-child(4) > .parameters-col_description input"
+        )
         .should("have.value", "string")
         .should("not.have.class", "invalid")
         // cURL component should exist
@@ -160,58 +189,76 @@ describe("OpenAPI 3.0 Validation for Required Request Body and Request Body Fiel
 
   describe("Request Body: switching between Content Types", () => {
     it("after application/json 'invalid' error, on switch content type to application/x-www-form-urlencoded, SHOULD be free of errors", () => {
-      cy.visit(
-        "/?url=/documents/features/petstore-only-pet.openapi.yaml"
-      )
+      cy.visit("/?url=/documents/features/petstore-only-pet.openapi.yaml")
         .get("#operations-pet-addPet")
         .click()
         // Expand Try It Out
         .get(".try-out__btn")
         .click()
         // get and clear textarea
-        .get(".opblock-body .opblock-section .opblock-section-request-body .body-param textarea")
+        .get(
+          ".opblock-body .opblock-section .opblock-section-request-body .body-param textarea"
+        )
         .should("not.have.class", "invalid")
         .clear()
         // Execute
         .get(".execute.opblock-control__btn")
         .click()
-        .get(".opblock-body .opblock-section .opblock-section-request-body .body-param textarea")
+        .get(
+          ".opblock-body .opblock-section .opblock-section-request-body .body-param textarea"
+        )
         .should("have.class", "invalid")
         // switch content type
-        .get(".opblock-section .opblock-section-request-body .body-param-content-type > select")
+        .get(
+          ".opblock-section .opblock-section-request-body .body-param-content-type > select"
+        )
         .select("application/x-www-form-urlencoded")
-        .get(".opblock-body .opblock-section .opblock-section-request-body .parameters:nth-child(2) > .parameters-col_description input")
+        .get(
+          ".opblock-body .opblock-section .opblock-section-request-body .parameters:nth-child(2) > .parameters-col_description input"
+        )
         .should("not.have.class", "invalid")
         // add item to get input, just an extra confirmation of non-invalid class
-        .get(".opblock-body .opblock-section .opblock-section-request-body .parameters:nth-child(4) > .parameters-col_description button")
+        .get(
+          ".opblock-body .opblock-section .opblock-section-request-body .parameters:nth-child(4) > .parameters-col_description button"
+        )
         .click()
-        .get(".opblock-body .opblock-section .opblock-section-request-body .parameters:nth-child(4) > .parameters-col_description input")
+        .get(
+          ".opblock-body .opblock-section .opblock-section-request-body .parameters:nth-child(4) > .parameters-col_description input"
+        )
         .should("not.have.class", "invalid")
     })
     it("after application/x-www-form-urlencoded 'invalid' error, on switch content type to application/json, SHOULD be free of errors", () => {
-      cy.visit(
-        "/?url=/documents/features/petstore-only-pet.openapi.yaml"
-      )
+      cy.visit("/?url=/documents/features/petstore-only-pet.openapi.yaml")
         .get("#operations-pet-addPet")
         .click()
-        .get(".opblock-section .opblock-section-request-body .body-param-content-type > select")
+        .get(
+          ".opblock-section .opblock-section-request-body .body-param-content-type > select"
+        )
         .select("application/x-www-form-urlencoded")
         // Expand Try It Out
         .get(".try-out__btn")
         .click()
         // get and clear input
-        .get(".opblock-body .opblock-section .opblock-section-request-body .parameters:nth-child(2) > .parameters-col_description input")
+        .get(
+          ".opblock-body .opblock-section .opblock-section-request-body .parameters:nth-child(2) > .parameters-col_description input"
+        )
         .clear()
         // Execute
         .get(".execute.opblock-control__btn")
         .click()
         // class "invalid" should now exist (and render red, which we won't check)
-        .get(".opblock-body .opblock-section .opblock-section-request-body .parameters:nth-child(2) > .parameters-col_description input")
+        .get(
+          ".opblock-body .opblock-section .opblock-section-request-body .parameters:nth-child(2) > .parameters-col_description input"
+        )
         .should("have.class", "invalid")
         // switch content type
-        .get(".opblock-section .opblock-section-request-body .body-param-content-type > select")
+        .get(
+          ".opblock-section .opblock-section-request-body .body-param-content-type > select"
+        )
         .select("application/json")
-        .get(".opblock-body .opblock-section .opblock-section-request-body .body-param textarea")
+        .get(
+          ".opblock-body .opblock-section .opblock-section-request-body .body-param textarea"
+        )
         .should("not.have.class", "invalid")
     })
   })


### PR DESCRIPTION
Refs #8409

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
