### PR TITLE
feat: respect Encoding Object while building requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "reselect": "^4.1.8",
         "serialize-error": "^8.1.0",
         "sha.js": "^2.4.11",
-        "swagger-client": "^3.19.11",
+        "swagger-client": "^3.20.0",
         "url-parse": "^1.5.10",
         "xml": "=1.0.1",
         "xml-but-prettier": "^1.0.1",
@@ -5210,25 +5210,25 @@
       "dev": true
     },
     "node_modules/@swagger-api/apidom-ast": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-0.74.0.tgz",
-      "integrity": "sha512-GViXTzRAI4U/3Y57HY8Rvf7lFQQjrqXtofR6+bTced3YwxnaaL9dSIPbPrmDKtgmx4hPcMZoKV4zoc6JasLx7g==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-0.74.1.tgz",
+      "integrity": "sha512-EoHyaRBeZmNYFNlDNZGeI45zRLfcVW0o4uZ8Fs/+HN1UIyDoZdr+ObElj5PEkCmdDx7ADlNmoGK4B+4AQA2LeA==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
         "@types/ramda": "~0.29.3",
         "ramda": "~0.29.0",
         "ramda-adjunct": "^4.0.0",
         "stampit": "^4.3.2",
-        "unraw": "^2.0.1"
+        "unraw": "^3.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-core": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-0.74.0.tgz",
-      "integrity": "sha512-6U8MLy1SKpWgM0D5CIpAkYW5NGGd9yPDGow0J/sqAwqgTipIkoUqa0DTErXjd0z0m2a+e8UsVXhTZmj0lF7EoQ==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-0.74.1.tgz",
+      "integrity": "sha512-y70oo/CrNMSi7TtUkATXkSWd+Q/4BjchwCuLpWbhSJuIpJM+W9yGyzWOFTFLZQpDbwK0yzocMk8iPClq/rWNPw==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-ast": "^0.74.0",
+        "@swagger-api/apidom-ast": "^0.74.1",
         "@types/ramda": "~0.29.3",
         "minim": "~0.23.8",
         "ramda": "~0.29.0",
@@ -5238,26 +5238,26 @@
       }
     },
     "node_modules/@swagger-api/apidom-json-pointer": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-0.74.0.tgz",
-      "integrity": "sha512-vhvxpyewfxnJ+k+Uxr9O4wd0Ult+yD0+n0SIawk8dbeIMAkcVDBjo17xCoeAF+1iOeht276flHIgXTRCwg9U/w==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-0.74.1.tgz",
+      "integrity": "sha512-UusZdVY2AbYSyMK0aPSNvCiCtgn6NcGnS9fbAPVFsV+ALEtWYdMs/ZjfqYhbuzd+nRY34J9GCF7m+kVysZ9EWw==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.74.0",
+        "@swagger-api/apidom-core": "^0.74.1",
         "@types/ramda": "~0.29.3",
         "ramda": "~0.29.0",
         "ramda-adjunct": "^4.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-ns-api-design-systems": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-0.74.0.tgz",
-      "integrity": "sha512-xSXdxmWDK5/CTaoG0upVxbGUsh4LqkSycM5Jki+scwMs7K4j/RxgeTb6YUIifDJzeOaFyX2A/1y5gcZV0cinsQ==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-0.74.1.tgz",
+      "integrity": "sha512-eJxd3B4lQbVCi+g9ZXSM0IeCbqPEH5o7WdLdfrSowFLQqc7jQur/29UhbAh2PDvPSI/l7oaNzwgPTp4Zm8SaTw==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.74.0",
-        "@swagger-api/apidom-ns-openapi-3-1": "^0.74.0",
+        "@swagger-api/apidom-core": "^0.74.1",
+        "@swagger-api/apidom-ns-openapi-3-1": "^0.74.1",
         "@types/ramda": "~0.29.3",
         "ramda": "~0.29.0",
         "ramda-adjunct": "^4.0.0",
@@ -5265,14 +5265,14 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-asyncapi-2": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-0.74.0.tgz",
-      "integrity": "sha512-iCVcL7x4gJ+RbGSj6h8DxXZYNUlkrfQAfakz4x0q67x4NltW7Zrcs/WAqNTbZxtPxiVOXpW72kk5bFvQd3hgxw==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-0.74.1.tgz",
+      "integrity": "sha512-xH6ilO8jJpZOWzWwbse3xi8zIbe3Iho+AMwwMFtkCnjUqmv81TGhlA6VPXpLCKgFsnZqJVyCKn/VaTW8N6379w==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.74.0",
-        "@swagger-api/apidom-ns-json-schema-draft-7": "^0.74.0",
+        "@swagger-api/apidom-core": "^0.74.1",
+        "@swagger-api/apidom-ns-json-schema-draft-7": "^0.74.1",
         "@types/ramda": "~0.29.3",
         "ramda": "~0.29.0",
         "ramda-adjunct": "^4.0.0",
@@ -5280,13 +5280,13 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-draft-4": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-0.74.0.tgz",
-      "integrity": "sha512-BNn3l/i7Hzj6qzJfiDsA/29XmUka8I/UsmnQa+4sIpu3DScM8L0m1SzZ+B+5jqVsLnx732dqEuulFClV+f0rQg==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-0.74.1.tgz",
+      "integrity": "sha512-zUQvrxoRQpvdYymHko1nxNeVWwqdGDYNYWUFW/EGZbP0sigKmuSZkh6LdseB9Pxt1WQD/6MkW3zN4JMXt/qFUA==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-ast": "^0.74.0",
-        "@swagger-api/apidom-core": "^0.74.0",
+        "@swagger-api/apidom-ast": "^0.74.1",
+        "@swagger-api/apidom-core": "^0.74.1",
         "@types/ramda": "~0.29.3",
         "ramda": "~0.29.0",
         "ramda-adjunct": "^4.0.0",
@@ -5294,14 +5294,14 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-draft-6": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-0.74.0.tgz",
-      "integrity": "sha512-L6ktmlZvoZMiojmFTIgTWGIzed3paqvJCYqVtLjDAhGBNC7bQK8hd0piskg6V/FjG3c4/tY778yV8E9MMLqrTA==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-0.74.1.tgz",
+      "integrity": "sha512-8GFH6bR5ERyuS+4u7CnLirBPYkYWostk31WDj7YeY5b0BRNtI3omH4rV24KECu99ZAg/unZY688VwmN25Dut/A==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.74.0",
-        "@swagger-api/apidom-ns-json-schema-draft-4": "^0.74.0",
+        "@swagger-api/apidom-core": "^0.74.1",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^0.74.1",
         "@types/ramda": "~0.29.3",
         "ramda": "~0.29.0",
         "ramda-adjunct": "^4.0.0",
