### PR TITLE
fix(docker): update libtiff to non-vulnerable version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM nginx:1.25.1-alpine
 
-RUN apk update && apk add --no-cache "nodejs>=18.14.1-r0 " && apk del tiff nginx-module-image-filter
+RUN apk update && apk add --no-cache "nodejs>=18.14.1-r0" && apk add --no-cache "tiff>=4.4.0-r3"
 
 LABEL maintainer="fehguy"
 


### PR DESCRIPTION
Refs CVE-2023-0801
Refs 2ff8986dbc5020883974d6ed80e13070705d7e50
