### PR TITLE
fix(oas31): detect user request body edits in OpenAPI.paths

### DIFF
--- a/src/core/plugins/oas31/fn.js
+++ b/src/core/plugins/oas31/fn.js
@@ -46,7 +46,7 @@ export const createOnlyOAS31SelectorWrapper =
     if (system.getSystem().specSelectors.isOAS31()) {
       const selectedValue = selector(state, ...args)
       return typeof selectedValue === "function"
-        ? selectedValue(system)
+        ? selectedValue(oriSelector, system)
         : selectedValue
     } else {
       return oriSelector(...args)

--- a/src/core/plugins/oas31/oas3-extensions/wrap-selectors.js
+++ b/src/core/plugins/oas31/oas3-extensions/wrap-selectors.js
@@ -4,12 +4,14 @@
 import { createOnlyOAS31SelectorWrapper } from "../fn"
 
 export const hasUserEditedBody = createOnlyOAS31SelectorWrapper(
-  (state, path, method) => (system) => {
+  (state, path, method) => (oriSelector, system) => {
     const webhooks = system.specSelectors.webhooks()
 
     if (webhooks.hasIn([path, method])) {
       // try it out functionality is disabled for webhooks
       return false
     }
+
+    return oriSelector(path, method)
   }
 )

--- a/src/core/plugins/oas31/spec-extensions/wrap-selectors.js
+++ b/src/core/plugins/oas31/spec-extensions/wrap-selectors.js
@@ -12,7 +12,7 @@ export const isOAS3 =
   }
 
 export const selectLicenseUrl = createOnlyOAS31SelectorWrapper(
-  () => (system) => {
+  () => (oriSelector, system) => {
     return system.oas31Selectors.selectLicenseUrl()
   }
 )


### PR DESCRIPTION
Affected wrapped selector was hasUserEditedBody.
This commit fixes the bug by calling the original
selector when path+method combination is not found in OpenAPI.webhooks field.

Refs #8498