@@ -5309,14 +5309,14 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-json-schema-draft-7": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-0.74.0.tgz",
-      "integrity": "sha512-8YgAmMQFK849yrrppKYwmGUHyxeh3RKWaHrOUjNJyX2kAWLZzKMxVDRIVDs3OmoHsPleoM1P0yZxhqna9QME2w==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-0.74.1.tgz",
+      "integrity": "sha512-4ttxnBuRcegp1ooKtwoOqXDUNCWH4GuQlMBOUlHfKPR35qbMf0LCYU+ROvTk05ycoVkc2x6+AJQ4He684EXwfw==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.74.0",
-        "@swagger-api/apidom-ns-json-schema-draft-6": "^0.74.0",
+        "@swagger-api/apidom-core": "^0.74.1",
+        "@swagger-api/apidom-ns-json-schema-draft-6": "^0.74.1",
         "@types/ramda": "~0.29.3",
         "ramda": "~0.29.0",
         "ramda-adjunct": "^4.0.0",
@@ -5324,13 +5324,13 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-openapi-3-0": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-0.74.0.tgz",
-      "integrity": "sha512-tOjSoAJAiAGZRWGqCeHEqbAVbaXA/dF5tAiptX+tQV7AnbwhVtIYW2UUOQFl4AnBPug+1WV2y//Q8e582zUHmg==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-0.74.1.tgz",
+      "integrity": "sha512-n5jccxnbiNjHiID0uTV1UXdt47WxyduQRKK9ILo7N2yXqkwI1ygqQNBVEUC/YZnHT4ZvFsifYAqbT0hO1h54ig==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.74.0",
-        "@swagger-api/apidom-ns-json-schema-draft-4": "^0.74.0",
+        "@swagger-api/apidom-core": "^0.74.1",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^0.74.1",
         "@types/ramda": "~0.29.3",
         "ramda": "~0.29.0",
         "ramda-adjunct": "^4.0.0",
@@ -5338,14 +5338,14 @@
       }
     },
     "node_modules/@swagger-api/apidom-ns-openapi-3-1": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-0.74.0.tgz",
-      "integrity": "sha512-VUAdfPqC7XycKzxNH4xUPfHs4/6y/15tOLFoM6dzHgaq9PAoiSqp4fuVFeFpQC6IYQ/8qjrN3l+IOMeNj0BEjQ==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-0.74.1.tgz",
+      "integrity": "sha512-8ZqQBjMfiCEwePUbwdKIAStl7nIPIiyKGrON4Sy+PWTwvCQiam3haKeT5r6TDiTFyrS3idSplfXijuWfZF//Ag==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-ast": "^0.74.0",
-        "@swagger-api/apidom-core": "^0.74.0",
-        "@swagger-api/apidom-ns-openapi-3-0": "^0.74.0",
+        "@swagger-api/apidom-ast": "^0.74.1",
+        "@swagger-api/apidom-core": "^0.74.1",
+        "@swagger-api/apidom-ns-openapi-3-0": "^0.74.1",
         "@types/ramda": "~0.29.3",
         "ramda": "~0.29.0",
         "ramda-adjunct": "^4.0.0",
@@ -5353,74 +5353,74 @@
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-json": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-0.74.0.tgz",
-      "integrity": "sha512-ppNkc34jzkplAje9WCq226szpy8Ekbyy7ebRO1UFCPfualacl4gVPjUEfVqrki1+vg6VxPyuBTMfHi5G8c0gFQ==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-0.74.1.tgz",
+      "integrity": "sha512-RFwnL2u3OzKVkE4jQ4zGNHA83BnXM3EjpTNRbCzcmsP78RGr7H9HebPaiRPpLMyC3GuzBwPXe8WbOdYsReuFww==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.74.0",
-        "@swagger-api/apidom-ns-api-design-systems": "^0.74.0",
-        "@swagger-api/apidom-parser-adapter-json": "^0.74.0",
+        "@swagger-api/apidom-core": "^0.74.1",
+        "@swagger-api/apidom-ns-api-design-systems": "^0.74.1",
+        "@swagger-api/apidom-parser-adapter-json": "^0.74.1",
         "@types/ramda": "~0.29.3",
         "ramda": "~0.29.0",
         "ramda-adjunct": "^4.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-yaml": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-0.74.0.tgz",
-      "integrity": "sha512-tjg4j2vh/3I6S/rvoH16iNxfKw9ctYZ3Xn9MpI7FtcxRdGNuH2FfPqDl4Zt9Xos1P5K/yrHIpoR+RI17BX8Nig==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-0.74.1.tgz",
+      "integrity": "sha512-3r5lxhP/glOhQVFRVRf/Ps2F5V2oMowG6+YBkajV2jCW9XPIrIuVef+KcjbQQlm06J3QnD+Tg/ZiLXcxziAvoQ==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.74.0",
-        "@swagger-api/apidom-ns-api-design-systems": "^0.74.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.74.0",
+        "@swagger-api/apidom-core": "^0.74.1",
+        "@swagger-api/apidom-ns-api-design-systems": "^0.74.1",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.74.1",
         "@types/ramda": "~0.29.3",
         "ramda": "~0.29.0",
         "ramda-adjunct": "^4.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-2": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-0.74.0.tgz",
-      "integrity": "sha512-a5twJ9Njmi3uIoVQtUh53Kpszz5Q3wpPcHFEmIQCuoiD+5ZBgBeWT1p7iwdi8M+kkKh/k71dh61mVbWGpRO2Gg==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-0.74.1.tgz",
+      "integrity": "sha512-jPp5n0aKtqZrQrz+Lh1B5LNocuMliA3OvNWGGTD14T54qNDJ+a2B6a31SXZqzjqfseWr7SeE2Z/RM5ljqviLWA==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.74.0",
-        "@swagger-api/apidom-ns-asyncapi-2": "^0.74.0",
-        "@swagger-api/apidom-parser-adapter-json": "^0.74.0",
+        "@swagger-api/apidom-core": "^0.74.1",
+        "@swagger-api/apidom-ns-asyncapi-2": "^0.74.1",
+        "@swagger-api/apidom-parser-adapter-json": "^0.74.1",
         "@types/ramda": "~0.29.3",
         "ramda": "~0.29.0",
         "ramda-adjunct": "^4.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-0.74.0.tgz",
-      "integrity": "sha512-+VVR4maTlLXqlkBkBOeT85WY28hVh+yWMow/b+XdOVxoGf1mki6nI45uyq7XJU8A688us5YX4/9yzTDSd3tjRw==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-0.74.1.tgz",
+      "integrity": "sha512-em8o7bu0XEMac6cJvSi9WjMpTEny39gn+1UrANnICpvsMoiRjlfE5yEG4eueewV1nsukO4qTiUjTf32BGNgHYg==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.74.0",
-        "@swagger-api/apidom-ns-asyncapi-2": "^0.74.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.74.0",
+        "@swagger-api/apidom-core": "^0.74.1",
+        "@swagger-api/apidom-ns-asyncapi-2": "^0.74.1",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.74.1",
         "@types/ramda": "~0.29.3",
         "ramda": "~0.29.0",
         "ramda-adjunct": "^4.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-json": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-0.74.0.tgz",
