### PR TITLE
fix(json-schema-2020-12): enable sub-tree expansion optimization

### DIFF
--- a/src/core/plugins/json-schema-2020-12/hoc.jsx
+++ b/src/core/plugins/json-schema-2020-12/hoc.jsx
@@ -104,7 +104,7 @@ export const withJSONSchemaContext = (Component, overrides = {}) => {
        * By default, entire schema tree is rendered and collapsed parts of the
        * tree are hidden with css.
        */
-      optimizeExpansion: false,
+      optimizeExpansion: true,
       ...overrides.config,
     },
     fn: {


### PR DESCRIPTION
Schema Object sub-trees are not renderer until
expanded.

Before the entire Scheam Object tree was rendered
and collapsed sub-trees here hidden by css.

Refs #8606
