### PR TITLE
feature(oauth2): allow passing additional form params to token endpoint

### DIFF
--- a/src/core/oauth2-authorize.js
+++ b/src/core/oauth2-authorize.js
@@ -127,6 +127,7 @@ export default function authorize ( { auth, authActions, errActions, configs, au
     state: state,
     redirectUrl: redirectUrl,
     callback: callback,
-    errCb: errActions.newAuthErr
+    errCb: errActions.newAuthErr,
+    authConfigs: authConfigs
   })
 }

--- a/src/core/plugins/auth/actions.js
+++ b/src/core/plugins/auth/actions.js
@@ -137,7 +137,7 @@ export const authorizeApplication = ( auth ) => ( { authActions } ) => {
   return authActions.authorizeRequest({body: buildFormData(form), name, url: schema.get("tokenUrl"), auth, headers })
 }
 
-export const authorizeAccessCodeWithFormParams = ( { auth, redirectUrl } ) => ( { authActions } ) => {
+export const authorizeAccessCodeWithFormParams = ( { auth, redirectUrl, authConfigs } ) => ( { authActions } ) => {
   let { schema, name, clientId, clientSecret, codeVerifier } = auth
   let form = {
     grant_type: "authorization_code",
@@ -145,13 +145,14 @@ export const authorizeAccessCodeWithFormParams = ( { auth, redirectUrl } ) => ( 
     client_id: clientId,
     client_secret: clientSecret,
     redirect_uri: redirectUrl,
-    code_verifier: codeVerifier
+    code_verifier: codeVerifier,
   }
+  Object.assign(form, authConfigs.additionalTokenFormParams || {})
 
   return authActions.authorizeRequest({body: buildFormData(form), name, url: schema.get("tokenUrl"), auth})
 }
 
-export const authorizeAccessCodeWithBasicAuthentication = ( { auth, redirectUrl } ) => ( { authActions } ) => {
+export const authorizeAccessCodeWithBasicAuthentication = ( { auth, redirectUrl, authConfigs } ) => ( { authActions } ) => {
   let { schema, name, clientId, clientSecret, codeVerifier } = auth
   let headers = {
     Authorization: "Basic " + btoa(clientId + ":" + clientSecret)
@@ -163,6 +164,7 @@ export const authorizeAccessCodeWithBasicAuthentication = ( { auth, redirectUrl 
     redirect_uri: redirectUrl,
     code_verifier: codeVerifier
   }
+  Object.assign(form, authConfigs.additionalTokenFormParams || {})
 
   return authActions.authorizeRequest({body: buildFormData(form), name, url: schema.get("tokenUrl"), auth, headers})
 }


### PR DESCRIPTION
### Description

This PR adds a config variable allowing users to add arbitrary fields to the form body sent to the token endpoint.


### Motivation and Context

Some OAuth2 providers, like [Logto](https://logto.io/), accept additional parameters in the body of the token endpoint. For example, if you pass `resource=https://api.example.net`, it would issue `access_token` for that particular API.

I'm not yet sure if this is a valid OAuth2 implementation detail, but it should make the configuration more versatile and allow working with more identity providers.


### How Has This Been Tested?

Not yet :') I'll be grateful for pointers to how to cover it with unit / integrations tests!

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [x] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
