### PR TITLE
fix: React warnings of "Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead."

### DIFF
--- a/src/core/components/errors.jsx
+++ b/src/core/components/errors.jsx
@@ -84,7 +84,7 @@ const ThrownErrorItem = ( { error, jumpToLine } ) => {
     )
   }
 
-const SpecErrorItem = ( { error, jumpToLine } ) => {
+const SpecErrorItem = ( { error, jumpToLine = null } ) => {
   let locationMessage = null
 
   if(error.get("path")) {
@@ -124,10 +124,6 @@ function toTitleCase(str) {
 ThrownErrorItem.propTypes = {
   error: PropTypes.object.isRequired,
   jumpToLine: PropTypes.func
-}
-
-ThrownErrorItem.defaultProps = {
-  jumpToLine: null
 }
 
 SpecErrorItem.propTypes = {

--- a/src/core/components/highlight-code.jsx
+++ b/src/core/components/highlight-code.jsx
@@ -7,7 +7,7 @@ import isFunction from "lodash/isFunction"
 import saveAs from "js-file-download"
 import { CopyToClipboard } from "react-copy-to-clipboard"
 
-const HighlightCode = ({value, fileName, className, downloadable, getConfigs, canCopy, language}) => {
+const HighlightCode = ({value, fileName = "response.txt", className, downloadable, getConfigs, canCopy, language}) => {
   const config = isFunction(getConfigs) ? getConfigs() : null
   const canSyntaxHighlight = get(config, "syntaxHighlight") !== false && get(config, "syntaxHighlight.activated", true)
   const rootRef = useRef(null)
@@ -80,10 +80,6 @@ HighlightCode.propTypes = {
   fileName: PropTypes.string,
   language: PropTypes.string,
   canCopy: PropTypes.bool
-}
-
-HighlightCode.defaultProps = {
-  fileName: "response.txt"
 }
 
 export default HighlightCode

--- a/src/core/components/providers/markdown.jsx
+++ b/src/core/components/providers/markdown.jsx
@@ -18,7 +18,7 @@ if (DomPurify.addHook) {
   })
 }
 
-function Markdown({ source, className = "", getConfigs }) {
+function Markdown({ source, className = "", getConfigs = () => ({ useUnsafeMarkdown: false }) }) {
   if (typeof source !== "string") {
     return null
   }
@@ -49,10 +49,6 @@ Markdown.propTypes = {
   source: PropTypes.string.isRequired,
   className: PropTypes.string,
   getConfigs: PropTypes.func,
-}
-
-Markdown.defaultProps = {
-  getConfigs: () => ({ useUnsafeMarkdown: false }),
 }
 
 export default Markdown

--- a/src/core/plugins/icons/components/arrow-down.jsx
+++ b/src/core/plugins/icons/components/arrow-down.jsx
@@ -4,7 +4,7 @@
 import React from "react"
 import PropTypes from "prop-types"
 
-const ArrowDown = ({ className, width, height, ...rest }) => (
+const ArrowDown = ({ className = null, width = 20, height = 20, ...rest }) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 20 20"
@@ -23,12 +23,6 @@ ArrowDown.propTypes = {
   className: PropTypes.string,
   width: PropTypes.string,
   height: PropTypes.string,
-}
-
-ArrowDown.defaultProps = {
-  className: null,
-  width: 20,
-  height: 20,
 }
 
 export default ArrowDown

--- a/src/core/plugins/icons/components/arrow-up.jsx
+++ b/src/core/plugins/icons/components/arrow-up.jsx
@@ -4,7 +4,7 @@
 import React from "react"
 import PropTypes from "prop-types"
 
-const ArrowUp = ({ className, width, height, ...rest }) => (
+const ArrowUp = ({ className = null, width = 20, height = 20, ...rest }) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 20 20"
@@ -23,12 +23,6 @@ ArrowUp.propTypes = {
   className: PropTypes.string,
   width: PropTypes.string,
   height: PropTypes.string,
-}
-
-ArrowUp.defaultProps = {
-  className: null,
-  width: 20,
-  height: 20,
 }
 
 export default ArrowUp

--- a/src/core/plugins/icons/components/arrow.jsx
+++ b/src/core/plugins/icons/components/arrow.jsx
@@ -4,7 +4,7 @@
 import React from "react"
 import PropTypes from "prop-types"
 
-const Arrow = ({ className, width, height, ...rest }) => (
+const Arrow = ({ className = null, width = 20, height = 20, ...rest }) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 20 20"
@@ -23,12 +23,6 @@ Arrow.propTypes = {
   className: PropTypes.string,
   width: PropTypes.string,
   height: PropTypes.string,
-}
-
-Arrow.defaultProps = {
-  className: null,
-  width: 20,
-  height: 20,
 }
 
 export default Arrow

--- a/src/core/plugins/icons/components/close.jsx
+++ b/src/core/plugins/icons/components/close.jsx
@@ -4,7 +4,7 @@
 import React from "react"
 import PropTypes from "prop-types"
 
-const Close = ({ className, width, height, ...rest }) => (
+const Close = ({ className = null, width = 20, height = 20, ...rest }) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 20 20"
@@ -23,12 +23,6 @@ Close.propTypes = {
   className: PropTypes.string,
   width: PropTypes.string,
   height: PropTypes.string,
-}
-
-Close.defaultProps = {
-  className: null,
-  width: 20,
-  height: 20,
 }
 
 export default Close

--- a/src/core/plugins/icons/components/copy.jsx
+++ b/src/core/plugins/icons/components/copy.jsx
@@ -4,7 +4,7 @@
 import React from "react"
 import PropTypes from "prop-types"
 
-const Copy = ({ className, width, height, ...rest }) => (
+const Copy = ({ className = null, width = 15, height = 16, ...rest }) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 15 16"
@@ -29,12 +29,6 @@ Copy.propTypes = {
   className: PropTypes.string,
   width: PropTypes.string,
   height: PropTypes.string,
-}
-
-Copy.defaultProps = {
-  className: null,
-  width: 15,
-  height: 16,
 }
 
 export default Copy

--- a/src/core/plugins/icons/components/lock.jsx
+++ b/src/core/plugins/icons/components/lock.jsx
@@ -4,7 +4,7 @@
 import React from "react"
 import PropTypes from "prop-types"
 
-const Lock = ({ className, width, height, ...rest }) => (
+const Lock = ({ className = null, width = 20, height = 20, ...rest }) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 20 20"
@@ -23,12 +23,6 @@ Lock.propTypes = {
   className: PropTypes.string,
   width: PropTypes.string,
   height: PropTypes.string,
-}
-
-Lock.defaultProps = {
-  className: null,
-  width: 20,
-  height: 20,
 }
 
 export default Lock

--- a/src/core/plugins/icons/components/unlock.jsx
+++ b/src/core/plugins/icons/components/unlock.jsx
@@ -4,7 +4,7 @@
 import React from "react"
 import PropTypes from "prop-types"
 
-const Unlock = ({ className, width, height, ...rest }) => (
+const Unlock = ({ className = null, width = 20, height = 20, ...rest }) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 20 20"
@@ -23,12 +23,6 @@ Unlock.propTypes = {
   className: PropTypes.string,
   width: PropTypes.string,
   height: PropTypes.string,
-}
-
-Unlock.defaultProps = {
-  className: null,
-  width: 20,
-  height: 20,
 }
 
 export default Unlock

--- a/src/core/plugins/json-schema-2020-12/components/Accordion/Accordion.jsx
+++ b/src/core/plugins/json-schema-2020-12/components/Accordion/Accordion.jsx
@@ -7,7 +7,7 @@ import classNames from "classnames"
 
 import { useComponent } from "../../hooks"
 
-const Accordion = ({ expanded, children, onChange }) => {
+const Accordion = ({ expanded = false, children, onChange }) => {
   const ChevronRightIcon = useComponent("ChevronRightIcon")
 
   const handleExpansion = useCallback(
@@ -40,10 +40,6 @@ Accordion.propTypes = {
   expanded: PropTypes.bool,
   children: PropTypes.node.isRequired,
   onChange: PropTypes.func.isRequired,
-}
-
-Accordion.defaultProps = {
-  expanded: false,
 }
 
 export default Accordion

--- a/src/core/plugins/json-schema-2020-12/components/JSONSchema/JSONSchema.jsx
+++ b/src/core/plugins/json-schema-2020-12/components/JSONSchema/JSONSchema.jsx
@@ -23,7 +23,7 @@ import {
 } from "../../context"
 
 const JSONSchema = forwardRef(
-  ({ schema, name, dependentRequired, onExpand }, ref) => {
+  ({ schema, name = "", dependentRequired = [], onExpand = () => {} }, ref) => {
     const fn = useFn()
     const isExpanded = useIsExpanded()
     const isExpandedDeeply = useIsExpandedDeeply()
@@ -213,12 +213,6 @@ JSONSchema.propTypes = {
   schema: propTypes.schema.isRequired,
   dependentRequired: PropTypes.arrayOf(PropTypes.string),
   onExpand: PropTypes.func,
-}
-
-JSONSchema.defaultProps = {
-  name: "",
-  dependentRequired: [],
-  onExpand: () => {},
 }
 
 export default JSONSchema

--- a/src/core/plugins/json-schema-2020-12/components/keywords/Title/Title.jsx
+++ b/src/core/plugins/json-schema-2020-12/components/keywords/Title/Title.jsx
@@ -7,7 +7,7 @@ import PropTypes from "prop-types"
 import { schema } from "../../../prop-types"
 import { useFn } from "../../../hooks"
 
-const Title = ({ title, schema }) => {
+const Title = ({ title = "", schema }) => {
   const fn = useFn()
   const renderedTitle = title || fn.getTitle(schema)
 
@@ -23,10 +23,6 @@ const Title = ({ title, schema }) => {
 Title.propTypes = {
   title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   schema: schema.isRequired,
-}
-
-Title.defaultProps = {
-  title: "",
 }
 
 export default Title

--- a/src/core/plugins/json-schema-2020-12/components/keywords/Type.jsx
+++ b/src/core/plugins/json-schema-2020-12/components/keywords/Type.jsx
@@ -7,7 +7,7 @@ import PropTypes from "prop-types"
 import { schema } from "../../prop-types"
 import { useFn } from "../../hooks"
 
-const Type = ({ schema, isCircular }) => {
+const Type = ({ schema, isCircular = false }) => {
   const fn = useFn()
   const type = fn.getType(schema)
   const circularSuffix = isCircular ? " [circular]" : ""
@@ -22,10 +22,6 @@ const Type = ({ schema, isCircular }) => {
 Type.propTypes = {
   schema: schema.isRequired,
   isCircular: PropTypes.bool,
-}
-
-Type.defaultProps = {
-  isCircular: false,
 }
 
 export default Type

--- a/src/core/plugins/oas3/wrap-components/markdown.jsx
+++ b/src/core/plugins/oas3/wrap-components/markdown.jsx
@@ -9,7 +9,7 @@ const parser = new Remarkable("commonmark")
 parser.block.ruler.enable(["table"])
 parser.set({ linkTarget: "_blank" })
 
-export const Markdown = ({ source, className = "", getConfigs }) => {
+export const Markdown = ({ source, className = "", getConfigs = () => ({ useUnsafeMarkdown: false }) }) => {
   if(typeof source !== "string") {
     return null
   }
@@ -40,10 +40,6 @@ Markdown.propTypes = {
   source: PropTypes.string,
   className: PropTypes.string,
   getConfigs: PropTypes.func,
-}
-
-Markdown.defaultProps = {
-  getConfigs: () => ({ useUnsafeMarkdown: false }),
 }
 
 export default OAS3ComponentWrapFactory(Markdown)

--- a/src/core/plugins/oas31/json-schema-2020-12-extensions/components/keywords/Discriminator/DiscriminatorMapping.jsx
+++ b/src/core/plugins/oas31/json-schema-2020-12-extensions/components/keywords/Discriminator/DiscriminatorMapping.jsx
@@ -29,8 +29,4 @@ DiscriminatorMapping.propTypes = {
   }),
 }
 
-DiscriminatorMapping.defaultProps = {
-  mapping: undefined,
-}
-
 export default DiscriminatorMapping


### PR DESCRIPTION
Remove deprecated warning that occurs in React 18.2.0.

### Description
When I am trying to use swagger-ui with react@18.2.0 I am getting this warning. The React [MR](https://github.com/facebook/react/pull/25699) to print this warning on console is here.

```
Warning: {FunctionComponentName}: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
```


### How Has This Been Tested?
I am pretty sure this is a small refactor to remove this warning and I could work on that 😄


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