-      "integrity": "sha512-c1DUoNa1IJhEck+CW98cy5PRMby/ngKU+/nCtQf78XGwW8ujX+o5VFqFHZ7CUetLO/FxA7DS1JhPvuwlltsNeA==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-0.74.1.tgz",
+      "integrity": "sha512-CtJxt/o0ZyW/GkvETuTUUlCjTJ/wH0S7jr3CBnZR/vVVVlVfIYkGw2fEo8HUBAr+EnJNFfWOzOAjXQHul71wUw==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-ast": "^0.74.0",
-        "@swagger-api/apidom-core": "^0.74.0",
+        "@swagger-api/apidom-ast": "^0.74.1",
+        "@swagger-api/apidom-core": "^0.74.1",
         "@types/ramda": "~0.29.3",
         "ramda": "~0.29.0",
         "ramda-adjunct": "^4.0.0",
@@ -5431,74 +5431,74 @@
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-0": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-0.74.0.tgz",
-      "integrity": "sha512-aOP1ZC4N0rZJXxfGs1lIp+nQ16ZGrXK2AmhejX5YpXLLxUpwNjH8SIZLbBhsOJAuSlRp7HWCqSenq8LtKlie7w==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-0.74.1.tgz",
+      "integrity": "sha512-k8zOeb2aCyEVUdW1sUUBmawyqHmx7C7WB9eXFM1yEzwy3Y589cVygiy6AG1yOaPU8WWzR80+xPEqHw0VmqkBRg==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.74.0",
-        "@swagger-api/apidom-ns-openapi-3-0": "^0.74.0",
-        "@swagger-api/apidom-parser-adapter-json": "^0.74.0",
+        "@swagger-api/apidom-core": "^0.74.1",
+        "@swagger-api/apidom-ns-openapi-3-0": "^0.74.1",
+        "@swagger-api/apidom-parser-adapter-json": "^0.74.1",
         "@types/ramda": "~0.29.3",
         "ramda": "~0.29.0",
         "ramda-adjunct": "^4.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-1": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-0.74.0.tgz",
-      "integrity": "sha512-KCMoWQBTYrh8i0pjMh6Hh8ZM4JVxMWAhJaGwoA6jDChSYP7yxlIO44bHjvX/f88UAW0U5y8ViwDdmy5wak22mw==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-0.74.1.tgz",
+      "integrity": "sha512-x70fOeBiavi9siSq2Hr07cBcIXdTEDpi87OpaQIGTk5tjN8wQfnQF1MWxdHpe4p/cJN7LiYw5Dx6uIAhp/RuGg==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.74.0",
-        "@swagger-api/apidom-ns-openapi-3-1": "^0.74.0",
-        "@swagger-api/apidom-parser-adapter-json": "^0.74.0",
+        "@swagger-api/apidom-core": "^0.74.1",
+        "@swagger-api/apidom-ns-openapi-3-1": "^0.74.1",
+        "@swagger-api/apidom-parser-adapter-json": "^0.74.1",
         "@types/ramda": "~0.29.3",
         "ramda": "~0.29.0",
         "ramda-adjunct": "^4.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-0.74.0.tgz",
-      "integrity": "sha512-bjYYCX6bsRizHi8jUt1RZSRA40U2orutzx+KYrfeO6/BGOWBDHYdbvH+RTjlT7McK3dy3NOOtFzitoFdyJRqXQ==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-0.74.1.tgz",
+      "integrity": "sha512-MdZrzR+9AbunoP9OyETqZabhCllUiu5lu59uG7exo7jR1GfC28A4wVolNhi0C01wOcS+55t+1qvzi+i+9Kz3ew==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.74.0",
-        "@swagger-api/apidom-ns-openapi-3-0": "^0.74.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.74.0",
+        "@swagger-api/apidom-core": "^0.74.1",
+        "@swagger-api/apidom-ns-openapi-3-0": "^0.74.1",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.74.1",
         "@types/ramda": "~0.29.3",
         "ramda": "~0.29.0",
         "ramda-adjunct": "^4.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-0.74.0.tgz",
-      "integrity": "sha512-AqTqy2V1zKqjsD2Gd+ZA/qetfcHqub/C0rHVvoN4RkFNMJlt6M7Hiy3D9A7ulkm9AyCJ9U0YV0a7QxfqeAfG+w==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-0.74.1.tgz",
+      "integrity": "sha512-OaDAhZm38chXyc0P0yHQSD4fCmUmEUWTTLgHntJDmvAZ7nSkV4NddDP7cgZ07z8dLEwMokI//9u+I/s0G0BO0Q==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.74.0",
-        "@swagger-api/apidom-ns-openapi-3-1": "^0.74.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.74.0",
+        "@swagger-api/apidom-core": "^0.74.1",
+        "@swagger-api/apidom-ns-openapi-3-1": "^0.74.1",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.74.1",
         "@types/ramda": "~0.29.3",
         "ramda": "~0.29.0",
         "ramda-adjunct": "^4.0.0"
       }
     },
     "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-0.74.0.tgz",
-      "integrity": "sha512-2sWjrwD83CFNGQKpV6Ce7QsApAP1PouRuF+jUw35IrXWdfvxHL4h2IPXrOAtwLMDHmzkBE7DVz6tFcWVAz4RDA==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-0.74.1.tgz",
+      "integrity": "sha512-QHxx3ZJ12FAF8yserAR1qL863/eOdi78HgdDFqVeg5tOfUUDXLnvEYbtCWejIjudBFD6s88ctffzN7+DEDFOPg==",
       "optional": true,
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-ast": "^0.74.0",
-        "@swagger-api/apidom-core": "^0.74.0",
+        "@swagger-api/apidom-ast": "^0.74.1",
+        "@swagger-api/apidom-core": "^0.74.1",
         "@types/ramda": "~0.29.3",
         "ramda": "~0.29.0",
         "ramda-adjunct": "^4.0.0",
@@ -5509,12 +5509,12 @@
       }
     },
     "node_modules/@swagger-api/apidom-reference": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-0.74.0.tgz",
-      "integrity": "sha512-vUGpzM9UlZmvipkwXuBZqoYl431XiF8opHViq5/hgmA0+bVo1Ozvw/SZzyLgP8NLAsdR0Enui015qBY0T3/p9Q==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-0.74.1.tgz",
+      "integrity": "sha512-DwMGmTA2VkiPf8CLDnhhR4PObqzrGGOKydxd3uWWFFI0/itU8mZcBZssMHseW1dV2fC9hvkva672Gt2W/wSJng==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.74.0",
+        "@swagger-api/apidom-core": "^0.74.1",
         "@types/ramda": "~0.29.3",
         "axios": "^1.4.0",
         "minimatch": "^7.4.3",
