### PR TITLE
feat(samples): support new semantics of exclusive number ranges

### DIFF
--- a/src/core/plugins/json-schema-2020-12/samples-extensions/fn.js
+++ b/src/core/plugins/json-schema-2020-12/samples-extensions/fn.js
@@ -694,20 +694,22 @@ export const sampleFromSchemaGeneric = (
     // display schema default
     value = primitive(schema)
     if (typeof value === "number") {
-      let min = schema.minimum
-      if (min !== undefined && min !== null) {
-        if (schema.exclusiveMinimum) {
-          min++
-        }
-        value = min
+      let minValue = null
+      let maxValue = null
+      const { minimum, maximum, exclusiveMinimum, exclusiveMaximum } = schema
+      if (typeof minimum === "number") {
+        minValue = minimum
       }
-      let max = schema.maximum
-      if (max !== undefined && max !== null) {
-        if (schema.exclusiveMaximum) {
-          max--
-        }
-        value = max
+      if (typeof exclusiveMinimum === "number" && exclusiveMinimum > minValue) {
+        minValue = exclusiveMinimum + 1
       }
+      if (typeof maximum === "number") {
+        maxValue = maximum
+      }
+      if (typeof exclusiveMaximum === "number" && exclusiveMaximum < maxValue) {
+        maxValue = exclusiveMaximum - 1
+      }
+      value = minValue || maxValue || value
     }
     if (typeof value === "string") {
       if (schema.maxLength !== null && schema.maxLength !== undefined) {

--- a/test/unit/core/plugins/json-schema-2020-12/samples-extensions/fn.js
+++ b/test/unit/core/plugins/json-schema-2020-12/samples-extensions/fn.js
@@ -1298,13 +1298,11 @@ describe("sampleFromSchema", () => {
     expect(sampleFromSchema(definition)).toEqual(expected)
   })
 
-  it("should handle minimum with exclusive", () => {
+  it("should handle exclusiveMinimum", () => {
     const definition = {
       type: "number",
-      minimum: 5,
-      exclusiveMinimum: true,
+      exclusiveMinimum: 5,
     }
-
     const expected = 6
 
     expect(sampleFromSchema(definition)).toEqual(expected)
@@ -1321,11 +1319,10 @@ describe("sampleFromSchema", () => {
     expect(sampleFromSchema(definition)).toEqual(expected)
   })
 
-  it("should handle maximum with exclusive", () => {
+  it("should handle exclusiveMaximum", () => {
     const definition = {
       type: "number",
-      maximum: -1,
-      exclusiveMaximum: true,
+      exclusiveMaximum: -1,
     }
 
     const expected = -2


### PR DESCRIPTION
This change is specific to JSON Schema 2020-12
and OpenAPI 3.1.0.

Refs #8577