### PR TITLE
fix(json-schema-2020-12): add rendering support for type='integer'

### DIFF
--- a/src/core/plugins/json-schema-2020-12/fn.js
+++ b/src/core/plugins/json-schema-2020-12/fn.js
@@ -117,7 +117,15 @@ export const getType = (schema, processedSchemas = new WeakSet()) => {
     ? type.map((t) => (t === "array" ? getArrayType() : t)).join(" | ")
     : type === "array"
     ? getArrayType()
-    : ["null", "boolean", "object", "array", "number", "string"].includes(type)
+    : [
+        "null",
+        "boolean",
+        "object",
+        "array",
+        "number",
+        "integer",
+        "string",
+      ].includes(type)
     ? type
     : inferType()
 


### PR DESCRIPTION
Refs #9013


Renders now as 
![image](https://github.com/swagger-api/swagger-ui/assets/193286/7a2871d7-5a08-43f0-ba2c-6e9207cafa25)

for following fixture:

```yaml
openapi: 3.1.0
info:
  version: 1.2.3
  title: title
components: 
  schemas:
    Location:
      properties:
        lat:
          type: integer
```

