### PR TITLE
fix(deep-linking): When swagger UI is served under subpath deep link removes path

### DIFF
--- a/src/core/plugins/deep-linking/helpers.js
+++ b/src/core/plugins/deep-linking/helpers.js
@@ -1,7 +1,3 @@
 export const setHash = (value) => {
-  if(value) {
-    return history.pushState(null, null, `#${value}`)
-  } else {
-    return window.location.hash = ""
-  }
+  return window.location.hash = value || ""
 }


### PR DESCRIPTION
### Description
This PR changes the way the hash is set when deep linking is enabled.

### Motivation and Context
Our application has an explicit [`html > head > base`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base) set to where the application is exposed for example `<base url="https://company.com/base/" />`. This is needed to allow client side routing while keeping the ability to change the base path under which the app is served.
Swagger UI is exposed under `https://company.com/base/api`, so when deep linking is enabled it would change the URL to `https://company.com/base/#/Tag/OperationId` instead of `https://company.com/base/api#/Tag/OperationId`. By using the `location.hash` API not only for resetting the hash, but also for setting it this works as expected as it only sets the hash, but leaves the rest of the URL intact.

### How Has This Been Tested?
I patched the swagger-ui implementation locally and verified that the behavior is as expected.

## Checklist
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.

Not sure if there would be a good way on how to test this automatically. 
