### PR TITLE
fix(docker): enable IPv6 explicitly by env variable

### DIFF
--- a/docker/docker-entrypoint.d/40-swagger-ui.sh
+++ b/docker/docker-entrypoint.d/40-swagger-ui.sh
@@ -39,6 +39,11 @@ if [[ -f "$SWAGGER_JSON" ]]; then
   sed -i "s|http://example.com/api|$REL_PATH|g" $INITIALIZER_SCRIPT
 fi
 
+# enable/disable the address and port for IPv6 addresses that nginx listens on
+if [[ -n "${PORT_IPV6}" ]]; then
+    sed -i "s|8080;|8080;\n    listen            [::]:${PORT_IPV6};|g" $NGINX_CONF
+fi
+
 # replace the PORT that nginx listens on if PORT is supplied
 if [[ -n "${PORT}" ]]; then
     sed -i "s|8080|${PORT}|g" $NGINX_CONF

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -30,7 +30,6 @@ http {
 
   server {
     listen            8080;
-    listen            [::]:8080;
     server_name       localhost;
     index             index.html index.htm;
 


### PR DESCRIPTION
Enabling IPv6 address and port for IPv6 addresses
caused backward incompatible issues in the docker image.

Refs #8447


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [X] All new and existing tests passed.