@@ -5524,20 +5524,20 @@
         "stampit": "^4.3.2"
       },
       "optionalDependencies": {
-        "@swagger-api/apidom-json-pointer": "^0.74.0",
-        "@swagger-api/apidom-ns-asyncapi-2": "^0.74.0",
-        "@swagger-api/apidom-ns-openapi-3-0": "^0.74.0",
-        "@swagger-api/apidom-ns-openapi-3-1": "^0.74.0",
-        "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^0.74.0",
-        "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^0.74.0",
-        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^0.74.0",
-        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^0.74.0",
-        "@swagger-api/apidom-parser-adapter-json": "^0.74.0",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^0.74.0",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^0.74.0",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^0.74.0",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^0.74.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.74.0"
+        "@swagger-api/apidom-json-pointer": "^0.74.1",
+        "@swagger-api/apidom-ns-asyncapi-2": "^0.74.1",
+        "@swagger-api/apidom-ns-openapi-3-0": "^0.74.1",
+        "@swagger-api/apidom-ns-openapi-3-1": "^0.74.1",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^0.74.1",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^0.74.1",
+        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^0.74.1",
+        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^0.74.1",
+        "@swagger-api/apidom-parser-adapter-json": "^0.74.1",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^0.74.1",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^0.74.1",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^0.74.1",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^0.74.1",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.74.1"
       }
     },
     "node_modules/@swagger-api/apidom-reference/node_modules/brace-expansion": {
@@ -27331,15 +27331,15 @@
       }
     },
     "node_modules/swagger-client": {
-      "version": "3.19.11",
-      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.19.11.tgz",
-      "integrity": "sha512-ef4t4nRGC8NuC8rz6OazEGU/QgkrFVMUba1vDmCL1Zuov50rTix9f33COr6RSmzQEc9aqY/kd+6f43a/7TbHhQ==",
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.20.0.tgz",
+      "integrity": "sha512-5RLge2NIE1UppIT/AjUPEceT05hcBAzjiQkrXJYjpxsbFV/UDH3pp+fsrWbAeuZtgRdhNB9KDo+szLoUpzkydQ==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.20.13",
-        "@swagger-api/apidom-core": ">=0.71.0 <1.0.0",
-        "@swagger-api/apidom-json-pointer": ">=0.71.0 <1.0.0",
-        "@swagger-api/apidom-ns-openapi-3-1": ">=0.71.0 <1.0.0",
-        "@swagger-api/apidom-reference": ">=0.71.1 <1.0.0",
+        "@swagger-api/apidom-core": ">=0.74.1 <1.0.0",
+        "@swagger-api/apidom-json-pointer": ">=0.74.1 <1.0.0",
+        "@swagger-api/apidom-ns-openapi-3-1": ">=0.74.1 <1.0.0",
+        "@swagger-api/apidom-reference": ">=0.74.1 <1.0.0",
         "cookie": "~0.5.0",
         "cross-fetch": "^3.1.5",
         "deepmerge": "~4.3.0",
@@ -28254,9 +28254,9 @@
       }
     },
     "node_modules/unraw": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unraw/-/unraw-2.0.1.tgz",
-      "integrity": "sha512-tdOvLfRzHolwYcHS6HIX860MkK9LQ4+oLuNwFYL7bpgTEO64PZrcQxkisgwJYCfF8sKiWLwwu1c83DvMkbefIQ=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unraw/-/unraw-3.0.0.tgz",
+      "integrity": "sha512-08/DA66UF65OlpUDIQtbJyrqTR0jTAlJ+jsnkQ4jxR7+K5g5YG1APZKQSMCE1vqqmD+2pv6+IdEjmopFatacvg=="
     },
     "node_modules/untildify": {
       "version": "4.0.0",
@@ -33106,25 +33106,25 @@
       "dev": true
     },
     "@swagger-api/apidom-ast": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-0.74.0.tgz",
-      "integrity": "sha512-GViXTzRAI4U/3Y57HY8Rvf7lFQQjrqXtofR6+bTced3YwxnaaL9dSIPbPrmDKtgmx4hPcMZoKV4zoc6JasLx7g==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-0.74.1.tgz",
+      "integrity": "sha512-EoHyaRBeZmNYFNlDNZGeI45zRLfcVW0o4uZ8Fs/+HN1UIyDoZdr+ObElj5PEkCmdDx7ADlNmoGK4B+4AQA2LeA==",
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
         "@types/ramda": "~0.29.3",
         "ramda": "~0.29.0",
         "ramda-adjunct": "^4.0.0",
         "stampit": "^4.3.2",
-        "unraw": "^2.0.1"
+        "unraw": "^3.0.0"
       }
     },
     "@swagger-api/apidom-core": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-0.74.0.tgz",
-      "integrity": "sha512-6U8MLy1SKpWgM0D5CIpAkYW5NGGd9yPDGow0J/sqAwqgTipIkoUqa0DTErXjd0z0m2a+e8UsVXhTZmj0lF7EoQ==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-0.74.1.tgz",
+      "integrity": "sha512-y70oo/CrNMSi7TtUkATXkSWd+Q/4BjchwCuLpWbhSJuIpJM+W9yGyzWOFTFLZQpDbwK0yzocMk8iPClq/rWNPw==",
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-ast": "^0.74.0",
+        "@swagger-api/apidom-ast": "^0.74.1",
         "@types/ramda": "~0.29.3",
         "minim": "~0.23.8",
         "ramda": "~0.29.0",
@@ -33134,26 +33134,26 @@
       }
     },
     "@swagger-api/apidom-json-pointer": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-0.74.0.tgz",
-      "integrity": "sha512-vhvxpyewfxnJ+k+Uxr9O4wd0Ult+yD0+n0SIawk8dbeIMAkcVDBjo17xCoeAF+1iOeht276flHIgXTRCwg9U/w==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-0.74.1.tgz",
+      "integrity": "sha512-UusZdVY2AbYSyMK0aPSNvCiCtgn6NcGnS9fbAPVFsV+ALEtWYdMs/ZjfqYhbuzd+nRY34J9GCF7m+kVysZ9EWw==",
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.74.0",
+        "@swagger-api/apidom-core": "^0.74.1",
         "@types/ramda": "~0.29.3",
         "ramda": "~0.29.0",
         "ramda-adjunct": "^4.0.0"
       }
     },
     "@swagger-api/apidom-ns-api-design-systems": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-0.74.0.tgz",
-      "integrity": "sha512-xSXdxmWDK5/CTaoG0upVxbGUsh4LqkSycM5Jki+scwMs7K4j/RxgeTb6YUIifDJzeOaFyX2A/1y5gcZV0cinsQ==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-0.74.1.tgz",
+      "integrity": "sha512-eJxd3B4lQbVCi+g9ZXSM0IeCbqPEH5o7WdLdfrSowFLQqc7jQur/29UhbAh2PDvPSI/l7oaNzwgPTp4Zm8SaTw==",
       "optional": true,
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.74.0",
-        "@swagger-api/apidom-ns-openapi-3-1": "^0.74.0",
+        "@swagger-api/apidom-core": "^0.74.1",
+        "@swagger-api/apidom-ns-openapi-3-1": "^0.74.1",
         "@types/ramda": "~0.29.3",
         "ramda": "~0.29.0",
         "ramda-adjunct": "^4.0.0",
