### PR TITLE
feat(samples): add support for const keyword

### DIFF
--- a/src/core/plugins/json-schema-2020-12/samples-extensions/fn.js
+++ b/src/core/plugins/json-schema-2020-12/samples-extensions/fn.js
@@ -101,6 +101,7 @@ const liftSampleHelper = (oldSchema, target, config = {}) => {
     "enum",
     "xml",
     "type",
+    "const",
     ...objectContracts,
     ...arrayContracts,
     ...numberContracts,
@@ -683,7 +684,10 @@ export const sampleFromSchemaGeneric = (
   }
 
   let value
-  if (schema && Array.isArray(schema.enum)) {
+  if (typeof schema?.const !== "undefined") {
+    // display const value
+    value = schema.const
+  } else if (schema && Array.isArray(schema.enum)) {
     //display enum first value
     value = normalizeArray(schema.enum)[0]
   } else if (schema) {

--- a/test/unit/core/plugins/json-schema-2020-12/samples-extensions/fn.js
+++ b/test/unit/core/plugins/json-schema-2020-12/samples-extensions/fn.js
@@ -86,30 +86,31 @@ describe("sampleFromSchema", () => {
   })
 
   it("should handle type keyword defined as list of types", function () {
-    const definition = fromJS({
-      type: ["object", "string"],
-    })
+    const definition = fromJS({ type: ["object", "string"] })
     const expected = {}
 
     expect(sampleFromSchema(definition)).toEqual(expected)
   })
 
   it("should prioritize array when array and object defined as list of types", function () {
-    const definition = fromJS({
-      type: ["object", "array"],
-    })
+    const definition = fromJS({ type: ["object", "array"] })
     const expected = []
 
     expect(sampleFromSchema(definition)).toEqual(expected)
   })
 
   it("should handle primitive types defined as list of types", function () {
-    const definition = fromJS({
-      type: ["string", "number"],
-    })
+    const definition = fromJS({ type: ["string", "number"] })
     const expected = "string"
 
     expect(sampleFromSchema(definition)).toEqual(expected)
+  })
+
+  it("should return const value", function () {
+    const definition = fromJS({ const: 3 })
+    const expected = 3
+
+    expect(sampleFromSchema(definition)).toStrictEqual(expected)
   })
 
   it("handles Immutable.js objects for nested schemas", function () {


### PR DESCRIPTION
This change is specific to JSON Schema 2020-12
and OpenAPI 3.1.0.

Refs #8577
