### PR TITLE
fix(swagger-ui-react): fix default value for spec prop

### DIFF
--- a/flavors/swagger-ui-react/index.jsx
+++ b/flavors/swagger-ui-react/index.jsx
@@ -124,7 +124,7 @@ SwaggerUI.propTypes = {
 }
 
 SwaggerUI.defaultProps = {
-  spec: {},
+  spec: "",
   url: "",
   layout: "BaseLayout",
   requestInterceptor: req => req,


### PR DESCRIPTION
Default value must be set to  (empty string) and
not to {} (empty object).

Refs #8976