@@ -33161,14 +33161,14 @@
       }
     },
     "@swagger-api/apidom-ns-asyncapi-2": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-0.74.0.tgz",
-      "integrity": "sha512-iCVcL7x4gJ+RbGSj6h8DxXZYNUlkrfQAfakz4x0q67x4NltW7Zrcs/WAqNTbZxtPxiVOXpW72kk5bFvQd3hgxw==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-0.74.1.tgz",
+      "integrity": "sha512-xH6ilO8jJpZOWzWwbse3xi8zIbe3Iho+AMwwMFtkCnjUqmv81TGhlA6VPXpLCKgFsnZqJVyCKn/VaTW8N6379w==",
       "optional": true,
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.74.0",
-        "@swagger-api/apidom-ns-json-schema-draft-7": "^0.74.0",
+        "@swagger-api/apidom-core": "^0.74.1",
+        "@swagger-api/apidom-ns-json-schema-draft-7": "^0.74.1",
         "@types/ramda": "~0.29.3",
         "ramda": "~0.29.0",
         "ramda-adjunct": "^4.0.0",
@@ -33176,13 +33176,13 @@
       }
     },
     "@swagger-api/apidom-ns-json-schema-draft-4": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-0.74.0.tgz",
-      "integrity": "sha512-BNn3l/i7Hzj6qzJfiDsA/29XmUka8I/UsmnQa+4sIpu3DScM8L0m1SzZ+B+5jqVsLnx732dqEuulFClV+f0rQg==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-0.74.1.tgz",
+      "integrity": "sha512-zUQvrxoRQpvdYymHko1nxNeVWwqdGDYNYWUFW/EGZbP0sigKmuSZkh6LdseB9Pxt1WQD/6MkW3zN4JMXt/qFUA==",
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-ast": "^0.74.0",
-        "@swagger-api/apidom-core": "^0.74.0",
+        "@swagger-api/apidom-ast": "^0.74.1",
+        "@swagger-api/apidom-core": "^0.74.1",
         "@types/ramda": "~0.29.3",
         "ramda": "~0.29.0",
         "ramda-adjunct": "^4.0.0",
@@ -33190,14 +33190,14 @@
       }
     },
     "@swagger-api/apidom-ns-json-schema-draft-6": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-0.74.0.tgz",
-      "integrity": "sha512-L6ktmlZvoZMiojmFTIgTWGIzed3paqvJCYqVtLjDAhGBNC7bQK8hd0piskg6V/FjG3c4/tY778yV8E9MMLqrTA==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-0.74.1.tgz",
+      "integrity": "sha512-8GFH6bR5ERyuS+4u7CnLirBPYkYWostk31WDj7YeY5b0BRNtI3omH4rV24KECu99ZAg/unZY688VwmN25Dut/A==",
       "optional": true,
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.74.0",
-        "@swagger-api/apidom-ns-json-schema-draft-4": "^0.74.0",
+        "@swagger-api/apidom-core": "^0.74.1",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^0.74.1",
         "@types/ramda": "~0.29.3",
         "ramda": "~0.29.0",
         "ramda-adjunct": "^4.0.0",
@@ -33205,14 +33205,14 @@
       }
     },
     "@swagger-api/apidom-ns-json-schema-draft-7": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-0.74.0.tgz",
-      "integrity": "sha512-8YgAmMQFK849yrrppKYwmGUHyxeh3RKWaHrOUjNJyX2kAWLZzKMxVDRIVDs3OmoHsPleoM1P0yZxhqna9QME2w==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-0.74.1.tgz",
+      "integrity": "sha512-4ttxnBuRcegp1ooKtwoOqXDUNCWH4GuQlMBOUlHfKPR35qbMf0LCYU+ROvTk05ycoVkc2x6+AJQ4He684EXwfw==",
       "optional": true,
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.74.0",
-        "@swagger-api/apidom-ns-json-schema-draft-6": "^0.74.0",
+        "@swagger-api/apidom-core": "^0.74.1",
+        "@swagger-api/apidom-ns-json-schema-draft-6": "^0.74.1",
         "@types/ramda": "~0.29.3",
         "ramda": "~0.29.0",
         "ramda-adjunct": "^4.0.0",
@@ -33220,13 +33220,13 @@
       }
     },
     "@swagger-api/apidom-ns-openapi-3-0": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-0.74.0.tgz",
-      "integrity": "sha512-tOjSoAJAiAGZRWGqCeHEqbAVbaXA/dF5tAiptX+tQV7AnbwhVtIYW2UUOQFl4AnBPug+1WV2y//Q8e582zUHmg==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-0.74.1.tgz",
+      "integrity": "sha512-n5jccxnbiNjHiID0uTV1UXdt47WxyduQRKK9ILo7N2yXqkwI1ygqQNBVEUC/YZnHT4ZvFsifYAqbT0hO1h54ig==",
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.74.0",
-        "@swagger-api/apidom-ns-json-schema-draft-4": "^0.74.0",
+        "@swagger-api/apidom-core": "^0.74.1",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^0.74.1",
         "@types/ramda": "~0.29.3",
         "ramda": "~0.29.0",
         "ramda-adjunct": "^4.0.0",
@@ -33234,14 +33234,14 @@
       }
     },
     "@swagger-api/apidom-ns-openapi-3-1": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-0.74.0.tgz",
-      "integrity": "sha512-VUAdfPqC7XycKzxNH4xUPfHs4/6y/15tOLFoM6dzHgaq9PAoiSqp4fuVFeFpQC6IYQ/8qjrN3l+IOMeNj0BEjQ==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-0.74.1.tgz",
+      "integrity": "sha512-8ZqQBjMfiCEwePUbwdKIAStl7nIPIiyKGrON4Sy+PWTwvCQiam3haKeT5r6TDiTFyrS3idSplfXijuWfZF//Ag==",
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-ast": "^0.74.0",
-        "@swagger-api/apidom-core": "^0.74.0",
-        "@swagger-api/apidom-ns-openapi-3-0": "^0.74.0",
+        "@swagger-api/apidom-ast": "^0.74.1",
+        "@swagger-api/apidom-core": "^0.74.1",
+        "@swagger-api/apidom-ns-openapi-3-0": "^0.74.1",
         "@types/ramda": "~0.29.3",
         "ramda": "~0.29.0",
         "ramda-adjunct": "^4.0.0",
@@ -33249,74 +33249,74 @@
       }
     },
     "@swagger-api/apidom-parser-adapter-api-design-systems-json": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-0.74.0.tgz",
