### PR TITLE
chore(deps): bump swagger-client from 3.19.6 to 3.19.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "reselect": "^4.1.7",
         "serialize-error": "^8.1.0",
         "sha.js": "^2.4.11",
-        "swagger-client": "^3.19.6",
+        "swagger-client": "^3.19.7",
         "url-parse": "^1.5.10",
         "xml": "=1.0.1",
         "xml-but-prettier": "^1.0.1",
@@ -4783,846 +4783,338 @@
       "dev": true
     },
     "node_modules/@swagger-api/apidom-ast": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-0.69.0.tgz",
-      "integrity": "sha512-JsRyi1Ir3VeNSSWmIFqgaFOQCIUvCoKcfmOcU/h4Jz1IOkQij1vj3qEFln4J9sByOWHrhA8zD1Cf+LnXkbGVZg==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-0.69.3.tgz",
+      "integrity": "sha512-orGw/gihk7RmorxibwalthDS58B7QaEBd31fK+/aFx6QqEO1tEO35F850BiL2B5C8TaK8C2Tey01AZTXCxYmfw==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@types/ramda": "=0.28.23",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0",
+        "@types/ramda": "=0.29.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0",
         "stampit": "=4.3.2",
         "unraw": "=2.0.1"
       }
     },
-    "node_modules/@swagger-api/apidom-ast/node_modules/ramda": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
-    },
-    "node_modules/@swagger-api/apidom-ast/node_modules/ramda-adjunct": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-      "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-      "engines": {
-        "node": ">=0.10.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda-adjunct"
-      },
-      "peerDependencies": {
-        "ramda": ">= 0.28.0 <= 0.28.0"
-      }
-    },
     "node_modules/@swagger-api/apidom-core": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-0.69.2.tgz",
-      "integrity": "sha512-av9vS1SbXxGJvCt4QggrIvS8dr3ZfL6jxrNQGr4cq1wFY/n5ruj0RsXix208c3Zp1Kua3QVOUaJvA+7RdT1VJA==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-0.69.3.tgz",
+      "integrity": "sha512-EIQiJUuT/V9nGkHOYYFP0QNgAW7Y4QwrQzldDzy9ltcHbOKY3TNh/QzYvO0+HvKSv9W7u7WTMH/kaRaSsaZsGw==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-ast": "^0.69.0",
-        "@types/ramda": "=0.28.23",
+        "@swagger-api/apidom-ast": "^0.69.3",
+        "@types/ramda": "=0.29.0",
         "minim": "=0.23.8",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0",
         "short-unique-id": "=4.4.4",
         "stampit": "=4.3.2"
       }
     },
-    "node_modules/@swagger-api/apidom-core/node_modules/ramda": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
-    },
-    "node_modules/@swagger-api/apidom-core/node_modules/ramda-adjunct": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-      "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-      "engines": {
-        "node": ">=0.10.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda-adjunct"
-      },
-      "peerDependencies": {
-        "ramda": ">= 0.28.0 <= 0.28.0"
-      }
-    },
     "node_modules/@swagger-api/apidom-json-pointer": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-0.69.2.tgz",
-      "integrity": "sha512-ipu94QNw8ZKWC+pfie5IyIzVImR5N0PANXkUSfFon5L4aMAtggKpZn7aUv/2Cxn51JsCvjZwkXT7PaJ8RddpxA==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-0.69.3.tgz",
+      "integrity": "sha512-VYXqLY8f2fkaS/d+vVQEMEOEZRXAgGm5tCMx4C7uaU+wC+SKPH/zTh+qElbkaXQr4nfLjbphBsHh31doCyBEjw==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.2",
-        "@types/ramda": "=0.28.23",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0"
-      }
-    },
-    "node_modules/@swagger-api/apidom-json-pointer/node_modules/ramda": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
-    },
-    "node_modules/@swagger-api/apidom-json-pointer/node_modules/ramda-adjunct": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-      "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-      "engines": {
-        "node": ">=0.10.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda-adjunct"
-      },
-      "peerDependencies": {
-        "ramda": ">= 0.28.0 <= 0.28.0"
+        "@swagger-api/apidom-core": "^0.69.3",
+        "@types/ramda": "=0.29.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-ns-api-design-systems": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-0.69.2.tgz",
-      "integrity": "sha512-JnOPiDvPfNH/6WWVBqBwK0oIHscHECtL1iZDUE9nB4NSbyoV10oulkuhHNAO9BImqtU4rxtWbXyTL1MEuUdHHQ==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-0.69.3.tgz",
+      "integrity": "sha512-oTwIG8LyKnU4/m8BtAOc+X572+nH4gjxITYtw0L8f4a8Iv1b8LHS0KRzG7c/LVUGtMijpv3aBKPV6QvWhjrrtg==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.2",
-        "@swagger-api/apidom-ns-openapi-3-1": "^0.69.2",
-        "@types/ramda": "=0.28.23",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0",
+        "@swagger-api/apidom-core": "^0.69.3",
+        "@swagger-api/apidom-ns-openapi-3-1": "^0.69.3",
+        "@types/ramda": "=0.29.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0",
         "stampit": "=4.3.2"
-      }
-    },
-    "node_modules/@swagger-api/apidom-ns-api-design-systems/node_modules/ramda": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
-      "optional": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
-    },
-    "node_modules/@swagger-api/apidom-ns-api-design-systems/node_modules/ramda-adjunct": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-      "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda-adjunct"
-      },
-      "peerDependencies": {
-        "ramda": ">= 0.28.0 <= 0.28.0"
       }
     },
     "node_modules/@swagger-api/apidom-ns-asyncapi-2": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-0.69.2.tgz",
-      "integrity": "sha512-SOg9P4rM5Aj2jabt4njmFbZTRMX8/vRHgiDL9vE+uz7s6j64B9QBSFF42j17cEVq6ToqQ7jtu40f1D7K62puQA==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-0.69.3.tgz",
+      "integrity": "sha512-98HgNbZWqPHqf+EyXs/GcAnayA08/mfN7YlXIRRIys+rll4M/1b+ap+BkTnJ+le3Kra7DhIQ8ucQuEJ+Ik1Sxg==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.2",
-        "@swagger-api/apidom-ns-json-schema-draft-7": "^0.69.2",
-        "@types/ramda": "=0.28.23",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0",
+        "@swagger-api/apidom-core": "^0.69.3",
+        "@swagger-api/apidom-ns-json-schema-draft-7": "^0.69.3",
+        "@types/ramda": "=0.29.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0",
         "stampit": "=4.3.2"
