### PR TITLE
Fixed Cookie Authentication

### DIFF
--- a/src/core/plugins/auth/wrap-actions.js
+++ b/src/core/plugins/auth/wrap-actions.js
@@ -24,7 +24,11 @@ export const authorize = (oriAction, system) => (payload) => {
     const isApiKeyInCookie = isApiKeyAuth && isInCookie
 
     if (isApiKeyInCookie) {
-      document.cookie = `${schema.get("name")}=${value}; SameSite=None; Secure`
+      const secure = `${configs.url?.split("/")[0] === "https:" ? ";secure" : ""}`
+      const urlBasePath = configs.url?.split("/")[3]
+      const path = `${urlBasePath === undefined ? ";path=/" : ";path=/".concat(urlBasePath)}`
+      let cookieStr = `${schema.get("name")}=${value};samesite=None${secure}${path}`
+      document.cookie = cookieStr
     }
   } catch (error) {
     console.error(
@@ -49,7 +53,9 @@ export const logout = (oriAction, system) => (payload) => {
 
         if (isApiKeyInCookie) {
           const cookieName = auth.getIn(["schema", "name"])
-          document.cookie = `${cookieName}=; Max-Age=-99999999`
+          const urlBasePath = configs.url?.split("/")[3]
+          const path = `${urlBasePath === undefined ? ";path=/" : ";path=/".concat(urlBasePath)}`
+          document.cookie = `${cookieName}=;max-age=-99999999${path}`
         }
       })
     }

--- a/src/core/plugins/auth/wrap-actions.js
+++ b/src/core/plugins/auth/wrap-actions.js
@@ -25,7 +25,7 @@ export const authorize = (oriAction, system) => (payload) => {
 
     if (isApiKeyInCookie) {
       const secure = `${configs.url?.split("/")[0] === "https:" ? ";secure" : ""}`
-      const urlBasePath = configs.url?.split("/")[3]
+      const urlBasePath = configs.url?.split("/").splice(3).join("/")
       const path = `${urlBasePath === undefined ? ";path=/" : ";path=/".concat(urlBasePath)}`
       let cookieStr = `${schema.get("name")}=${value};samesite=None${secure}${path}`
       document.cookie = cookieStr
@@ -53,7 +53,7 @@ export const logout = (oriAction, system) => (payload) => {
 
         if (isApiKeyInCookie) {
           const cookieName = auth.getIn(["schema", "name"])
-          const urlBasePath = configs.url?.split("/")[3]
+          const urlBasePath = configs.url?.split("/").splice(3).join("/")
           const path = `${urlBasePath === undefined ? ";path=/" : ";path=/".concat(urlBasePath)}`
           document.cookie = `${cookieName}=;max-age=-99999999${path}`
         }

--- a/test/unit/core/plugins/auth/wrap-actions.js
+++ b/test/unit/core/plugins/auth/wrap-actions.js
@@ -38,7 +38,82 @@ describe("Cookie based apiKey persistence in document.cookie", () => {
       authorize(jest.fn(), system)(payload)
 
       expect(document.cookie).toEqual(
-        "apiKeyCookie=test; SameSite=None; Secure"
+        "apiKeyCookie=test;samesite=None;path=/"
+      )
+    })
+
+    it("should persist secure cookie in document.cookie for non-SSL targets", () => {
+      const system = {
+        getConfigs: () => ({
+          persistAuthorization: true,
+          url: "http://example.org"
+        }),
+      }
+      const payload = {
+        api_key: {
+          schema: fromJS({
+            type: "apiKey",
+            name: "apiKeyCookie",
+            in: "cookie",
+          }),
+          value: "test",
+        },
+      }
+
+      authorize(jest.fn(), system)(payload)
+
+      expect(document.cookie).toEqual(
+        "apiKeyCookie=test;samesite=None;path=/"
+      )
+    })
+
+    it("should persist secure cookie in document.cookie for SSL targets", () => {
+      const system = {
+        getConfigs: () => ({
+          persistAuthorization: true,
+          url: "https://example.org"
+        }),
+      }
+      const payload = {
+        api_key: {
+          schema: fromJS({
+            type: "apiKey",
+            name: "apiKeyCookie",
+            in: "cookie",
+          }),
+          value: "test",
+        },
+      }
+
+      authorize(jest.fn(), system)(payload)
+
+      expect(document.cookie).toEqual(
+        "apiKeyCookie=test;samesite=None;secure;path=/"
+      )
+    })
+
+    it("should persist secure cookie in document.cookie for non-root SSL targets", () => {
+      const system = {
+        getConfigs: () => ({
+          persistAuthorization: true,
+          url: "https://example.org/api"
+        }),
+      }
+      const payload = {
+        api_key: {
+          schema: fromJS({
+            type: "apiKey",
+            name: "apiKeyCookie",
+            in: "cookie",
+          }),
+          value: "test",
+        },
+      }
+
+      authorize(jest.fn(), system)(payload)
+
+      expect(document.cookie).toEqual(
+        "apiKeyCookie=test;samesite=None;secure;path=/api"
       )
     })
 
@@ -64,7 +139,7 @@ describe("Cookie based apiKey persistence in document.cookie", () => {
 
       logout(jest.fn(), system)(["api_key"])
 
-      expect(document.cookie).toEqual("apiKeyCookie=; Max-Age=-99999999")
+      expect(document.cookie).toEqual("apiKeyCookie=;max-age=-99999999;path=/")
     })
   })
 

--- a/test/unit/core/plugins/auth/wrap-actions.js
+++ b/test/unit/core/plugins/auth/wrap-actions.js
@@ -117,6 +117,31 @@ describe("Cookie based apiKey persistence in document.cookie", () => {
       )
     })
 