-      "integrity": "sha512-ppNkc34jzkplAje9WCq226szpy8Ekbyy7ebRO1UFCPfualacl4gVPjUEfVqrki1+vg6VxPyuBTMfHi5G8c0gFQ==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-0.74.1.tgz",
+      "integrity": "sha512-RFwnL2u3OzKVkE4jQ4zGNHA83BnXM3EjpTNRbCzcmsP78RGr7H9HebPaiRPpLMyC3GuzBwPXe8WbOdYsReuFww==",
       "optional": true,
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.74.0",
-        "@swagger-api/apidom-ns-api-design-systems": "^0.74.0",
-        "@swagger-api/apidom-parser-adapter-json": "^0.74.0",
+        "@swagger-api/apidom-core": "^0.74.1",
+        "@swagger-api/apidom-ns-api-design-systems": "^0.74.1",
+        "@swagger-api/apidom-parser-adapter-json": "^0.74.1",
         "@types/ramda": "~0.29.3",
         "ramda": "~0.29.0",
         "ramda-adjunct": "^4.0.0"
       }
     },
     "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-0.74.0.tgz",
-      "integrity": "sha512-tjg4j2vh/3I6S/rvoH16iNxfKw9ctYZ3Xn9MpI7FtcxRdGNuH2FfPqDl4Zt9Xos1P5K/yrHIpoR+RI17BX8Nig==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-0.74.1.tgz",
+      "integrity": "sha512-3r5lxhP/glOhQVFRVRf/Ps2F5V2oMowG6+YBkajV2jCW9XPIrIuVef+KcjbQQlm06J3QnD+Tg/ZiLXcxziAvoQ==",
       "optional": true,
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.74.0",
-        "@swagger-api/apidom-ns-api-design-systems": "^0.74.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.74.0",
+        "@swagger-api/apidom-core": "^0.74.1",
+        "@swagger-api/apidom-ns-api-design-systems": "^0.74.1",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.74.1",
         "@types/ramda": "~0.29.3",
         "ramda": "~0.29.0",
         "ramda-adjunct": "^4.0.0"
       }
     },
     "@swagger-api/apidom-parser-adapter-asyncapi-json-2": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-0.74.0.tgz",
-      "integrity": "sha512-a5twJ9Njmi3uIoVQtUh53Kpszz5Q3wpPcHFEmIQCuoiD+5ZBgBeWT1p7iwdi8M+kkKh/k71dh61mVbWGpRO2Gg==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-0.74.1.tgz",
+      "integrity": "sha512-jPp5n0aKtqZrQrz+Lh1B5LNocuMliA3OvNWGGTD14T54qNDJ+a2B6a31SXZqzjqfseWr7SeE2Z/RM5ljqviLWA==",
       "optional": true,
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.74.0",
-        "@swagger-api/apidom-ns-asyncapi-2": "^0.74.0",
-        "@swagger-api/apidom-parser-adapter-json": "^0.74.0",
+        "@swagger-api/apidom-core": "^0.74.1",
+        "@swagger-api/apidom-ns-asyncapi-2": "^0.74.1",
+        "@swagger-api/apidom-parser-adapter-json": "^0.74.1",
         "@types/ramda": "~0.29.3",
         "ramda": "~0.29.0",
         "ramda-adjunct": "^4.0.0"
       }
     },
     "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-0.74.0.tgz",
-      "integrity": "sha512-+VVR4maTlLXqlkBkBOeT85WY28hVh+yWMow/b+XdOVxoGf1mki6nI45uyq7XJU8A688us5YX4/9yzTDSd3tjRw==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-0.74.1.tgz",
+      "integrity": "sha512-em8o7bu0XEMac6cJvSi9WjMpTEny39gn+1UrANnICpvsMoiRjlfE5yEG4eueewV1nsukO4qTiUjTf32BGNgHYg==",
       "optional": true,
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.74.0",
-        "@swagger-api/apidom-ns-asyncapi-2": "^0.74.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.74.0",
+        "@swagger-api/apidom-core": "^0.74.1",
+        "@swagger-api/apidom-ns-asyncapi-2": "^0.74.1",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.74.1",
         "@types/ramda": "~0.29.3",
         "ramda": "~0.29.0",
         "ramda-adjunct": "^4.0.0"
       }
     },
     "@swagger-api/apidom-parser-adapter-json": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-0.74.0.tgz",
-      "integrity": "sha512-c1DUoNa1IJhEck+CW98cy5PRMby/ngKU+/nCtQf78XGwW8ujX+o5VFqFHZ7CUetLO/FxA7DS1JhPvuwlltsNeA==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-0.74.1.tgz",
+      "integrity": "sha512-CtJxt/o0ZyW/GkvETuTUUlCjTJ/wH0S7jr3CBnZR/vVVVlVfIYkGw2fEo8HUBAr+EnJNFfWOzOAjXQHul71wUw==",
       "optional": true,
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-ast": "^0.74.0",
-        "@swagger-api/apidom-core": "^0.74.0",
+        "@swagger-api/apidom-ast": "^0.74.1",
+        "@swagger-api/apidom-core": "^0.74.1",
         "@types/ramda": "~0.29.3",
         "ramda": "~0.29.0",
         "ramda-adjunct": "^4.0.0",
@@ -33327,74 +33327,74 @@
       }
     },
     "@swagger-api/apidom-parser-adapter-openapi-json-3-0": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-0.74.0.tgz",
-      "integrity": "sha512-aOP1ZC4N0rZJXxfGs1lIp+nQ16ZGrXK2AmhejX5YpXLLxUpwNjH8SIZLbBhsOJAuSlRp7HWCqSenq8LtKlie7w==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-0.74.1.tgz",
+      "integrity": "sha512-k8zOeb2aCyEVUdW1sUUBmawyqHmx7C7WB9eXFM1yEzwy3Y589cVygiy6AG1yOaPU8WWzR80+xPEqHw0VmqkBRg==",
       "optional": true,
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.74.0",
-        "@swagger-api/apidom-ns-openapi-3-0": "^0.74.0",
-        "@swagger-api/apidom-parser-adapter-json": "^0.74.0",
+        "@swagger-api/apidom-core": "^0.74.1",
+        "@swagger-api/apidom-ns-openapi-3-0": "^0.74.1",
+        "@swagger-api/apidom-parser-adapter-json": "^0.74.1",
         "@types/ramda": "~0.29.3",
         "ramda": "~0.29.0",
         "ramda-adjunct": "^4.0.0"
       }
     },
     "@swagger-api/apidom-parser-adapter-openapi-json-3-1": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-0.74.0.tgz",
-      "integrity": "sha512-KCMoWQBTYrh8i0pjMh6Hh8ZM4JVxMWAhJaGwoA6jDChSYP7yxlIO44bHjvX/f88UAW0U5y8ViwDdmy5wak22mw==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-0.74.1.tgz",
+      "integrity": "sha512-x70fOeBiavi9siSq2Hr07cBcIXdTEDpi87OpaQIGTk5tjN8wQfnQF1MWxdHpe4p/cJN7LiYw5Dx6uIAhp/RuGg==",
       "optional": true,
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.74.0",
-        "@swagger-api/apidom-ns-openapi-3-1": "^0.74.0",
-        "@swagger-api/apidom-parser-adapter-json": "^0.74.0",
+        "@swagger-api/apidom-core": "^0.74.1",
+        "@swagger-api/apidom-ns-openapi-3-1": "^0.74.1",
+        "@swagger-api/apidom-parser-adapter-json": "^0.74.1",
         "@types/ramda": "~0.29.3",
         "ramda": "~0.29.0",
         "ramda-adjunct": "^4.0.0"
       }
     },
     "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-0.74.0.tgz",