-      }
-    },
-    "node_modules/@swagger-api/apidom-ns-asyncapi-2/node_modules/ramda": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
-      "optional": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
-    },
-    "node_modules/@swagger-api/apidom-ns-asyncapi-2/node_modules/ramda-adjunct": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-      "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda-adjunct"
-      },
-      "peerDependencies": {
-        "ramda": ">= 0.28.0 <= 0.28.0"
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-draft-4": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-0.69.2.tgz",
-      "integrity": "sha512-8yB4afGBAX+vN5oNRxZMWWS/2G0Q9VUzlL2AOu0Q70FQkscbjQcsb6QX9LbHFMrwi3MgOgE0ewMncpcwskuoXA==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-0.69.3.tgz",
+      "integrity": "sha512-/tMeoz1IHEblc3OwWC812NQFLITOnexjGVujG5Wvsr9ZnTkRb+0g7CbXuooujwfcEY+++o2+kCUgy4SBQFIIlQ==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.2",
-        "@types/ramda": "=0.28.23",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0",
+        "@swagger-api/apidom-core": "^0.69.3",
+        "@types/ramda": "=0.29.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0",
         "stampit": "=4.3.2"
-      }
-    },
-    "node_modules/@swagger-api/apidom-ns-json-schema-draft-4/node_modules/ramda": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
-    },
-    "node_modules/@swagger-api/apidom-ns-json-schema-draft-4/node_modules/ramda-adjunct": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-      "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-      "engines": {
-        "node": ">=0.10.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda-adjunct"
-      },
-      "peerDependencies": {
-        "ramda": ">= 0.28.0 <= 0.28.0"
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-draft-6": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-0.69.2.tgz",
-      "integrity": "sha512-RPazXv7L37vrdqHeFy/ZrKVz+vnVOqEFrHFefaq2L5avnzInVTRsTJm+61q0jqnckozz426Gbg5wJgq+Yvpbqg==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-0.69.3.tgz",
+      "integrity": "sha512-B/6zPFYW1xE66Uc/jOdZVZMEe0+444heTMlpGJGejTy6pNRxCTOsv+B63QzctJv410dHPxGeMRZMeff9wQPBDA==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.2",
-        "@swagger-api/apidom-ns-json-schema-draft-4": "^0.69.2",
-        "@types/ramda": "=0.28.23",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0",
+        "@swagger-api/apidom-core": "^0.69.3",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^0.69.3",
+        "@types/ramda": "=0.29.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0",
         "stampit": "=4.3.2"
-      }
-    },
-    "node_modules/@swagger-api/apidom-ns-json-schema-draft-6/node_modules/ramda": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
-      "optional": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
-    },
-    "node_modules/@swagger-api/apidom-ns-json-schema-draft-6/node_modules/ramda-adjunct": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-      "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda-adjunct"
-      },
-      "peerDependencies": {
-        "ramda": ">= 0.28.0 <= 0.28.0"
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-draft-7": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-0.69.2.tgz",
-      "integrity": "sha512-pQQE85xjv+UaObQzkhpOPochQ8GhWETAUuzDxHrgKmw20Ca03QAC7RV3tbSnkIbI5cy9wpb4gRM0T5/PzZnBYA==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-0.69.3.tgz",
+      "integrity": "sha512-EkgPlKPQZ3XBkbxAFh2lXsLcyIwRikARFD3RlupsKjAHVFbH7cImbPxb+MnjacfwgVreMk34OWuXqjnGZ8lG1Q==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.2",
-        "@swagger-api/apidom-ns-json-schema-draft-6": "^0.69.2",
-        "@types/ramda": "=0.28.23",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0",
+        "@swagger-api/apidom-core": "^0.69.3",
+        "@swagger-api/apidom-ns-json-schema-draft-6": "^0.69.3",
+        "@types/ramda": "=0.29.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0",
         "stampit": "=4.3.2"
-      }
-    },
-    "node_modules/@swagger-api/apidom-ns-json-schema-draft-7/node_modules/ramda": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
-      "optional": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
-    },
-    "node_modules/@swagger-api/apidom-ns-json-schema-draft-7/node_modules/ramda-adjunct": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-      "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda-adjunct"
-      },
-      "peerDependencies": {
-        "ramda": ">= 0.28.0 <= 0.28.0"
       }
     },
     "node_modules/@swagger-api/apidom-ns-openapi-3-0": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-0.69.2.tgz",
-      "integrity": "sha512-OroXRC+Q1btrpuQ3+ZbMi9XGYiab3YQMg/Rx1wpszbW5C5IPtaa2/FtMcBGYWR5IIdxi+bAT8itbMBGSCcz/Ew==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-0.69.3.tgz",
+      "integrity": "sha512-iScwP+SzX8SJMrgChZbdS60Ode/zXfesNaDA+HkNBLbfSrri4/C5FTB0gfWOG0gCGPq+1K5dHlgLrEgogfAARw==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.2",
-        "@swagger-api/apidom-ns-json-schema-draft-4": "^0.69.2",
-        "@types/ramda": "=0.28.23",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0",
+        "@swagger-api/apidom-core": "^0.69.3",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^0.69.3",
+        "@types/ramda": "=0.29.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0",
         "stampit": "=4.3.2"
-      }
-    },
-    "node_modules/@swagger-api/apidom-ns-openapi-3-0/node_modules/ramda": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
-    },
-    "node_modules/@swagger-api/apidom-ns-openapi-3-0/node_modules/ramda-adjunct": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-      "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-      "engines": {
-        "node": ">=0.10.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda-adjunct"
-      },
-      "peerDependencies": {
-        "ramda": ">= 0.28.0 <= 0.28.0"
       }
     },
     "node_modules/@swagger-api/apidom-ns-openapi-3-1": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-0.69.2.tgz",
-      "integrity": "sha512-2yyUmdbvkDnZuOGDduvlp4dtLL/8a1PCR+Ajk9+PR4ZTdbMFtZWcr/knGc33Rtr8eXQwd4NPypFHhTLCEHiGwg==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-0.69.3.tgz",
+      "integrity": "sha512-J+yIsTBTn7rzfj+vaCXRRdOCrL4kxwnS3P/h4lXb82EZnPU/EbJi+C0LK7O24/vXpeBVRr+OpDfnhpospanMJg==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.2",
-        "@swagger-api/apidom-ns-openapi-3-0": "^0.69.2",
-        "@types/ramda": "=0.28.23",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0",
+        "@swagger-api/apidom-core": "^0.69.3",
+        "@swagger-api/apidom-ns-openapi-3-0": "^0.69.3",
+        "@types/ramda": "=0.29.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0",
         "stampit": "=4.3.2"
       }
     },
-    "node_modules/@swagger-api/apidom-ns-openapi-3-1/node_modules/ramda": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
-    },
-    "node_modules/@swagger-api/apidom-ns-openapi-3-1/node_modules/ramda-adjunct": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-      "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-      "engines": {
-        "node": ">=0.10.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda-adjunct"
-      },
-      "peerDependencies": {
-        "ramda": ">= 0.28.0 <= 0.28.0"
-      }
-    },
     "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-json": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-0.69.2.tgz",
-      "integrity": "sha512-qVL8JrnsjuD3uS1PTNoBTKd5YXPs2SfxRGyKwcmrUXFS+jJmbyYF04xmCgXkwI6TZYjY6KlNb8vmOt4Xr8FqnA==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-0.69.3.tgz",
+      "integrity": "sha512-y8xOaSaZVphITajH12T1EHLuZB9kw79DTdQRYoMC+BqZQbsPv3/mLWXS1STQU9oR/PZBA9FJcgAFdThaRgi8UA==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.2",
-        "@swagger-api/apidom-ns-api-design-systems": "^0.69.2",
-        "@swagger-api/apidom-parser-adapter-json": "^0.69.2",
-        "@types/ramda": "=0.28.23",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-json/node_modules/ramda": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
-      "optional": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-json/node_modules/ramda-adjunct": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-      "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda-adjunct"
-      },
-      "peerDependencies": {
-        "ramda": ">= 0.28.0 <= 0.28.0"
+        "@swagger-api/apidom-core": "^0.69.3",
+        "@swagger-api/apidom-ns-api-design-systems": "^0.69.3",
+        "@swagger-api/apidom-parser-adapter-json": "^0.69.3",
+        "@types/ramda": "=0.29.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-yaml": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-0.69.2.tgz",
-      "integrity": "sha512-vMWfQiXcSeo9XSJJ1Yny4BAUw/3RBbBTsPBbNSsnMtpcDhBbodxdko1CeYkGc8sKM0QyeTFPJuiVhb3kGidbcQ==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-0.69.3.tgz",
+      "integrity": "sha512-zMc+Dy7zl7cT8YduaUEpvLkRDVfZp8jZ1v13VjueX/VhsSXK0DW+OX/Mc8CU1Qx6Gg6tUMKxqmILdXZwxCrh6Q==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.2",
-        "@swagger-api/apidom-ns-api-design-systems": "^0.69.2",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.69.2",
-        "@types/ramda": "=0.28.23",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/node_modules/ramda": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
-      "optional": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/node_modules/ramda-adjunct": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-      "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda-adjunct"
-      },
-      "peerDependencies": {
-        "ramda": ">= 0.28.0 <= 0.28.0"
+        "@swagger-api/apidom-core": "^0.69.3",
+        "@swagger-api/apidom-ns-api-design-systems": "^0.69.3",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.69.3",
+        "@types/ramda": "=0.29.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-2": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-0.69.2.tgz",
-      "integrity": "sha512-/WDVzOcGFxSgBVCiXHVnfiOeYIWtn2RG/Bnn8leUmWRN9oRBiCS3Lh60qWVpvs4BOVntL7SYJnC+buicKD1iJA==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-0.69.3.tgz",
+      "integrity": "sha512-BbsBxxZxTMX2rKgVKJtqPoAsER0JvCe1pt3NUBLuQssugvpwaqimIsKC65dwspHFGSn0CVdBKA4n/XhZ3aT7tw==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.2",
-        "@swagger-api/apidom-ns-asyncapi-2": "^0.69.2",
-        "@swagger-api/apidom-parser-adapter-json": "^0.69.2",
-        "@types/ramda": "=0.28.23",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-2/node_modules/ramda": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
-      "optional": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-2/node_modules/ramda-adjunct": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-      "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda-adjunct"
-      },
-      "peerDependencies": {
-        "ramda": ">= 0.28.0 <= 0.28.0"
+        "@swagger-api/apidom-core": "^0.69.3",
+        "@swagger-api/apidom-ns-asyncapi-2": "^0.69.3",
+        "@swagger-api/apidom-parser-adapter-json": "^0.69.3",
+        "@types/ramda": "=0.29.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-0.69.2.tgz",
-      "integrity": "sha512-qr5epdayokdYyPIJITyqWmUxdknhgPbXhWpSxdEvM8UHgtyutvvvFenFM5pXD1ft8I/uv9oj2WNZxCH2mpsR1g==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-0.69.3.tgz",
+      "integrity": "sha512-lae39qaKrkls+iVzYuc9CUyCbRl80wNK8iBWriSVETv5IwlVS6wywtTxCqtzcpd5K+m9KqXAlSkd+Z2AS9cWuQ==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.2",
-        "@swagger-api/apidom-ns-asyncapi-2": "^0.69.2",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.69.2",
-        "@types/ramda": "=0.28.23",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/node_modules/ramda": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
-      "optional": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/node_modules/ramda-adjunct": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-      "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda-adjunct"
-      },
-      "peerDependencies": {
-        "ramda": ">= 0.28.0 <= 0.28.0"
+        "@swagger-api/apidom-core": "^0.69.3",
+        "@swagger-api/apidom-ns-asyncapi-2": "^0.69.3",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.69.3",
+        "@types/ramda": "=0.29.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-json": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-0.69.2.tgz",
-      "integrity": "sha512-mRXrf9bz2lxf9DY2n2WkB3GlQ8MXRqKBwpXLwjDqqve25Wf6X8QNzfz5ykYORQMuyDIgPq/8aMet7yjHRNtcUQ==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-0.69.3.tgz",
+      "integrity": "sha512-Z1CqG9OcV4WVESdQ1D0s5JUa2jeF8hpw4RupMDJ4lRoKTVeIDS5Qb7OOhIGeKpK2DgMep9SN2ULYJdgldPtq/A==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-ast": "^0.69.0",
-        "@swagger-api/apidom-core": "^0.69.2",
-        "@types/ramda": "=0.28.23",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0",
+        "@swagger-api/apidom-ast": "^0.69.3",
+        "@swagger-api/apidom-core": "^0.69.3",
+        "@types/ramda": "=0.29.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0",
         "stampit": "=4.3.2",
         "tree-sitter": "=0.20.1",
         "tree-sitter-json": "=0.20.0",
         "web-tree-sitter": "=0.20.7"
       }
     },
