### PR TITLE
Update nginx base image to fix CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # We don't declare them here — take a look at our docs.
 # https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md
 
-FROM nginx:1.23.4-alpine
+FROM nginx:1.24.0-alpine
 
 RUN apk update && apk add --no-cache "nodejs>=18.14.1-r0 "
 


### PR DESCRIPTION
### Description
Update nginx to fix CVEs

- CVE-2023-29469
- CVE-2023-28484⁠

### Motivation and Context
There are 2 open CVEs for the `nginx:1.23.4-alpine` base Docker image. They are both fixed in v1.24.0

### How Has This Been Tested?
1. Opened a PR in my forked repo and observed that the Github Actions checks passed
2. Built the container locally and confirmed it started successfully

### My PR contains... 
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
