### PR TITLE
fix(oauth2): add fallback for case when window.opener is null

### DIFF
--- a/dev-helpers/oauth2-redirect.html
+++ b/dev-helpers/oauth2-redirect.html
@@ -6,6 +6,14 @@
 <script>
     'use strict';
     function run () {
+        if (!window.opener) {
+            prompt("Run this in devtools on the Swagger UI page to complete auth:", [
+                `swaggerUIRedirectOauth2.auth.code = "${JSON.stringify((new URLSearchParams(location.search)).get('code'))}";`
+                `delete swaggerUIRedirectOauth2.state;`,
+                `swaggerUIRedirectOauth2.callback({ auth: swaggerUIRedirectOauth2.auth, redirectUrl: swaggerUIRedirectOauth2.redirectUrl});`,
+            ].join(" "));
+            return;
+        }
         var oauth2 = window.opener.swaggerUIRedirectOauth2;
         var sentState = oauth2.state;
         var redirectUrl = oauth2.redirectUrl;

--- a/dev-helpers/oauth2-redirect.html
+++ b/dev-helpers/oauth2-redirect.html
@@ -8,7 +8,7 @@
     function run () {
         if (!window.opener) {
             prompt("Run this in devtools on the Swagger UI page to complete auth:", [
-                `swaggerUIRedirectOauth2.auth.code = "${JSON.stringify((new URLSearchParams(location.search)).get('code'))}";`
+                `swaggerUIRedirectOauth2.auth.code = ${JSON.stringify((new URLSearchParams(location.search)).get('code'))};`,
                 `delete swaggerUIRedirectOauth2.state;`,
                 `swaggerUIRedirectOauth2.callback({ auth: swaggerUIRedirectOauth2.auth, redirectUrl: swaggerUIRedirectOauth2.redirectUrl});`,
             ].join(" "));


### PR DESCRIPTION
### Motivation and Context

Sometimes `window.opener` might be null (there's [multiple issues](https://github.com/swagger-api/swagger-ui/issues?q=is%3Aissue+is%3Aopen+opener) about that). Currently this results in a blank page without any indication of what might have gone wrong.

Related: #8315, #3227
Fixes #8030, fixes #6150


### Description

This PR adds a fallback: if `window.opener` is null, it will display a one-liner to run on a Swagger UI page (using devtools) in a `prompt()`. Not too elegant, but given this is an edge case I'm not sure if it warrants more complex UI.


### How Has This Been Tested?

I've checked the added snippet independently by running it in devtools and it works as intended.

I'll be grateful for pointers to how to cover it with unit / integrations tests :-) 


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->


### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
