### PR TITLE
Feature: add a button to expand/collapse all operations

### DIFF
--- a/src/core/components/layouts/base.jsx
+++ b/src/core/components/layouts/base.jsx
@@ -5,6 +5,14 @@ import React from "react"
 import PropTypes from "prop-types"
 
 export default class BaseLayout extends React.Component {
+  constructor(props, context) {
+    super(props, context)
+
+    this.state = {
+      operationsCollapsed: false,
+    }
+  }
+
   static propTypes = {
     errSelectors: PropTypes.object.isRequired,
     errActions: PropTypes.object.isRequired,
@@ -12,6 +20,11 @@ export default class BaseLayout extends React.Component {
     oas3Selectors: PropTypes.object.isRequired,
     oas3Actions: PropTypes.object.isRequired,
     getComponent: PropTypes.func.isRequired,
+  }
+
+  toggleCollapse = () => {
+    const oldValue = this.state.operationsCollapsed
+    this.setState({ operationsCollapsed: !oldValue })
   }
 
   render() {
@@ -122,8 +135,15 @@ export default class BaseLayout extends React.Component {
           <FilterContainer />
 
           <Row>
+            <div className="text-right">
+              <button className="btn " onClick={ this.toggleCollapse }>
+                { this.state.operationsCollapsed ? "Expand All" : "Collapse All"}
+              </button>
+            </div>
+          </Row>
+          <Row>
             <Col mobile={12} desktop={12}>
-              <Operations />
+              <Operations collapseAll={this.state.operationsCollapsed} />
             </Col>
           </Row>
 

--- a/src/core/components/operations.jsx
+++ b/src/core/components/operations.jsx
@@ -3,6 +3,13 @@ import PropTypes from "prop-types"
 import Im from "immutable"
 
 export default class Operations extends React.Component {
+  constructor(props, context) {
+    super(props, context)
+
+    this.state = {
+      collapseAll: props.collapseAll,
+    }
+  }
 
   static propTypes = {
     specSelectors: PropTypes.object.isRequired,
@@ -15,7 +22,18 @@ export default class Operations extends React.Component {
     authActions: PropTypes.object.isRequired,
     authSelectors: PropTypes.object.isRequired,
     getConfigs: PropTypes.func.isRequired,
-    fn: PropTypes.func.isRequired
+    fn: PropTypes.func.isRequired,
+    collapseAll: PropTypes.bool.isRequired
+  }
+
+  static getDerivedStateFromProps(nextProps, prevState) {
+    if (nextProps.collapseAll !== prevState.collapseAll) {
+      nextProps.specSelectors.taggedOperations().map((tagObj, tag) =>
+        nextProps.layoutActions.show(["operations-tag", tag], !nextProps.collapseAll)
+      )
+      return ({ collapseAll: nextProps.collapseAll })
+    }
+    return null
   }
 
   render() {
@@ -96,5 +114,6 @@ Operations.propTypes = {
   specActions: PropTypes.object.isRequired,
   layoutSelectors: PropTypes.object.isRequired,
   getComponent: PropTypes.func.isRequired,
-  fn: PropTypes.object.isRequired
+  fn: PropTypes.object.isRequired,
+  collapseAll: PropTypes.bool.isRequired
 }

--- a/src/style/_layout.scss
+++ b/src/style/_layout.scss
@@ -41,6 +41,10 @@
     }
 }
 
+.text-right {
+    text-align: right;
+}
+
 @mixin method($color)
 {
     border-color: $color;


### PR DESCRIPTION
This PR addresses https://github.com/swagger-api/swagger-ui/issues/7964 : the list of entries is usually long and a handy button to collapse them all can be useful, at the same time a button to expand them all (to use a browser search functionality for instance) can be useful as well.

### Description
This PR adds a button to the main page. This button lives with its own state that represents the value of its flag. Once the button gets hit, the flag is toggled and the value is passed as a prop to the `<Operations>` child. This one uses the flag to trigger the visibility of all the `<OperationTag>` accordingly. After that the components render lifecycle remains the same as before.


### Motivation and Context
Fixes #7964


### How Has This Been Tested?
Manual test:
- load the page with the `docExpansion` set to `list`
- click the expand/collapse button
- all the entries are now collapsed
- expand some entry by clicking on the tag name
- click the expand/collapse button again
- all the entries are now expanded
- collapse some entry by clicking on the tag name
- click the expand/collapse button again
- all the entries are now collapsed


### Screenshots (if appropriate):
![swagger-ui-expand-collapse-all](https://github.com/swagger-api/swagger-ui/assets/7080830/b232746c-0755-416c-b052-4fd3fc111965)



## Checklist

### My PR contains... 
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.


## Notes
- Tests are not yet implemented, but they'd rather be with no particular limitation. An initial feedback about the current implementation would be very nice before continuing down this path.
- The button should load considering the `docExpansion` config value: if the entries are expanded on loading because of the config parameter, the global button should start with `Collapse All`, and the other way around that in other cases.