### PR TITLE
feat(spec): add new specJS selector

### DIFF
--- a/src/core/plugins/err/error-transformers/hook.js
+++ b/src/core/plugins/err/error-transformers/hook.js
@@ -9,7 +9,7 @@ const errorTransformers = [
 
 export default function transformErrors (errors) {
   // Dev note: unimplemented artifact where
-  // jsSpec: system.specSelectors.specJson().toJS()
+  // jsSpec: system.specSelectors.specJS()
   // regardless, to be compliant with redux@4, instead of calling the store method here,
   // jsSpec should be pass down as an argument,
   let inputs = {

--- a/src/core/plugins/spec/actions.js
+++ b/src/core/plugins/spec/actions.js
@@ -238,7 +238,7 @@ const debResolveSubtrees = debounce(async () => {
       }
     }, Promise.resolve({
       resultMap: (specSelectors.specResolvedSubtree([]) || Map()).toJS(),
-      specWithCurrentSubtrees: specSelectors.specJson().toJS()
+      specWithCurrentSubtrees: specSelectors.specJS()
     }))
 
     delete requestBatch.system

--- a/src/core/plugins/spec/selectors.js
+++ b/src/core/plugins/spec/selectors.js
@@ -38,6 +38,11 @@ export const specJson = createSelector(
   spec => spec.get("json", Map())
 )
 
+export const specJS = createSelector(
+  specJson,
+  (spec) => spec.toJS()
+)
+
 export const specResolved = createSelector(
   state,
   spec => spec.get("resolved", Map())


### PR DESCRIPTION
This selector always returns the same JavaScript
object unless it really changes.

Before this change it customary to call
specJson().toJS() which always resulted
in transformation operation and new JavaScript
object.

Refs #8606