### PR TITLE
fix(build): add support for remix.run bundler

### DIFF
--- a/webpack/es-bundle-core.js
+++ b/webpack/es-bundle-core.js
@@ -55,14 +55,14 @@ const result = configBuilder(
           "deep-extend", // uses Buffer as global symbol
           "randombytes", // uses require('safe-buffer')
           "sha.js", // uses require('safe-buffer')
-          /xml/, // uses require('stream')
-          /process\/browser/, // is injected via ProvidePlugin
-          /readable-stream/, // byproduct of buffer ProvidePlugin injection
+          "xml", // uses require('stream')
+          "process/browser", // is injected via ProvidePlugin
+          /^readable-stream/, // byproduct of buffer ProvidePlugin injection
           "util-deprecate", // dependency of readable-stream
           "inherits", // dependency of readable-stream
           "events", // dependency of readable-stream
-          /safe-buffer/, // contained in resolve.alias
-          /string_decoder/, // byproduct of buffer ProvidePlugin injection
+          "safe-buffer", // contained in resolve.alias
+          "string_decoder/", // byproduct of buffer ProvidePlugin injection
           "buffer", // buffer is injected via ProvidePlugin
         ],
         importType: (moduleName) => {


### PR DESCRIPTION
We were accidentally bundling `xml-but-prettier`
library which resulted in failed remix.run builds.

