### PR TITLE
fix(json-schema-2020-12): fix rendering of items keywords

### DIFF
--- a/src/core/plugins/json-schema-2020-12/components/keywords/Items.jsx
+++ b/src/core/plugins/json-schema-2020-12/components/keywords/Items.jsx
@@ -4,15 +4,16 @@
 import React from "react"
 
 import { schema } from "../../prop-types"
-import { useComponent } from "../../hooks"
+import { useFn, useComponent } from "../../hooks"
 
 const Items = ({ schema }) => {
+  const fn = useFn()
   const JSONSchema = useComponent("JSONSchema")
 
   /**
    * Rendering.
    */
-  if (!schema?.items) return null
+  if (!fn.hasKeyword(schema, "items")) return null
 
   const name = (
     <span className="json-schema-2020-12-keyword__name json-schema-2020-12-keyword__name--primary">

--- a/src/core/plugins/json-schema-2020-12/fn.js
+++ b/src/core/plugins/json-schema-2020-12/fn.js
@@ -151,7 +151,7 @@ export const isExpandable = (schema) => {
     fn.hasKeyword(schema, "else") ||
     schema?.dependentSchemas ||
     schema?.prefixItems ||
-    schema?.items ||
+    fn.hasKeyword(schema, "items") ||
     fn.hasKeyword(schema, "contains") ||
     schema?.properties ||
     schema?.patternProperties ||


### PR DESCRIPTION
As JSON Schema 2020-12 can be represented as
a Boolean Schema, different keyword detection
needs to be used.

Refs #8513
