### PR TITLE
fix(swagger-ui-react): re-enable SSR support

### DIFF
--- a/flavors/swagger-ui-react/index.jsx
+++ b/flavors/swagger-ui-react/index.jsx
@@ -37,7 +37,7 @@ export default class SwaggerUI extends React.Component {
       filter: this.props.filter,
       persistAuthorization: this.props.persistAuthorization,
       withCredentials: this.props.withCredentials,
-      oauth2RedirectUrl: this.props.oauth2RedirectUrl
+      ...(typeof this.props.oauth2RedirectUrl === 'string' ? { oauth2RedirectUrl: this.props.oauth2RedirectUrl} : {})
     })
 
     this.system = ui
@@ -166,7 +166,7 @@ SwaggerUI.defaultProps = {
   displayRequestDuration: false,
   withCredentials: undefined,
   persistAuthorization: false,
-  oauth2RedirectUrl: `${window.location.protocol}//${window.location.host}${window.location.pathname.substring(0, window.location.pathname.lastIndexOf("/"))}/oauth2-redirect.html`,
+  oauth2RedirectUrl: undefined,
 }
 
 SwaggerUI.presets = swaggerUIConstructor.presets


### PR DESCRIPTION
SSR support was re-enabled by passing the oauth2RedirectUrl only when defined.

Refs #8976