-    "node_modules/@swagger-api/apidom-parser-adapter-json/node_modules/ramda": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
-      "optional": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-json/node_modules/ramda-adjunct": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-      "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda-adjunct"
-      },
-      "peerDependencies": {
-        "ramda": ">= 0.28.0 <= 0.28.0"
-      }
-    },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-0": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-0.69.2.tgz",
-      "integrity": "sha512-NGOX9NcrAy1RX1f+uA2rLZbgVWte6O4HRVk0eVjuR3NKjJzuXFdfaYJUpT8IGJx2cW6HsQtJU+BpR+LMfZnM9A==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-0.69.3.tgz",
+      "integrity": "sha512-f5Xby5hAGy4VujkV74UA61UkSVRsNzhcBaW0IIapVVepFEclfU7J3dGvfkMIXv5Bg0infGeKddIUZUY61JN88w==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.2",
-        "@swagger-api/apidom-ns-openapi-3-0": "^0.69.2",
-        "@swagger-api/apidom-parser-adapter-json": "^0.69.2",
-        "@types/ramda": "=0.28.23",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-0/node_modules/ramda": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
-      "optional": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-0/node_modules/ramda-adjunct": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-      "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda-adjunct"
-      },
-      "peerDependencies": {
-        "ramda": ">= 0.28.0 <= 0.28.0"
+        "@swagger-api/apidom-core": "^0.69.3",
+        "@swagger-api/apidom-ns-openapi-3-0": "^0.69.3",
+        "@swagger-api/apidom-parser-adapter-json": "^0.69.3",
+        "@types/ramda": "=0.29.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-1": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-0.69.2.tgz",
-      "integrity": "sha512-agafo94Uru42/nnydZ2wEt3ENAB6LWAd9l4d8wZL0ifAkjx8fv8rfH601LpFBQq3iD2DlGm0+UpFZXLfBuuQbQ==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-0.69.3.tgz",
+      "integrity": "sha512-Yq3k/d89Nmf+ePD5EIIkhXNti2Ru5XMqOXDbNQGKHH00e252Q+c+QF2A7Pgdy0xP3oA9OoYTGHLtL0ncmzYB9A==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.2",
-        "@swagger-api/apidom-ns-openapi-3-1": "^0.69.2",
-        "@swagger-api/apidom-parser-adapter-json": "^0.69.2",
-        "@types/ramda": "=0.28.23",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-1/node_modules/ramda": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
-      "optional": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-1/node_modules/ramda-adjunct": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-      "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda-adjunct"
-      },
-      "peerDependencies": {
-        "ramda": ">= 0.28.0 <= 0.28.0"
+        "@swagger-api/apidom-core": "^0.69.3",
+        "@swagger-api/apidom-ns-openapi-3-1": "^0.69.3",
+        "@swagger-api/apidom-parser-adapter-json": "^0.69.3",
+        "@types/ramda": "=0.29.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-0.69.2.tgz",
-      "integrity": "sha512-p7Wqk7vCgh9mkXQmk9I/uXri2+1MLCQ14NHfrVowey4ntH4LzBf0NtvxgfCryzzLb2RpdUwIxoh+uf4ibTzyyA==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-0.69.3.tgz",
+      "integrity": "sha512-X4Qtg/0n0l2leWBBZC8+7Kj6eP3pqB4WCWlacoWuldz8WBDBuffTBmTV/qe6gKdI4DW6mX5ovxDf+tz2tr0ppQ==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.2",
-        "@swagger-api/apidom-ns-openapi-3-0": "^0.69.2",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.69.2",
-        "@types/ramda": "=0.28.23",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/node_modules/ramda": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
-      "optional": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/node_modules/ramda-adjunct": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-      "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda-adjunct"
-      },
-      "peerDependencies": {
-        "ramda": ">= 0.28.0 <= 0.28.0"
+        "@swagger-api/apidom-core": "^0.69.3",
+        "@swagger-api/apidom-ns-openapi-3-0": "^0.69.3",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.69.3",
+        "@types/ramda": "=0.29.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-0.69.2.tgz",
-      "integrity": "sha512-Dq914JCnOqmRl6DyxeaP91MlZvIn62hax4RsANeiHIm2ICwwCQLNM9RNUkWq3iimHZpvTz+etM3QkKMakXUnqQ==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-0.69.3.tgz",
+      "integrity": "sha512-ZW/2T92HZT2RQOPW1VOa78VyDYD5wwR9EGNKXBsfMCnl0zVHwhwwkn/GgsYS0VDk56t43ww5DHM976q4ukF6Ew==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.2",
-        "@swagger-api/apidom-ns-openapi-3-1": "^0.69.2",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.69.2",
-        "@types/ramda": "=0.28.23",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/node_modules/ramda": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
-      "optional": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/node_modules/ramda-adjunct": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-      "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda-adjunct"
-      },
-      "peerDependencies": {
-        "ramda": ">= 0.28.0 <= 0.28.0"
+        "@swagger-api/apidom-core": "^0.69.3",
+        "@swagger-api/apidom-ns-openapi-3-1": "^0.69.3",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.69.3",
+        "@types/ramda": "=0.29.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-0.69.2.tgz",
-      "integrity": "sha512-5sWKGF/phSd+kvOD8xfB2W26QeN2U6LOoLy6eYvf8DP5q4doiLoEcVIunpcVjl04IWVet+VFH9XFGEMlKk7qKQ==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-0.69.3.tgz",
+      "integrity": "sha512-HJ/OiXnVoUshwKrfaHDq4LfKeKxBsa6Bmo8NVdSZiRfeA1Y/fAx9mWW5xSzTADxmc6yA2MevnfIoq7W0NX6SSQ==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-ast": "^0.69.0",
-        "@swagger-api/apidom-core": "^0.69.2",
-        "@types/ramda": "=0.28.23",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0",
+        "@swagger-api/apidom-ast": "^0.69.3",
+        "@swagger-api/apidom-core": "^0.69.3",
+        "@types/ramda": "=0.29.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0",
         "stampit": "=4.3.2",
         "tree-sitter": "=0.20.1",
         "tree-sitter-yaml": "=0.5.0",
         "web-tree-sitter": "=0.20.7"
       }
     },
