### PR TITLE
fix(oas31): display Callback operations only

### DIFF
--- a/src/core/plugins/oas3/components/callbacks.jsx
+++ b/src/core/plugins/oas3/components/callbacks.jsx
@@ -1,54 +1,49 @@
+/**
+ * @prettier
+ */
 import React from "react"
 import PropTypes from "prop-types"
 import ImPropTypes from "react-immutable-proptypes"
-import { fromJS } from "immutable"
 
-const Callbacks = (props) => {
-  let { callbacks, getComponent, specPath } = props
-  // const Markdown = getComponent("Markdown", true)
+const Callbacks = ({ callbacks, specPath, specSelectors, getComponent }) => {
+  const operationDTOs = specSelectors.callbacksOperations({
+    callbacks,
+    specPath,
+  })
+  const callbackNames = Object.keys(operationDTOs)
+
   const OperationContainer = getComponent("OperationContainer", true)
 
-  if(!callbacks) {
-    return <span>No callbacks</span>
-  }
+  if (callbackNames.length === 0) return <span>No callbacks</span>
 
-  let callbackElements = callbacks.entrySeq().map(([callbackName, callback]) => {
-    return <div key={callbackName}>
-      <h2>{callbackName}</h2>
-      { callback.entrySeq().map(([pathItemName, pathItem]) => {
-        if(pathItemName === "$$ref") {
-          return null
-        }
-        return <div key={pathItemName}>
-          { pathItem.entrySeq().map(([method, operation]) => {
-            if(method === "$$ref") {
-              return null
-            }
-            let op = fromJS({
-              operation
-            })
-            return <OperationContainer
-              {...props}
-              op={op}
-              key={method}
-              tag={""}
-              method={method}
-              path={pathItemName}
-              specPath={specPath.push(callbackName, pathItemName, method)}
+  return (
+    <div>
+      {callbackNames.map((callbackName) => (
+        <div key={`${callbackName}`}>
+          <h2>{callbackName}</h2>
+
+          {operationDTOs[callbackName].map((operationDTO) => (
+            <OperationContainer
+              key={`${callbackName}-${operationDTO.path}-${operationDTO.method}`}
+              op={operationDTO.operation}
+              tag=""
+              method={operationDTO.method}
+              path={operationDTO.path}
+              specPath={operationDTO.specPath}
               allowTryItOut={false}
-              />
-          }) }
+            />
+          ))}
         </div>
-      }) }
+      ))}
     </div>
-  })
-  return <div>
-    {callbackElements}
-  </div>
+  )
 }
 
 Callbacks.propTypes = {
   getComponent: PropTypes.func.isRequired,
+  specSelectors: PropTypes.shape({
+    callbacksOperations: PropTypes.func.isRequired,
+  }).isRequired,
   callbacks: ImPropTypes.iterable.isRequired,
   specPath: ImPropTypes.list.isRequired,
 }

--- a/src/core/plugins/oas31/spec-extensions/selectors.js
+++ b/src/core/plugins/oas31/spec-extensions/selectors.js
@@ -27,9 +27,13 @@ export const selectWebhooksOperations = createSelector(
   (state, system) => system.specSelectors.webhooks(),
   (state, system) => system.specSelectors.validOperationMethods(),
   (state, system) => system.specSelectors.specResolvedSubtree(["webhooks"]),
-  (webhooks, validOperationMethods) =>
-    webhooks
+  (webhooks, validOperationMethods) => {
+    if (!Map.isMap(webhooks)) return {}
+
+    return webhooks
       .reduce((allOperations, pathItem, pathItemName) => {
+        if (!Map.isMap(pathItem)) return allOperations
+
         const pathItemOperations = pathItem
           .entrySeq()
           .filter(([key]) => validOperationMethods.includes(key))
@@ -42,9 +46,10 @@ export const selectWebhooksOperations = createSelector(
 
         return allOperations.concat(pathItemOperations)
       }, List())
-      .groupBy((operation) => operation.path)
+      .groupBy((operationDTO) => operationDTO.path)
       .map((operations) => operations.toArray())
       .toObject()
+  }
 )
 
 export const license = () => (system) => {


### PR DESCRIPTION
Before this fix, other Path Item fields were
included into rendering as well (like servers).

Refs #8504