### PR TITLE
chore(release): cut the failed v5.4.0 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "swagger-ui",
-  "version": "5.3.2",
+  "version": "5.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "swagger-ui",
-      "version": "5.3.2",
+      "version": "5.4.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-ui",
-  "version": "5.3.2",
+  "version": "5.4.0",
   "main": "./dist/swagger-ui.js",
   "module": "./dist/swagger-ui-es-bundle-core.js",
   "exports": {


### PR DESCRIPTION
This release field to properly execute and we ended up with impartial release only. V5.4.1 will follow.