-    "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2/node_modules/ramda": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
-      "optional": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
-    },
-    "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2/node_modules/ramda-adjunct": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-      "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda-adjunct"
-      },
-      "peerDependencies": {
-        "ramda": ">= 0.28.0 <= 0.28.0"
-      }
-    },
     "node_modules/@swagger-api/apidom-reference": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-0.69.2.tgz",
-      "integrity": "sha512-aJsgtCP71t8a+frS+qn1FW9MqjjK60c3AnB2G3cUXGVwzmEPEkvBFF0LGlPmHftVvzzBvI7AsMC7+HZPM/t7rQ==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-0.69.3.tgz",
+      "integrity": "sha512-dimoVsW4COR4TUTgOqTnXSZAIdYOepIudWOvca2fGOcXg85eBMS4xJlNHx1095Fm664y5y8DVxIYe1oLu9gjVA==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.2",
-        "@types/ramda": "=0.28.23",
-        "axios": "=1.3.4",
+        "@swagger-api/apidom-core": "^0.69.3",
+        "@types/ramda": "=0.29.0",
+        "axios": "=1.3.6",
         "minimatch": "=7.4.3",
         "process": "=0.11.10",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0",
         "stampit": "=4.3.2"
       },
       "optionalDependencies": {
-        "@swagger-api/apidom-json-pointer": "^0.69.2",
-        "@swagger-api/apidom-ns-asyncapi-2": "^0.69.2",
-        "@swagger-api/apidom-ns-openapi-3-0": "^0.69.2",
-        "@swagger-api/apidom-ns-openapi-3-1": "^0.69.2",
-        "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^0.69.2",
-        "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^0.69.2",
-        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^0.69.2",
-        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^0.69.2",
-        "@swagger-api/apidom-parser-adapter-json": "^0.69.2",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^0.69.2",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^0.69.2",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^0.69.2",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^0.69.2",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.69.2"
+        "@swagger-api/apidom-json-pointer": "^0.69.3",
+        "@swagger-api/apidom-ns-asyncapi-2": "^0.69.3",
+        "@swagger-api/apidom-ns-openapi-3-0": "^0.69.3",
+        "@swagger-api/apidom-ns-openapi-3-1": "^0.69.3",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^0.69.3",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^0.69.3",
+        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^0.69.3",
+        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^0.69.3",
+        "@swagger-api/apidom-parser-adapter-json": "^0.69.3",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^0.69.3",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^0.69.3",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^0.69.3",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^0.69.3",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.69.3"
       }
     },
     "node_modules/@swagger-api/apidom-reference/node_modules/axios": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
-      "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.6.tgz",
+      "integrity": "sha512-PEcdkk7JcdPiMDkvM4K6ZBRYq9keuVJsToxm2zQIM70Qqo2WHTdJZMXcG9X+RmRp2VPNUQC8W1RAGbgt6b1yMg==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -5668,30 +5160,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-    },
-    "node_modules/@swagger-api/apidom-reference/node_modules/ramda": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda"
-      }
-    },
-    "node_modules/@swagger-api/apidom-reference/node_modules/ramda-adjunct": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-      "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-      "engines": {
-        "node": ">=0.10.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ramda-adjunct"
-      },
-      "peerDependencies": {
-        "ramda": ">= 0.28.0 <= 0.28.0"
-      }
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "5.0.1",
@@ -6038,11 +5506,11 @@
       "dev": true
     },
     "node_modules/@types/ramda": {
-      "version": "0.28.23",
-      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.28.23.tgz",
-      "integrity": "sha512-9TYWiwkew+mCMsL7jZ+kkzy6QXn8PL5/SKmBPmjgUlTpkokZWTBr+OhiIUDztpAEbslWyt24NNfEmZUBFmnXig==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.29.0.tgz",
+      "integrity": "sha512-TY9eKsklU43CmAbFJPKDUyBjleZ4EFAkbJeQRF4e8byGkOw1CjDcwg5EGa0Bgf0Kgs9BE9OU4UzQWnQDHnvMtA==",
       "dependencies": {
-        "ts-toolbelt": "^6.15.1"
+        "types-ramda": "^0.29.1"
       }
     },
     "node_modules/@types/range-parser": {
@@ -23790,6 +23258,30 @@
       "integrity": "sha512-y/M9weqWAH4iopRd7EHDEQQvpFPHj1AA3oHozE9tfITHUtTR7Z9PSlIRRG2l1GuW7sefC1cXFfIcF+cgnShdBA==",
       "dev": true
     },
+    "node_modules/ramda": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.29.0.tgz",
+      "integrity": "sha512-BBea6L67bYLtdbOqfp8f58fPMqEwx0doL+pAi8TZyp2YWz8R9G8z9x75CZI8W+ftqhFHCpEX2cRnUUXK130iKA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ramda"
+      }
+    },
+    "node_modules/ramda-adjunct": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-4.0.0.tgz",
+      "integrity": "sha512-W/NiJAlZdwZ/iUkWEQQgRdH5Szqqet1WoVH9cdqDVjFbVaZHuJfJRvsxqHhvq6tZse+yVbFatLDLdVa30wBlGQ==",
+      "engines": {
+        "node": ">=0.10.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ramda-adjunct"
+      },
+      "peerDependencies": {
+        "ramda": ">= 0.29.0"
+      }
+    },
     "node_modules/randexp": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.5.3.tgz",
@@ -27214,15 +26706,15 @@
       }
     },
     "node_modules/swagger-client": {
-      "version": "3.19.6",
-      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.19.6.tgz",
-      "integrity": "sha512-fd0XaoKz3lgs6viKkqK+o8QyrOOZULD4tLcUd8wEfsVBjJIAks2Qa1AhGUr87mfCWZw0Z9OXItWF9T477rRXzw==",
+      "version": "3.19.7",
+      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.19.7.tgz",
+      "integrity": "sha512-5U4+tksrzVODZaLTtivzS9be6u7rX5ZSWFKDIYWsy8HCwt9FH1ANrrGpY1wDHydpOeaySbxMjMaqEM9cGWxOuQ==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.13",
-        "@swagger-api/apidom-core": ">=0.69.2 <1.0.0",
-        "@swagger-api/apidom-json-pointer": ">=0.69.2 <1.0.0",
-        "@swagger-api/apidom-ns-openapi-3-1": ">=0.69.2 <1.0.0",
-        "@swagger-api/apidom-reference": ">=0.69.2 <1.0.0",
+        "@swagger-api/apidom-core": ">=0.69.3 <1.0.0",
+        "@swagger-api/apidom-json-pointer": ">=0.69.3 <1.0.0",
+        "@swagger-api/apidom-ns-openapi-3-1": ">=0.69.3 <1.0.0",
+        "@swagger-api/apidom-reference": ">=0.69.3 <1.0.0",
         "cookie": "~0.5.0",
         "cross-fetch": "^3.1.5",
         "deepmerge": "~4.3.0",
@@ -27769,9 +27261,9 @@
       }
     },
     "node_modules/ts-toolbelt": {
-      "version": "6.15.5",
-      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz",
-      "integrity": "sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A=="
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
+      "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w=="
     },
     "node_modules/tsconfig-paths": {
       "version": "3.14.1",
@@ -27932,6 +27424,14 @@
       "dev": true,
       "dependencies": {
         "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/types-ramda": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/types-ramda/-/types-ramda-0.29.2.tgz",
+      "integrity": "sha512-HpLcR0ly2EfXQwG8VSI5ov6ml7PvtT+u+cp+7lZLu7q4nhnPDVW+rUTC1uy/SNs4aAyTUXri5M/LyhgvjEXJDg==",
+      "dependencies": {
+        "ts-toolbelt": "^9.6.0"
       }
     },
     "node_modules/typescript": {
@@ -32582,624 +32082,336 @@
       "dev": true
     },
     "@swagger-api/apidom-ast": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-0.69.0.tgz",
-      "integrity": "sha512-JsRyi1Ir3VeNSSWmIFqgaFOQCIUvCoKcfmOcU/h4Jz1IOkQij1vj3qEFln4J9sByOWHrhA8zD1Cf+LnXkbGVZg==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-0.69.3.tgz",
+      "integrity": "sha512-orGw/gihk7RmorxibwalthDS58B7QaEBd31fK+/aFx6QqEO1tEO35F850BiL2B5C8TaK8C2Tey01AZTXCxYmfw==",
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@types/ramda": "=0.28.23",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0",
+        "@types/ramda": "=0.29.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0",
         "stampit": "=4.3.2",
         "unraw": "=2.0.1"
-      },
-      "dependencies": {
-        "ramda": {
-          "version": "0.28.0",
-          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-          "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA=="
-        },
-        "ramda-adjunct": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-          "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-          "requires": {}
-        }
       }
     },
     "@swagger-api/apidom-core": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-0.69.2.tgz",
