### PR TITLE
fix: Operation content is fixed for lower resolution sizes

### DIFF
--- a/src/style/_layout.scss
+++ b/src/style/_layout.scss
@@ -325,6 +325,7 @@
         font-size: 16px;
         @media (max-width: 768px) {
           font-size: 12px;
+        white-space: nowrap;
         }
 
 
@@ -350,6 +351,7 @@
       {
           flex-shrink: 1;
           max-width: 100%;
+          white-space: nowrap;
       }
     }
 
@@ -369,7 +371,7 @@
 
         flex: 1 1 auto;
 
-        word-break: break-word;
+        word-break: keep-all;
 
         @include text_body();
     }


### PR DESCRIPTION
Fixed Collapse of Operation content for lower resolution devices

### Description
On lower resolution devices, the text in operation content was starting to wrap character by character, I have made it such that it would wrap word by word which would make sense of whats written.

Fixes #8940

### Screenshots :

![Screenshot from 2023-10-01 04-57-40](https://github.com/swagger-api/swagger-ui/assets/103197883/ebe677c4-7a4c-4865-bb3d-48b27371ae12)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