+    it("should persist secure cookie in document.cookie for SSL targets with non-root multi-level base path", () => {
+      const system = {
+        getConfigs: () => ({
+          persistAuthorization: true,
+          url: "https://example.org/api/production"
+        }),
+      }
+      const payload = {
+        api_key: {
+          schema: fromJS({
+            type: "apiKey",
+            name: "apiKeyCookie",
+            in: "cookie",
+          }),
+          value: "test",
+        },
+      }
+
+      authorize(jest.fn(), system)(payload)
+
+      expect(document.cookie).toEqual(
+        "apiKeyCookie=test;samesite=None;secure;path=/api/production"
+      )
+    })
+
     it("should delete cookie from document.cookie", () => {
       const payload = fromJS({
         api_key: {
@@ -140,6 +165,32 @@ describe("Cookie based apiKey persistence in document.cookie", () => {
       logout(jest.fn(), system)(["api_key"])
 
       expect(document.cookie).toEqual("apiKeyCookie=;max-age=-99999999;path=/")
+    })
+
+    it("should delete cookie from document.cookie for targets with non-root multi-level base path", () => {
+      const payload = fromJS({
+        api_key: {
+          schema: {
+            type: "apiKey",
+            name: "apiKeyCookie",
+            in: "cookie",
+          },
+          value: "test",
+        },
+      })
+      const system = {
+        getConfigs: () => ({
+          persistAuthorization: true,
+          url: "https://example.org/api/production"
+        }),
+        authSelectors: {
+          authorized: () => payload,
+        },
+      }
+
+      logout(jest.fn(), system)(["api_key"])
+
+      expect(document.cookie).toEqual("apiKeyCookie=;max-age=-99999999;path=/api/production")
     })
   })
 
@@ -190,5 +241,31 @@ describe("Cookie based apiKey persistence in document.cookie", () => {
 
       expect(document.cookie).toEqual("")
     })
+  })
+
+  it("should delete cookie from document.cookie for targets with non-root multi-level base path", () => {
+    const payload = fromJS({
+      api_key: {
+        schema: {
+          type: "apiKey",
+          name: "apiKeyCookie",
+          in: "cookie",
+        },
+        value: "test",
+      },
+    })
+    const system = {
+      getConfigs: () => ({
+        persistAuthorization: false,
+        url: "https://example.org/api/production"
+      }),
+      authSelectors: {
+        authorized: () => payload,
+      },
+    }
+
+    logout(jest.fn(), system)(["api_key"])
+
+    expect(document.cookie).toEqual("")
   })
 })


### PR DESCRIPTION
Fixes for Cookie Authentication. This builds on top of the changes done as part of the issue #8683 (PR #8689) and #9710. The changes done as part of that PR don't work (both setting the Cookie as well as resetting it).

### Description

* Fixed Cookie Removal for Logouts
* Fixed Setting of Cookie by specifying the path
* Adding secure only when target is SSL/TLS
* Added Unit Tests


### Motivation and Context

The Cookie based Authentication was not working in at least Safari. Neither was the cookie being set, nor was was it being unset (after fixing the setting part). This was causing the API testing of Cookie Authentication based endpoints impossible.

The official [Mozilla Developer Documentation on document.cookie](https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie) was followed to implement the fix.

Swagger UI's official documentation states that cross domain Cookie Auth is not supported. While that may still be the case after this fix is released because of CORS blocks, this fix will work if the swagger UI is loaded from the same domain, where the APIs reside.

Fixes for removing the set Cookies have also been added


### How Has This Been Tested?

* A cookie authentication based nodejs application was used with swagger-express-ui.
* The `persistAuthorization` configuration field was set to true
* After deploying the application, the Authentication Cookie was set.
* API endpoints were hit using these browsers:
  * Mozilla Firefox
  * Google Chrome
  * Safari
  * Microsoft Edge
* The `Cookie` Request Header was verified to have an entry for the authentication cookie
* Logout was tested in the same manner.


### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