-      "integrity": "sha512-av9vS1SbXxGJvCt4QggrIvS8dr3ZfL6jxrNQGr4cq1wFY/n5ruj0RsXix208c3Zp1Kua3QVOUaJvA+7RdT1VJA==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-0.69.3.tgz",
+      "integrity": "sha512-EIQiJUuT/V9nGkHOYYFP0QNgAW7Y4QwrQzldDzy9ltcHbOKY3TNh/QzYvO0+HvKSv9W7u7WTMH/kaRaSsaZsGw==",
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-ast": "^0.69.0",
-        "@types/ramda": "=0.28.23",
+        "@swagger-api/apidom-ast": "^0.69.3",
+        "@types/ramda": "=0.29.0",
         "minim": "=0.23.8",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0",
         "short-unique-id": "=4.4.4",
         "stampit": "=4.3.2"
-      },
-      "dependencies": {
-        "ramda": {
-          "version": "0.28.0",
-          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-          "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA=="
-        },
-        "ramda-adjunct": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-          "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-          "requires": {}
-        }
       }
     },
     "@swagger-api/apidom-json-pointer": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-0.69.2.tgz",
-      "integrity": "sha512-ipu94QNw8ZKWC+pfie5IyIzVImR5N0PANXkUSfFon5L4aMAtggKpZn7aUv/2Cxn51JsCvjZwkXT7PaJ8RddpxA==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-0.69.3.tgz",
+      "integrity": "sha512-VYXqLY8f2fkaS/d+vVQEMEOEZRXAgGm5tCMx4C7uaU+wC+SKPH/zTh+qElbkaXQr4nfLjbphBsHh31doCyBEjw==",
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.2",
-        "@types/ramda": "=0.28.23",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0"
-      },
-      "dependencies": {
-        "ramda": {
-          "version": "0.28.0",
-          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-          "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA=="
-        },
-        "ramda-adjunct": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-          "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-          "requires": {}
-        }
+        "@swagger-api/apidom-core": "^0.69.3",
+        "@types/ramda": "=0.29.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0"
       }
     },
     "@swagger-api/apidom-ns-api-design-systems": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-0.69.2.tgz",
-      "integrity": "sha512-JnOPiDvPfNH/6WWVBqBwK0oIHscHECtL1iZDUE9nB4NSbyoV10oulkuhHNAO9BImqtU4rxtWbXyTL1MEuUdHHQ==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-0.69.3.tgz",
+      "integrity": "sha512-oTwIG8LyKnU4/m8BtAOc+X572+nH4gjxITYtw0L8f4a8Iv1b8LHS0KRzG7c/LVUGtMijpv3aBKPV6QvWhjrrtg==",
       "optional": true,
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.2",
-        "@swagger-api/apidom-ns-openapi-3-1": "^0.69.2",
-        "@types/ramda": "=0.28.23",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0",
+        "@swagger-api/apidom-core": "^0.69.3",
+        "@swagger-api/apidom-ns-openapi-3-1": "^0.69.3",
+        "@types/ramda": "=0.29.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0",
         "stampit": "=4.3.2"
-      },
-      "dependencies": {
-        "ramda": {
-          "version": "0.28.0",
-          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-          "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
-          "optional": true
-        },
-        "ramda-adjunct": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-          "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-          "optional": true,
-          "requires": {}
-        }
       }
     },
     "@swagger-api/apidom-ns-asyncapi-2": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-0.69.2.tgz",
-      "integrity": "sha512-SOg9P4rM5Aj2jabt4njmFbZTRMX8/vRHgiDL9vE+uz7s6j64B9QBSFF42j17cEVq6ToqQ7jtu40f1D7K62puQA==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-0.69.3.tgz",
+      "integrity": "sha512-98HgNbZWqPHqf+EyXs/GcAnayA08/mfN7YlXIRRIys+rll4M/1b+ap+BkTnJ+le3Kra7DhIQ8ucQuEJ+Ik1Sxg==",
       "optional": true,
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.2",
-        "@swagger-api/apidom-ns-json-schema-draft-7": "^0.69.2",
-        "@types/ramda": "=0.28.23",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0",
+        "@swagger-api/apidom-core": "^0.69.3",
+        "@swagger-api/apidom-ns-json-schema-draft-7": "^0.69.3",
+        "@types/ramda": "=0.29.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0",
         "stampit": "=4.3.2"
-      },
-      "dependencies": {
-        "ramda": {
-          "version": "0.28.0",
-          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-          "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
-          "optional": true
-        },
-        "ramda-adjunct": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-          "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-          "optional": true,
-          "requires": {}
-        }
       }
     },
     "@swagger-api/apidom-ns-json-schema-draft-4": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-0.69.2.tgz",
-      "integrity": "sha512-8yB4afGBAX+vN5oNRxZMWWS/2G0Q9VUzlL2AOu0Q70FQkscbjQcsb6QX9LbHFMrwi3MgOgE0ewMncpcwskuoXA==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-0.69.3.tgz",
+      "integrity": "sha512-/tMeoz1IHEblc3OwWC812NQFLITOnexjGVujG5Wvsr9ZnTkRb+0g7CbXuooujwfcEY+++o2+kCUgy4SBQFIIlQ==",
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.2",
-        "@types/ramda": "=0.28.23",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0",
+        "@swagger-api/apidom-core": "^0.69.3",
+        "@types/ramda": "=0.29.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0",
         "stampit": "=4.3.2"
-      },
-      "dependencies": {
-        "ramda": {
-          "version": "0.28.0",
-          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-          "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA=="
-        },
-        "ramda-adjunct": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-          "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-          "requires": {}
-        }
       }
     },
     "@swagger-api/apidom-ns-json-schema-draft-6": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-0.69.2.tgz",
-      "integrity": "sha512-RPazXv7L37vrdqHeFy/ZrKVz+vnVOqEFrHFefaq2L5avnzInVTRsTJm+61q0jqnckozz426Gbg5wJgq+Yvpbqg==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-0.69.3.tgz",
+      "integrity": "sha512-B/6zPFYW1xE66Uc/jOdZVZMEe0+444heTMlpGJGejTy6pNRxCTOsv+B63QzctJv410dHPxGeMRZMeff9wQPBDA==",
       "optional": true,
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.2",
-        "@swagger-api/apidom-ns-json-schema-draft-4": "^0.69.2",
-        "@types/ramda": "=0.28.23",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0",
+        "@swagger-api/apidom-core": "^0.69.3",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^0.69.3",
+        "@types/ramda": "=0.29.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0",
         "stampit": "=4.3.2"
-      },
-      "dependencies": {
-        "ramda": {
-          "version": "0.28.0",
-          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-          "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
-          "optional": true
-        },
-        "ramda-adjunct": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-          "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-          "optional": true,
-          "requires": {}
-        }
       }
     },
     "@swagger-api/apidom-ns-json-schema-draft-7": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-0.69.2.tgz",