-      "integrity": "sha512-bjYYCX6bsRizHi8jUt1RZSRA40U2orutzx+KYrfeO6/BGOWBDHYdbvH+RTjlT7McK3dy3NOOtFzitoFdyJRqXQ==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-0.74.1.tgz",
+      "integrity": "sha512-MdZrzR+9AbunoP9OyETqZabhCllUiu5lu59uG7exo7jR1GfC28A4wVolNhi0C01wOcS+55t+1qvzi+i+9Kz3ew==",
       "optional": true,
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.74.0",
-        "@swagger-api/apidom-ns-openapi-3-0": "^0.74.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.74.0",
+        "@swagger-api/apidom-core": "^0.74.1",
+        "@swagger-api/apidom-ns-openapi-3-0": "^0.74.1",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.74.1",
         "@types/ramda": "~0.29.3",
         "ramda": "~0.29.0",
         "ramda-adjunct": "^4.0.0"
       }
     },
     "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-0.74.0.tgz",
-      "integrity": "sha512-AqTqy2V1zKqjsD2Gd+ZA/qetfcHqub/C0rHVvoN4RkFNMJlt6M7Hiy3D9A7ulkm9AyCJ9U0YV0a7QxfqeAfG+w==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-0.74.1.tgz",
+      "integrity": "sha512-OaDAhZm38chXyc0P0yHQSD4fCmUmEUWTTLgHntJDmvAZ7nSkV4NddDP7cgZ07z8dLEwMokI//9u+I/s0G0BO0Q==",
       "optional": true,
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.74.0",
-        "@swagger-api/apidom-ns-openapi-3-1": "^0.74.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.74.0",
+        "@swagger-api/apidom-core": "^0.74.1",
+        "@swagger-api/apidom-ns-openapi-3-1": "^0.74.1",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.74.1",
         "@types/ramda": "~0.29.3",
         "ramda": "~0.29.0",
         "ramda-adjunct": "^4.0.0"
       }
     },
     "@swagger-api/apidom-parser-adapter-yaml-1-2": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-0.74.0.tgz",
-      "integrity": "sha512-2sWjrwD83CFNGQKpV6Ce7QsApAP1PouRuF+jUw35IrXWdfvxHL4h2IPXrOAtwLMDHmzkBE7DVz6tFcWVAz4RDA==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-0.74.1.tgz",
+      "integrity": "sha512-QHxx3ZJ12FAF8yserAR1qL863/eOdi78HgdDFqVeg5tOfUUDXLnvEYbtCWejIjudBFD6s88ctffzN7+DEDFOPg==",
       "optional": true,
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-ast": "^0.74.0",
-        "@swagger-api/apidom-core": "^0.74.0",
+        "@swagger-api/apidom-ast": "^0.74.1",
+        "@swagger-api/apidom-core": "^0.74.1",
         "@types/ramda": "~0.29.3",
         "ramda": "~0.29.0",
         "ramda-adjunct": "^4.0.0",
@@ -33405,26 +33405,26 @@
       }
     },
     "@swagger-api/apidom-reference": {
-      "version": "0.74.0",
-      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-0.74.0.tgz",
-      "integrity": "sha512-vUGpzM9UlZmvipkwXuBZqoYl431XiF8opHViq5/hgmA0+bVo1Ozvw/SZzyLgP8NLAsdR0Enui015qBY0T3/p9Q==",
+      "version": "0.74.1",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-0.74.1.tgz",
+      "integrity": "sha512-DwMGmTA2VkiPf8CLDnhhR4PObqzrGGOKydxd3uWWFFI0/itU8mZcBZssMHseW1dV2fC9hvkva672Gt2W/wSJng==",
       "requires": {
         "@babel/runtime-corejs3": "^7.20.7",
-        "@swagger-api/apidom-core": "^0.74.0",
-        "@swagger-api/apidom-json-pointer": "^0.74.0",
-        "@swagger-api/apidom-ns-asyncapi-2": "^0.74.0",
-        "@swagger-api/apidom-ns-openapi-3-0": "^0.74.0",
-        "@swagger-api/apidom-ns-openapi-3-1": "^0.74.0",
-        "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^0.74.0",
-        "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^0.74.0",
-        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^0.74.0",
-        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^0.74.0",
-        "@swagger-api/apidom-parser-adapter-json": "^0.74.0",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^0.74.0",
-        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^0.74.0",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^0.74.0",
-        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^0.74.0",
-        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.74.0",
+        "@swagger-api/apidom-core": "^0.74.1",
+        "@swagger-api/apidom-json-pointer": "^0.74.1",
+        "@swagger-api/apidom-ns-asyncapi-2": "^0.74.1",
+        "@swagger-api/apidom-ns-openapi-3-0": "^0.74.1",
+        "@swagger-api/apidom-ns-openapi-3-1": "^0.74.1",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^0.74.1",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^0.74.1",
+        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^0.74.1",
+        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^0.74.1",
+        "@swagger-api/apidom-parser-adapter-json": "^0.74.1",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^0.74.1",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^0.74.1",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^0.74.1",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^0.74.1",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^0.74.1",
         "@types/ramda": "~0.29.3",
         "axios": "^1.4.0",
         "minimatch": "^7.4.3",
@@ -49469,15 +49469,15 @@
       }
     },
     "swagger-client": {
-      "version": "3.19.11",
-      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.19.11.tgz",
-      "integrity": "sha512-ef4t4nRGC8NuC8rz6OazEGU/QgkrFVMUba1vDmCL1Zuov50rTix9f33COr6RSmzQEc9aqY/kd+6f43a/7TbHhQ==",
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.20.0.tgz",
+      "integrity": "sha512-5RLge2NIE1UppIT/AjUPEceT05hcBAzjiQkrXJYjpxsbFV/UDH3pp+fsrWbAeuZtgRdhNB9KDo+szLoUpzkydQ==",
       "requires": {
         "@babel/runtime-corejs3": "^7.20.13",
-        "@swagger-api/apidom-core": ">=0.71.0 <1.0.0",
-        "@swagger-api/apidom-json-pointer": ">=0.71.0 <1.0.0",
-        "@swagger-api/apidom-ns-openapi-3-1": ">=0.71.0 <1.0.0",
-        "@swagger-api/apidom-reference": ">=0.71.1 <1.0.0",
+        "@swagger-api/apidom-core": ">=0.74.1 <1.0.0",
+        "@swagger-api/apidom-json-pointer": ">=0.74.1 <1.0.0",
+        "@swagger-api/apidom-ns-openapi-3-1": ">=0.74.1 <1.0.0",
+        "@swagger-api/apidom-reference": ">=0.74.1 <1.0.0",
         "cookie": "~0.5.0",
         "cross-fetch": "^3.1.5",
         "deepmerge": "~4.3.0",
@@ -50169,9 +50169,9 @@
       "dev": true
     },
     "unraw": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unraw/-/unraw-2.0.1.tgz",
-      "integrity": "sha512-tdOvLfRzHolwYcHS6HIX860MkK9LQ4+oLuNwFYL7bpgTEO64PZrcQxkisgwJYCfF8sKiWLwwu1c83DvMkbefIQ=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unraw/-/unraw-3.0.0.tgz",
+      "integrity": "sha512-08/DA66UF65OlpUDIQtbJyrqTR0jTAlJ+jsnkQ4jxR7+K5g5YG1APZKQSMCE1vqqmD+2pv6+IdEjmopFatacvg=="
     },
     "untildify": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "reselect": "^4.1.8",
     "serialize-error": "^8.1.0",
     "sha.js": "^2.4.11",
