### PR TITLE
fix(docker): use vulnerability free Node.js=>18.14.1-r0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM nginx:1.23.3-alpine
 
-RUN apk update && apk add --no-cache "nodejs>=16.17.1-r0"
+RUN apk update && apk add --no-cache "nodejs>=18.14.1-r0 "
 
 LABEL maintainer="fehguy"
 


### PR DESCRIPTION
Node.js@18.12.1-r0 got installed by default.
CVE-2023-24807 was manifesting in image security
scans.

Refs https://github.com/swagger-api/swagger-ui/actions/runs/4310624218/jobs/7519243077