### PR TITLE
fix(swagger-ui-react): avoid babel output in build fragments

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -15,13 +15,23 @@ module.exports = {
         ],
         "@babel/preset-react",
       ],
+      "plugins": [
+        [
+          "transform-react-remove-prop-types",
+          {
+            "additionalLibraries": [
+              "react-immutable-proptypes"
+            ]
+          }
+        ],
+      ],
     },
     "esm": {
       "presets": [
         [
           "@babel/env",
           {
-            "debug": true,
+            "debug": false,
             "modules": false,
             "ignoreBrowserslistConfig": false,
             "useBuiltIns": false,


### PR DESCRIPTION
Problem was resolved by turning babel debug off.

Refs #9192