-      "integrity": "sha512-pQQE85xjv+UaObQzkhpOPochQ8GhWETAUuzDxHrgKmw20Ca03QAC7RV3tbSnkIbI5cy9wpb4gRM0T5/PzZnBYA==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-0.69.3.tgz",
+      "integrity": "sha512-EkgPlKPQZ3XBkbxAFh2lXsLcyIwRikARFD3RlupsKjAHVFbH7cImbPxb+MnjacfwgVreMk34OWuXqjnGZ8lG1Q==",
       "optional": true,
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.2",
-        "@swagger-api/apidom-ns-json-schema-draft-6": "^0.69.2",
-        "@types/ramda": "=0.28.23",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0",
+        "@swagger-api/apidom-core": "^0.69.3",
+        "@swagger-api/apidom-ns-json-schema-draft-6": "^0.69.3",
+        "@types/ramda": "=0.29.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0",
         "stampit": "=4.3.2"
-      },
-      "dependencies": {
-        "ramda": {
-          "version": "0.28.0",
-          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-          "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
-          "optional": true
-        },
-        "ramda-adjunct": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-          "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-          "optional": true,
-          "requires": {}
-        }
       }
     },
     "@swagger-api/apidom-ns-openapi-3-0": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-0.69.2.tgz",
-      "integrity": "sha512-OroXRC+Q1btrpuQ3+ZbMi9XGYiab3YQMg/Rx1wpszbW5C5IPtaa2/FtMcBGYWR5IIdxi+bAT8itbMBGSCcz/Ew==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-0.69.3.tgz",
+      "integrity": "sha512-iScwP+SzX8SJMrgChZbdS60Ode/zXfesNaDA+HkNBLbfSrri4/C5FTB0gfWOG0gCGPq+1K5dHlgLrEgogfAARw==",
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.2",
-        "@swagger-api/apidom-ns-json-schema-draft-4": "^0.69.2",
-        "@types/ramda": "=0.28.23",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0",
+        "@swagger-api/apidom-core": "^0.69.3",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^0.69.3",
+        "@types/ramda": "=0.29.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0",
         "stampit": "=4.3.2"
-      },
-      "dependencies": {
-        "ramda": {
-          "version": "0.28.0",
-          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-          "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA=="
-        },
-        "ramda-adjunct": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-          "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-          "requires": {}
-        }
       }
     },
     "@swagger-api/apidom-ns-openapi-3-1": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-0.69.2.tgz",
-      "integrity": "sha512-2yyUmdbvkDnZuOGDduvlp4dtLL/8a1PCR+Ajk9+PR4ZTdbMFtZWcr/knGc33Rtr8eXQwd4NPypFHhTLCEHiGwg==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-0.69.3.tgz",
+      "integrity": "sha512-J+yIsTBTn7rzfj+vaCXRRdOCrL4kxwnS3P/h4lXb82EZnPU/EbJi+C0LK7O24/vXpeBVRr+OpDfnhpospanMJg==",
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.2",
-        "@swagger-api/apidom-ns-openapi-3-0": "^0.69.2",
-        "@types/ramda": "=0.28.23",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0",
+        "@swagger-api/apidom-core": "^0.69.3",
+        "@swagger-api/apidom-ns-openapi-3-0": "^0.69.3",
+        "@types/ramda": "=0.29.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0",
         "stampit": "=4.3.2"
-      },
-      "dependencies": {
-        "ramda": {
-          "version": "0.28.0",
-          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-          "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA=="
-        },
-        "ramda-adjunct": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-          "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-          "requires": {}
-        }
       }
     },
     "@swagger-api/apidom-parser-adapter-api-design-systems-json": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-0.69.2.tgz",
-      "integrity": "sha512-qVL8JrnsjuD3uS1PTNoBTKd5YXPs2SfxRGyKwcmrUXFS+jJmbyYF04xmCgXkwI6TZYjY6KlNb8vmOt4Xr8FqnA==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-0.69.3.tgz",
+      "integrity": "sha512-y8xOaSaZVphITajH12T1EHLuZB9kw79DTdQRYoMC+BqZQbsPv3/mLWXS1STQU9oR/PZBA9FJcgAFdThaRgi8UA==",
       "optional": true,
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.2",
-        "@swagger-api/apidom-ns-api-design-systems": "^0.69.2",
-        "@swagger-api/apidom-parser-adapter-json": "^0.69.2",
-        "@types/ramda": "=0.28.23",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0"
-      },
-      "dependencies": {
-        "ramda": {
-          "version": "0.28.0",
-          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-          "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
-          "optional": true
-        },
-        "ramda-adjunct": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-          "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-          "optional": true,
-          "requires": {}
-        }
+        "@swagger-api/apidom-core": "^0.69.3",
+        "@swagger-api/apidom-ns-api-design-systems": "^0.69.3",
+        "@swagger-api/apidom-parser-adapter-json": "^0.69.3",
+        "@types/ramda": "=0.29.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0"
       }
     },
     "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-0.69.2.tgz",
-      "integrity": "sha512-vMWfQiXcSeo9XSJJ1Yny4BAUw/3RBbBTsPBbNSsnMtpcDhBbodxdko1CeYkGc8sKM0QyeTFPJuiVhb3kGidbcQ==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-0.69.3.tgz",
+      "integrity": "sha512-zMc+Dy7zl7cT8YduaUEpvLkRDVfZp8jZ1v13VjueX/VhsSXK0DW+OX/Mc8CU1Qx6Gg6tUMKxqmILdXZwxCrh6Q==",
       "optional": true,
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.2",
-        "@swagger-api/apidom-ns-api-design-systems": "^0.69.2",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.69.2",
-        "@types/ramda": "=0.28.23",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0"
-      },
-      "dependencies": {
-        "ramda": {
-          "version": "0.28.0",
-          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-          "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
-          "optional": true
-        },
-        "ramda-adjunct": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-          "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-          "optional": true,
-          "requires": {}
-        }
+        "@swagger-api/apidom-core": "^0.69.3",
+        "@swagger-api/apidom-ns-api-design-systems": "^0.69.3",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.69.3",
+        "@types/ramda": "=0.29.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0"
       }
     },
     "@swagger-api/apidom-parser-adapter-asyncapi-json-2": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-0.69.2.tgz",
-      "integrity": "sha512-/WDVzOcGFxSgBVCiXHVnfiOeYIWtn2RG/Bnn8leUmWRN9oRBiCS3Lh60qWVpvs4BOVntL7SYJnC+buicKD1iJA==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-0.69.3.tgz",
+      "integrity": "sha512-BbsBxxZxTMX2rKgVKJtqPoAsER0JvCe1pt3NUBLuQssugvpwaqimIsKC65dwspHFGSn0CVdBKA4n/XhZ3aT7tw==",
       "optional": true,
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.2",
-        "@swagger-api/apidom-ns-asyncapi-2": "^0.69.2",
-        "@swagger-api/apidom-parser-adapter-json": "^0.69.2",
-        "@types/ramda": "=0.28.23",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0"
-      },
-      "dependencies": {
-        "ramda": {
-          "version": "0.28.0",
-          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-          "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
-          "optional": true
-        },
-        "ramda-adjunct": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-          "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-          "optional": true,
-          "requires": {}
-        }
+        "@swagger-api/apidom-core": "^0.69.3",
+        "@swagger-api/apidom-ns-asyncapi-2": "^0.69.3",
+        "@swagger-api/apidom-parser-adapter-json": "^0.69.3",
+        "@types/ramda": "=0.29.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0"
       }
     },
     "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-0.69.2.tgz",
-      "integrity": "sha512-qr5epdayokdYyPIJITyqWmUxdknhgPbXhWpSxdEvM8UHgtyutvvvFenFM5pXD1ft8I/uv9oj2WNZxCH2mpsR1g==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-0.69.3.tgz",
+      "integrity": "sha512-lae39qaKrkls+iVzYuc9CUyCbRl80wNK8iBWriSVETv5IwlVS6wywtTxCqtzcpd5K+m9KqXAlSkd+Z2AS9cWuQ==",
       "optional": true,
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.2",
-        "@swagger-api/apidom-ns-asyncapi-2": "^0.69.2",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.69.2",
-        "@types/ramda": "=0.28.23",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0"
-      },
-      "dependencies": {
-        "ramda": {
-          "version": "0.28.0",
-          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-          "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
-          "optional": true
-        },
-        "ramda-adjunct": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-          "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-          "optional": true,
-          "requires": {}
-        }
+        "@swagger-api/apidom-core": "^0.69.3",
+        "@swagger-api/apidom-ns-asyncapi-2": "^0.69.3",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.69.3",
+        "@types/ramda": "=0.29.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0"
       }
     },
     "@swagger-api/apidom-parser-adapter-json": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-0.69.2.tgz",
