### PR TITLE
Fix reset button in Try It Out form

### DIFF
--- a/src/core/containers/OperationContainer.jsx
+++ b/src/core/containers/OperationContainer.jsx
@@ -2,7 +2,7 @@ import React, { PureComponent } from "react"
 import PropTypes from "prop-types"
 import ImPropTypes from "react-immutable-proptypes"
 import { opId } from "swagger-client/es/helpers"
-import { Iterable, fromJS, Map } from "immutable"
+import { Iterable, fromJS, Map, OrderedMap } from "immutable"
 
 export default class OperationContainer extends PureComponent {
   constructor(props, context) {
@@ -124,7 +124,7 @@ export default class OperationContainer extends PureComponent {
 
   onResetClick = (pathMethod) => {
     const defaultRequestBodyValue = this.props.oas3Selectors.selectDefaultRequestBodyValue(...pathMethod)
-    this.props.oas3Actions.setRequestBodyValue({ value: defaultRequestBodyValue, pathMethod })
+    this.props.oas3Actions.setRequestBodyValue({ value: OrderedMap(JSON.parse(defaultRequestBodyValue)), pathMethod })
   }
 
   onExecute = () => {

--- a/src/core/containers/OperationContainer.jsx
+++ b/src/core/containers/OperationContainer.jsx
@@ -2,7 +2,7 @@ import React, { PureComponent } from "react"
 import PropTypes from "prop-types"
 import ImPropTypes from "react-immutable-proptypes"
 import { opId } from "swagger-client/es/helpers"
-import { Iterable, fromJS, Map, OrderedMap } from "immutable"
+import { Iterable, fromJS, Map } from "immutable"
 
 export default class OperationContainer extends PureComponent {
   constructor(props, context) {
@@ -124,7 +124,7 @@ export default class OperationContainer extends PureComponent {
 
   onResetClick = (pathMethod) => {
     const defaultRequestBodyValue = this.props.oas3Selectors.selectDefaultRequestBodyValue(...pathMethod)
-    this.props.oas3Actions.setRequestBodyValue({ value: OrderedMap(JSON.parse(defaultRequestBodyValue)), pathMethod })
+    this.props.oas3Actions.setRequestBodyValue({ value: fromJS(JSON.parse(defaultRequestBodyValue)), pathMethod })
   }
 
   onExecute = () => {

--- a/src/core/plugins/json-schema-5-samples/fn/index.js
+++ b/src/core/plugins/json-schema-5-samples/fn/index.js
@@ -283,7 +283,7 @@ export const sampleFromSchemaGeneric = (schema, config={}, exampleOverride = und
   }
 
   const canAddProperty = (propName) => {
-    if(!schema || schema.maxProperties === null || schema.maxProperties === undefined) {
+    if(!respectXML || !schema || schema.maxProperties === null || schema.maxProperties === undefined) {
       return true
     }
     if(hasExceededMaxProperties()) {

--- a/src/core/plugins/oas3/reducers.js
+++ b/src/core/plugins/oas3/reducers.js
@@ -29,15 +29,18 @@ export default {
       // context: user switch from application/json to application/x-www-form-urlencoded
       currentVal = Map()
     }
-    let newVal
+    let newVal = currentVal
     const [...valueKeys] = value.keys()
     valueKeys.forEach((valueKey) => {
       let valueKeyVal = value.getIn([valueKey])
-      if (!currentVal.has(valueKey)) {
-        newVal = currentVal.setIn([valueKey, "value"], valueKeyVal)
+      if (!newVal.has(valueKey)) {
+      newVal = newVal.setIn([valueKey, "value"], valueKeyVal)
       } else if (!Map.isMap(valueKeyVal)) {
         // context: user input will be received as String
-        newVal = currentVal.setIn([valueKey, "value"], valueKeyVal)
+        newVal = newVal.setIn([valueKey, "value"], valueKeyVal)
+      } else {
+        // context: If multiple values are edited only last edited is string, previous are map.
+        newVal = newVal.set(valueKey, valueKeyVal)
       }
     })
     return state.setIn(["requestData", path, method, "bodyValue"], newVal)

--- a/test/e2e-cypress/e2e/bugs/9158.cy.js
+++ b/test/e2e-cypress/e2e/bugs/9158.cy.js
@@ -1,0 +1,29 @@
+describe("#9158: Reset button creates invalid inputs in the Try It Out form", () => {
+    it("it reset the user edited value and executes with the default value in case of try out reset. (#6517)", () => {
+      cy
+        .visit("?url=/documents/bugs/9158.yaml")
+        .get("#operations-default-post_users")
+        .click()
+        // Expand Try It Out
+        .get(".try-out__btn")
+        .click()
+        // replace multiple default values with bad value
+        .get(`.parameters[data-property-name="name"] input[type=text]`)
+        .type("{selectall}not the default name value")
+        .get(`.parameters[data-property-name="badgeid"] input[type=text]`)
+        .type("{selectall}not the default badge value")
+        // Reset Try It Out
+        .get(".try-out__btn.reset")
+        .click()
+        // Submit using default value
+        .get(".btn.execute")
+        .click()
+        // No required validation error on body parameter
+        .get(`.parameters[data-property-name="name"] input`)
+        .should("have.value", "default name")
+        .and("not.have.class", "invalid")
+        .get(`.parameters[data-property-name="badgeid"] input`)
+        .should("have.value", "12345")
+        .and("not.have.class", "invalid")
+    })
+  })

--- a/test/e2e-cypress/static/documents/bugs/9158.yaml
+++ b/test/e2e-cypress/static/documents/bugs/9158.yaml
@@ -1,0 +1,46 @@
+openapi: 3.0.3
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /users:
+    post:
+      summary: Create a user
+      description: Create a user, one of various ways
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/UserSource'
+      responses:
+        '204':
+          description: Successfully opened document
+        '400':
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                properties:
+                  output:
+                    type: string
+                    example: "Invalid request"
+components:
+  schemas:
+    UserSource:
+      type: object
+      properties:
+        name:
+          description: Full name
+          type: string
+          example: "default name"
+        badgeid:
+          description: Badge number
+          type: integer
+          format: uint32
+          example: 12345
+        email:
+          description: E-mail
+          type: string
+          example: "jsmith@business.com"
+      minProperties: 1
+      maxProperties: 3


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
The reset button needed the following two corrections:
1. The `oas3Actions.setRequestBodyValue` expects a orderedMap/Map and was currently being passed a string. So a conversion from string to orderedMap was added.
2. The `UPDATE_REQUEST_BODY_VALUE` action currently did not copy over the values if the value was a map assuming the user entered values will be string but that is not the case in reset, as the values will already have been converted to map. Therefore even the map values have been copied to correct key to reflect changes.
3. Furthermore, the loop to copy over the values overwrote the previous iteration changes due to it using the same unchanged variable every loop. The variable is now updated and retained every iteration to preserve changes from previous iterations.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->
Fixes #9158 


### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I manually tested this by opening the try it out form and using the yaml file provided in the issue description.


### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
