### PR TITLE
feat(samples): add support for regex string format

### DIFF
--- a/src/core/plugins/json-schema-2020-12/samples-extensions/fn.js
+++ b/src/core/plugins/json-schema-2020-12/samples-extensions/fn.js
@@ -41,6 +41,7 @@ const primitives = {
   string_time: () => new Date().toISOString().substring(11),
   string_duration: () => "P3D", // expresses a duration of 3 days
   string_password: () => "********",
+  string_regex: () => "^[a-z]+$",
   number: () => 0,
   number_float: () => 0.1,
   number_double: () => 0.1,

--- a/test/unit/core/plugins/json-schema-2020-12/samples-extensions/fn.js
+++ b/test/unit/core/plugins/json-schema-2020-12/samples-extensions/fn.js
@@ -71,6 +71,9 @@ describe("sampleFromSchema", () => {
     expect(sample({ type: "string", format: "password" })).toStrictEqual(
       "********"
     )
+    expect(sample({ type: "string", format: "regex" })).toStrictEqual(
+      "^[a-z]+$"
+    )
     expect(sample({ type: "number" })).toStrictEqual(0)
     expect(sample({ type: "number", format: "float" })).toStrictEqual(0.1)
     expect(sample({ type: "number", format: "double" })).toStrictEqual(0.1)


### PR DESCRIPTION
This change is specific to JSON Schema 2020-12
and OpenAPI 3.1.0.

Refs #8577