-      "integrity": "sha512-mRXrf9bz2lxf9DY2n2WkB3GlQ8MXRqKBwpXLwjDqqve25Wf6X8QNzfz5ykYORQMuyDIgPq/8aMet7yjHRNtcUQ==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-0.69.3.tgz",
+      "integrity": "sha512-Z1CqG9OcV4WVESdQ1D0s5JUa2jeF8hpw4RupMDJ4lRoKTVeIDS5Qb7OOhIGeKpK2DgMep9SN2ULYJdgldPtq/A==",
       "optional": true,
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-ast": "^0.69.0",
-        "@swagger-api/apidom-core": "^0.69.2",
-        "@types/ramda": "=0.28.23",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0",
+        "@swagger-api/apidom-ast": "^0.69.3",
+        "@swagger-api/apidom-core": "^0.69.3",
+        "@types/ramda": "=0.29.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0",
         "stampit": "=4.3.2",
         "tree-sitter": "=0.20.1",
         "tree-sitter-json": "=0.20.0",
         "web-tree-sitter": "=0.20.7"
-      },
-      "dependencies": {
-        "ramda": {
-          "version": "0.28.0",
-          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-          "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
-          "optional": true
-        },
-        "ramda-adjunct": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-          "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-          "optional": true,
-          "requires": {}
-        }
       }
     },
     "@swagger-api/apidom-parser-adapter-openapi-json-3-0": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-0.69.2.tgz",
-      "integrity": "sha512-NGOX9NcrAy1RX1f+uA2rLZbgVWte6O4HRVk0eVjuR3NKjJzuXFdfaYJUpT8IGJx2cW6HsQtJU+BpR+LMfZnM9A==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-0.69.3.tgz",
+      "integrity": "sha512-f5Xby5hAGy4VujkV74UA61UkSVRsNzhcBaW0IIapVVepFEclfU7J3dGvfkMIXv5Bg0infGeKddIUZUY61JN88w==",
       "optional": true,
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.2",
-        "@swagger-api/apidom-ns-openapi-3-0": "^0.69.2",
-        "@swagger-api/apidom-parser-adapter-json": "^0.69.2",
-        "@types/ramda": "=0.28.23",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0"
-      },
-      "dependencies": {
-        "ramda": {
-          "version": "0.28.0",
-          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-          "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
-          "optional": true
-        },
-        "ramda-adjunct": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-          "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-          "optional": true,
-          "requires": {}
-        }
+        "@swagger-api/apidom-core": "^0.69.3",
+        "@swagger-api/apidom-ns-openapi-3-0": "^0.69.3",
+        "@swagger-api/apidom-parser-adapter-json": "^0.69.3",
+        "@types/ramda": "=0.29.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0"
       }
     },
     "@swagger-api/apidom-parser-adapter-openapi-json-3-1": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-0.69.2.tgz",
-      "integrity": "sha512-agafo94Uru42/nnydZ2wEt3ENAB6LWAd9l4d8wZL0ifAkjx8fv8rfH601LpFBQq3iD2DlGm0+UpFZXLfBuuQbQ==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-0.69.3.tgz",
+      "integrity": "sha512-Yq3k/d89Nmf+ePD5EIIkhXNti2Ru5XMqOXDbNQGKHH00e252Q+c+QF2A7Pgdy0xP3oA9OoYTGHLtL0ncmzYB9A==",
       "optional": true,
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.2",
-        "@swagger-api/apidom-ns-openapi-3-1": "^0.69.2",
-        "@swagger-api/apidom-parser-adapter-json": "^0.69.2",
-        "@types/ramda": "=0.28.23",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0"
-      },
-      "dependencies": {
-        "ramda": {
-          "version": "0.28.0",
-          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-          "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
-          "optional": true
-        },
-        "ramda-adjunct": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-          "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-          "optional": true,
-          "requires": {}
-        }
+        "@swagger-api/apidom-core": "^0.69.3",
+        "@swagger-api/apidom-ns-openapi-3-1": "^0.69.3",
+        "@swagger-api/apidom-parser-adapter-json": "^0.69.3",
+        "@types/ramda": "=0.29.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0"
       }
     },
     "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-0.69.2.tgz",
-      "integrity": "sha512-p7Wqk7vCgh9mkXQmk9I/uXri2+1MLCQ14NHfrVowey4ntH4LzBf0NtvxgfCryzzLb2RpdUwIxoh+uf4ibTzyyA==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-0.69.3.tgz",
+      "integrity": "sha512-X4Qtg/0n0l2leWBBZC8+7Kj6eP3pqB4WCWlacoWuldz8WBDBuffTBmTV/qe6gKdI4DW6mX5ovxDf+tz2tr0ppQ==",
       "optional": true,
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.2",
-        "@swagger-api/apidom-ns-openapi-3-0": "^0.69.2",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.69.2",
-        "@types/ramda": "=0.28.23",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0"
-      },
-      "dependencies": {
-        "ramda": {
-          "version": "0.28.0",
-          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-          "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
-          "optional": true
-        },
-        "ramda-adjunct": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-          "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-          "optional": true,
-          "requires": {}
-        }
+        "@swagger-api/apidom-core": "^0.69.3",
+        "@swagger-api/apidom-ns-openapi-3-0": "^0.69.3",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.69.3",
+        "@types/ramda": "=0.29.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0"
       }
     },
     "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-0.69.2.tgz",
-      "integrity": "sha512-Dq914JCnOqmRl6DyxeaP91MlZvIn62hax4RsANeiHIm2ICwwCQLNM9RNUkWq3iimHZpvTz+etM3QkKMakXUnqQ==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-0.69.3.tgz",
+      "integrity": "sha512-ZW/2T92HZT2RQOPW1VOa78VyDYD5wwR9EGNKXBsfMCnl0zVHwhwwkn/GgsYS0VDk56t43ww5DHM976q4ukF6Ew==",
       "optional": true,
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.2",
-        "@swagger-api/apidom-ns-openapi-3-1": "^0.69.2",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.69.2",
-        "@types/ramda": "=0.28.23",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0"
-      },
-      "dependencies": {
-        "ramda": {
-          "version": "0.28.0",
-          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-          "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
-          "optional": true
-        },
-        "ramda-adjunct": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-          "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-          "optional": true,
-          "requires": {}
-        }
+        "@swagger-api/apidom-core": "^0.69.3",
+        "@swagger-api/apidom-ns-openapi-3-1": "^0.69.3",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.69.3",
+        "@types/ramda": "=0.29.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0"
       }
     },
     "@swagger-api/apidom-parser-adapter-yaml-1-2": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-0.69.2.tgz",
-      "integrity": "sha512-5sWKGF/phSd+kvOD8xfB2W26QeN2U6LOoLy6eYvf8DP5q4doiLoEcVIunpcVjl04IWVet+VFH9XFGEMlKk7qKQ==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-0.69.3.tgz",
+      "integrity": "sha512-HJ/OiXnVoUshwKrfaHDq4LfKeKxBsa6Bmo8NVdSZiRfeA1Y/fAx9mWW5xSzTADxmc6yA2MevnfIoq7W0NX6SSQ==",
       "optional": true,
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-ast": "^0.69.0",
-        "@swagger-api/apidom-core": "^0.69.2",
-        "@types/ramda": "=0.28.23",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0",
+        "@swagger-api/apidom-ast": "^0.69.3",
+        "@swagger-api/apidom-core": "^0.69.3",
+        "@types/ramda": "=0.29.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0",
         "stampit": "=4.3.2",
         "tree-sitter": "=0.20.1",
         "tree-sitter-yaml": "=0.5.0",
         "web-tree-sitter": "=0.20.7"
