### PR TITLE
feat(swagger-ui-react): add showCommonExtensions option

### DIFF
--- a/flavors/swagger-ui-react/README.md
+++ b/flavors/swagger-ui-react/README.md
@@ -114,6 +114,12 @@ Controls the display of vendor extension (`x-`) fields and values for Operations
 
 ⚠️ This prop is currently only applied once, on mount. Changes to this prop's value will not be propagated to the underlying Swagger UI instance. A future version of this module will remove this limitation, and the change will not be considered a breaking change.
 
+#### `showCommonExtensions`: PropTypes.bool
+
+Controls the display of extensions (pattern, maxLength, minLength, maximum, minimum) fields and values for Parameters.
+
+⚠️ This prop is currently only applied once, on mount. Changes to this prop's value will not be propagated to the underlying Swagger UI instance. A future version of this module will remove this limitation, and the change will not be considered a breaking change.
+
 #### `showMutatedRequest`: PropTypes.bool
 
 If set to `true`, uses the mutated request returned from a requestInterceptor to produce the curl command in the UI, otherwise the request before the requestInterceptor was applied is used.

--- a/flavors/swagger-ui-react/index.jsx
+++ b/flavors/swagger-ui-react/index.jsx
@@ -33,6 +33,7 @@ export default class SwaggerUI extends React.Component {
       showMutatedRequest: typeof this.props.showMutatedRequest === "boolean" ? this.props.showMutatedRequest : true,
       deepLinking: typeof this.props.deepLinking === "boolean" ? this.props.deepLinking : false,
       showExtensions: this.props.showExtensions,
+      showCommonExtensions: this.props.showCommonExtensions,
       filter: ["boolean", "string"].includes(typeof this.props.filter) ? this.props.filter : false,
       persistAuthorization: this.props.persistAuthorization,
       withCredentials: this.props.withCredentials,
@@ -122,6 +123,7 @@ SwaggerUI.propTypes = {
   presets: PropTypes.arrayOf(PropTypes.func),
   deepLinking: PropTypes.bool,
   showExtensions: PropTypes.bool,
+  showCommonExtensions: PropTypes.bool,
   filter: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.bool,
@@ -146,6 +148,7 @@ SwaggerUI.defaultProps = {
   deepLinking: false,
   displayRequestDuration: false,
   showExtensions: false,
+  showCommonExtensions: false,
   filter: false,
   requestSnippetsEnabled: false,
   requestSnippets: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

add showCommonExtensions option for swagger-ui-react.
<!--- Describe your changes in detail -->


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->



### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->



### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [x] My changes require a change to the project documentation.
- [x] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