-    "swagger-client": "^3.19.11",
+    "swagger-client": "^3.20.0",
     "url-parse": "^1.5.10",
     "xml": "=1.0.1",
     "xml-but-prettier": "^1.0.1",

--- a/src/core/plugins/request-snippets/fn.js
+++ b/src/core/plugins/request-snippets/fn.js
@@ -111,7 +111,18 @@ const curlify = (request, escape, newLine, ext = "") => {
         addNewLine()
         addIndent()
         addWordsWithoutLeadingSpace("-F")
-        if (v instanceof win.File) {
+
+        /**
+         * SwaggerClient produces specialized sub-class of File class, that only
+         * accepts string data and retain this data in `data`
+         * public property throughout the lifecycle of its instances.
+         *
+         * This sub-class is exclusively used only when Encoding Object
+         * is defined within the Media Type Object (OpenAPI 3.x.y).
+         */
+        if (v instanceof win.File && typeof v.valueOf() === "string") {
+          addWords(`${extractedKey}=${v.data}${v.type ? `;type=${v.type}` : ""}`)
+        } else if (v instanceof win.File) {
           addWords(`${extractedKey}=@${v.name}${v.type ? `;type=${v.type}` : ""}`)
         } else {
           addWords(`${extractedKey}=${v}`)

--- a/src/core/window.js
+++ b/src/core/window.js
@@ -5,7 +5,6 @@ function makeWindow() {
     open: () => {},
     close: () => {},
     File: function() {},
-    Blob: function() {},
     FormData: function() {},
   }
 

--- a/src/core/window.js
+++ b/src/core/window.js
@@ -4,7 +4,9 @@ function makeWindow() {
     history: {},
     open: () => {},
     close: () => {},
-    File: function() {}
+    File: function() {},
+    Blob: function() {},
+    FormData: function() {},
   }
 
   if(typeof window === "undefined") {

--- a/test/unit/core/curlify.js
+++ b/test/unit/core/curlify.js
@@ -1,6 +1,7 @@
 import Im from "immutable"
 import { requestSnippetGenerator_curl_bash as curl } from "core/plugins/request-snippets/fn.js"
 import win from "core/window"
+import { fromJSOrdered } from "core/utils"
 
 describe("curlify", function () {
 
@@ -200,25 +201,50 @@ describe("curlify", function () {
     expect(curlified).toEqual("curl -X 'POST' \\\n  'http://example.com' \\\n  -H 'content-type: multipart/form-data' \\\n  -F 'id=123' \\\n  -F 'file=@file.txt;type=text/plain'")
   })
 
-  it("should print a curl with object formData and file", function () {
-    let file = new win.File([""], "file.txt", { type: "text/plain" })
+  it("should print a curl with formData containing JSON and file", async function () {
+    /**
+     * Specialized sub-class of File class, that only
+     * accepts string data and retain this data in `data`
+     * public property throughout the lifecycle of its instances.
+     *
+     * This sub-class is exclusively used only when Encoding Object
+     * is defined within the Media Type Object (OpenAPI 3.x.y).
+     *
+     * Instances of a similar sub-class are produced by swagger-client request builder.
+     */
+    class FileWithData extends win.File {
+      constructor(data, name = "", options = {}) {
+        super([data], name, options)
+        this.data = data
+      }
+
+      valueOf() {
+        return this.data
+      }
+
+      toString() {
+        return this.valueOf()
+      }
+    }
+
+    let file = new win.File(["data"], "file.txt", { type: "text/plain" })
+    let optionsJSON = JSON.stringify({ some_array: ["string"], max_bar: 300 })
+    let options = new FileWithData(optionsJSON, "", { type: "application/json;charset=utf-8" })
+
+    let formData = new FormData()
+    formData.set("options", options)
+    formData.set("file", file)
 
     let req = {
       url: "http://example.com",
       method: "POST",
       headers: { "content-type": "multipart/form-data" },
-      body: {
-        options: JSON.stringify({
-          some_array: ["string"],
-          max_bar: 300,
-        }),
-        file
-      }
+      body: formData,
     }
 
-    let curlified = curl(Im.fromJS(req))
+    let curlified = curl(fromJSOrdered(req))
 
-    expect(curlified).toEqual(`curl -X 'POST' \\\n  'http://example.com' \\\n  -H 'content-type: multipart/form-data' \\\n  -F 'options={"some_array":["string"],"max_bar":300}' \\\n  -F 'file=@file.txt;type=text/plain'`)
+    expect(curlified).toEqual(`curl -X 'POST' \\\n  'http://example.com' \\\n  -H 'content-type: multipart/form-data' \\\n  -F 'options={"some_array":["string"],"max_bar":300};type=application/json;charset=utf-8' \\\n  -F 'file=@file.txt;type=text/plain'`)
   })
 
   it("should print a curl without form data type if type is unknown", function () {

--- a/test/unit/core/curlify.js
+++ b/test/unit/core/curlify.js
@@ -231,7 +231,7 @@ describe("curlify", function () {
     let optionsJSON = JSON.stringify({ some_array: ["string"], max_bar: 300 })
     let options = new FileWithData(optionsJSON, "", { type: "application/json;charset=utf-8" })
 
-    let formData = new FormData()
+    let formData = new win.FormData()
     formData.set("options", options)
     formData.set("file", file)
 


### PR DESCRIPTION
This change fixes both:

1. making multipart/form-data requests with content-type header for every individual boundary
2. generating correct CURL command for multipart/form-data request, allowing specifying content-type header for every individual boundary

Refs #4826
Refs #5356

---

**multipart/form-data boundaries now containing `Content-Type` headers**:

![image](https://github.com/swagger-api/swagger-ui/assets/193286/2becae10-8e57-45ca-aaaf-eddeddae45b1)

**CURL command correctly generated by assigning additional `type=`**:

![image](https://github.com/swagger-api/swagger-ui/assets/193286/fdad9375-c81c-43b3-834f-34450a40c19b)