-      },
-      "dependencies": {
-        "ramda": {
-          "version": "0.28.0",
-          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-          "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
-          "optional": true
-        },
-        "ramda-adjunct": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-          "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-          "optional": true,
-          "requires": {}
-        }
       }
     },
     "@swagger-api/apidom-reference": {
-      "version": "0.69.2",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-0.69.2.tgz",
-      "integrity": "sha512-aJsgtCP71t8a+frS+qn1FW9MqjjK60c3AnB2G3cUXGVwzmEPEkvBFF0LGlPmHftVvzzBvI7AsMC7+HZPM/t7rQ==",
+      "version": "0.69.3",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-0.69.3.tgz",
+      "integrity": "sha512-dimoVsW4COR4TUTgOqTnXSZAIdYOepIudWOvca2fGOcXg85eBMS4xJlNHx1095Fm664y5y8DVxIYe1oLu9gjVA==",
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.69.2",
-        "@swagger-api/apidom-json-pointer": "^0.69.2",
-        "@swagger-api/apidom-ns-asyncapi-2": "^0.69.2",
-        "@swagger-api/apidom-ns-openapi-3-0": "^0.69.2",
-        "@swagger-api/apidom-ns-openapi-3-1": "^0.69.2",
-        "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^0.69.2",
-        "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^0.69.2",
-        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^0.69.2",
-        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^0.69.2",
-        "@swagger-api/apidom-parser-adapter-json": "^0.69.2",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^0.69.2",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^0.69.2",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^0.69.2",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^0.69.2",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.69.2",
-        "@types/ramda": "=0.28.23",
-        "axios": "=1.3.4",
+        "@swagger-api/apidom-core": "^0.69.3",
+        "@swagger-api/apidom-json-pointer": "^0.69.3",
+        "@swagger-api/apidom-ns-asyncapi-2": "^0.69.3",
+        "@swagger-api/apidom-ns-openapi-3-0": "^0.69.3",
+        "@swagger-api/apidom-ns-openapi-3-1": "^0.69.3",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^0.69.3",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^0.69.3",
+        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^0.69.3",
+        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^0.69.3",
+        "@swagger-api/apidom-parser-adapter-json": "^0.69.3",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^0.69.3",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^0.69.3",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^0.69.3",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^0.69.3",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.69.3",
+        "@types/ramda": "=0.29.0",
+        "axios": "=1.3.6",
         "minimatch": "=7.4.3",
         "process": "=0.11.10",
-        "ramda": "=0.28.0",
-        "ramda-adjunct": "=3.4.0",
+        "ramda": "=0.29.0",
+        "ramda-adjunct": "=4.0.0",
         "stampit": "=4.3.2"
       },
       "dependencies": {
         "axios": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
-          "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
+          "version": "1.3.6",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.6.tgz",
+          "integrity": "sha512-PEcdkk7JcdPiMDkvM4K6ZBRYq9keuVJsToxm2zQIM70Qqo2WHTdJZMXcG9X+RmRp2VPNUQC8W1RAGbgt6b1yMg==",
           "requires": {
             "follow-redirects": "^1.15.0",
             "form-data": "^4.0.0",
@@ -33236,17 +32448,6 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
           "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-        },
-        "ramda": {
-          "version": "0.28.0",
-          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-          "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA=="
-        },
-        "ramda-adjunct": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-3.4.0.tgz",
-          "integrity": "sha512-qKRgqwZzJUZmPJfGK8/uLVxQXkiftKhW6FW9NUCUlQrzsBUZBvFAZUxwH7nTRwDMg+ChRU69rVVuS/4EUgtuIg==",
-          "requires": {}
         }
       }
     },
@@ -33586,11 +32787,11 @@
       "dev": true
     },
     "@types/ramda": {
-      "version": "0.28.23",
-      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.28.23.tgz",
-      "integrity": "sha512-9TYWiwkew+mCMsL7jZ+kkzy6QXn8PL5/SKmBPmjgUlTpkokZWTBr+OhiIUDztpAEbslWyt24NNfEmZUBFmnXig==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.29.0.tgz",
+      "integrity": "sha512-TY9eKsklU43CmAbFJPKDUyBjleZ4EFAkbJeQRF4e8byGkOw1CjDcwg5EGa0Bgf0Kgs9BE9OU4UzQWnQDHnvMtA==",
       "requires": {
-        "ts-toolbelt": "^6.15.1"
+        "types-ramda": "^0.29.1"
       }
     },
     "@types/range-parser": {
@@ -46754,6 +45955,17 @@
       "integrity": "sha512-y/M9weqWAH4iopRd7EHDEQQvpFPHj1AA3oHozE9tfITHUtTR7Z9PSlIRRG2l1GuW7sefC1cXFfIcF+cgnShdBA==",
       "dev": true
     },
+    "ramda": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.29.0.tgz",
+      "integrity": "sha512-BBea6L67bYLtdbOqfp8f58fPMqEwx0doL+pAi8TZyp2YWz8R9G8z9x75CZI8W+ftqhFHCpEX2cRnUUXK130iKA=="
+    },
+    "ramda-adjunct": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-4.0.0.tgz",
+      "integrity": "sha512-W/NiJAlZdwZ/iUkWEQQgRdH5Szqqet1WoVH9cdqDVjFbVaZHuJfJRvsxqHhvq6tZse+yVbFatLDLdVa30wBlGQ==",
+      "requires": {}
+    },
     "randexp": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.5.3.tgz",
@@ -49295,15 +48507,15 @@
       }
     },
     "swagger-client": {
-      "version": "3.19.6",
-      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.19.6.tgz",
-      "integrity": "sha512-fd0XaoKz3lgs6viKkqK+o8QyrOOZULD4tLcUd8wEfsVBjJIAks2Qa1AhGUr87mfCWZw0Z9OXItWF9T477rRXzw==",
+      "version": "3.19.7",
+      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.19.7.tgz",
+      "integrity": "sha512-5U4+tksrzVODZaLTtivzS9be6u7rX5ZSWFKDIYWsy8HCwt9FH1ANrrGpY1wDHydpOeaySbxMjMaqEM9cGWxOuQ==",
       "requires": {
         "@babel/runtime-corejs3": "^7.20.13",
-        "@swagger-api/apidom-core": ">=0.69.2 <1.0.0",
-        "@swagger-api/apidom-json-pointer": ">=0.69.2 <1.0.0",
-        "@swagger-api/apidom-ns-openapi-3-1": ">=0.69.2 <1.0.0",
-        "@swagger-api/apidom-reference": ">=0.69.2 <1.0.0",
+        "@swagger-api/apidom-core": ">=0.69.3 <1.0.0",
+        "@swagger-api/apidom-json-pointer": ">=0.69.3 <1.0.0",
+        "@swagger-api/apidom-ns-openapi-3-1": ">=0.69.3 <1.0.0",
+        "@swagger-api/apidom-reference": ">=0.69.3 <1.0.0",
         "cookie": "~0.5.0",
         "cross-fetch": "^3.1.5",
         "deepmerge": "~4.3.0",
@@ -49720,9 +48932,9 @@
       }
     },
     "ts-toolbelt": {
-      "version": "6.15.5",
-      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz",
-      "integrity": "sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A=="
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
+      "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w=="
     },
     "tsconfig-paths": {
       "version": "3.14.1",
@@ -49851,6 +49063,14 @@
       "dev": true,
       "requires": {
         "is-typedarray": "^1.0.0"
+      }
+    },
+    "types-ramda": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/types-ramda/-/types-ramda-0.29.2.tgz",
+      "integrity": "sha512-HpLcR0ly2EfXQwG8VSI5ov6ml7PvtT+u+cp+7lZLu7q4nhnPDVW+rUTC1uy/SNs4aAyTUXri5M/LyhgvjEXJDg==",
+      "requires": {
+        "ts-toolbelt": "^9.6.0"
       }
     },
     "typescript": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "reselect": "^4.1.7",
     "serialize-error": "^8.1.0",
     "sha.js": "^2.4.11",
-    "swagger-client": "^3.19.6",
+    "swagger-client": "^3.19.7",
     "url-parse": "^1.5.10",
     "xml": "=1.0.1",
     "xml-but-prettier": "^1.0.1",

--- a/webpack/_config-builder.js
+++ b/webpack/_config-builder.js
@@ -115,16 +115,6 @@ export default function buildConfig(
             "..",
             "node_modules/safe-buffer"
           ),
-          ramda: path.resolve(
-            __dirname,
-            "..",
-            "node_modules/@swagger-api/apidom-core/node_modules/ramda"
-          ),
-          "ramda-adjunct": path.resolve(
-            __dirname,
-            "..",
-            "node_modules/@swagger-api/apidom-core/node_modules/ramda-adjunct"
-          ),
         },
         fallback: {
           fs: false,


### PR DESCRIPTION
Webpack config need to be change to compensage. `ramda` and `ramda-adjunct` have beeen removed from webpack `resolve.alias` as they are now installed in the root of `node_modules` tree.