### PR TITLE
chore(release): manual release bump to v5.10.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "swagger-ui",
-  "version": "5.10.0",
+  "version": "5.10.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "swagger-ui",
-      "version": "5.10.0",
+      "version": "5.10.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-ui",
-  "version": "5.10.0",
+  "version": "5.10.1",
   "main": "./dist/swagger-ui.js",
   "module": "./dist/swagger-ui-es-bundle-core.js",
   "exports": {


### PR DESCRIPTION
v5.10.1 was a failed released, not all release
artifacts were published.

Refs https://github.com/swagger-api/swagger-ui/releases/tag/v5.10.1
