### PR TITLE
feat(samples): add support for uniqueItems keyword

### DIFF
--- a/test/unit/core/plugins/json-schema-2020-12/samples-extensions/fn.js
+++ b/test/unit/core/plugins/json-schema-2020-12/samples-extensions/fn.js
@@ -1233,6 +1233,37 @@ describe("sampleFromSchema", () => {
     expect(sampleFromSchema(definition)).toEqual(expected)
   })
 
+  it("should handle maxItems", () => {
+    const definition = {
+      type: "array",
+      minItems: 4,
+      maxItems: 7,
+      items: {
+        type: "string",
+      },
+    }
+
+    const expected = sampleFromSchema(definition).length
+
+    expect(expected).toBeGreaterThanOrEqual(4)
+    expect(expected).toBeLessThanOrEqual(7)
+  })
+
+  it("should handle uniqueItems", () => {
+    const definition = {
+      type: "array",
+      minItems: 2,
+      uniqueItems: true,
+      items: {
+        type: "string",
+      },
+    }
+
+    const expected = ["string"]
+
+    expect(sampleFromSchema(definition)).toEqual(expected)
+  })
+
   it("should handle minItems with example", () => {
     const definition = {
       type: "array",


### PR DESCRIPTION
This change is specific to JSON Schema 2020-12
and OpenAPI 3.1.0.

Refs #8577
