### PR TITLE
fix(oas31): defaultModelExpandDepth not applied to oneOf/anyOf

### DIFF
--- a/src/core/plugins/json-schema-2020-12/components/keywords/AllOf.jsx
+++ b/src/core/plugins/json-schema-2020-12/components/keywords/AllOf.jsx
@@ -5,14 +5,15 @@ import React, { useCallback, useState } from "react"
 import classNames from "classnames"
 
 import { schema } from "../../prop-types"
-import { useFn, useComponent, useIsExpandedDeeply } from "../../hooks"
+import { useFn, useComponent, useIsExpandedDeeply, useIsExpanded } from "../../hooks"
 import { JSONSchemaDeepExpansionContext } from "../../context"
 
 const AllOf = ({ schema }) => {
   const allOf = schema?.allOf || []
   const fn = useFn()
+  const isExpanded = useIsExpanded()
   const isExpandedDeeply = useIsExpandedDeeply()
-  const [expanded, setExpanded] = useState(isExpandedDeeply)
+  const [expanded, setExpanded] = useState(isExpanded || isExpandedDeeply)
   const [expandedDeeply, setExpandedDeeply] = useState(false)
   const Accordion = useComponent("Accordion")
   const ExpandDeepButton = useComponent("ExpandDeepButton")

--- a/src/core/plugins/json-schema-2020-12/components/keywords/AnyOf.jsx
+++ b/src/core/plugins/json-schema-2020-12/components/keywords/AnyOf.jsx
@@ -5,14 +5,15 @@ import React, { useCallback, useState } from "react"
 import classNames from "classnames"
 
 import { schema } from "../../prop-types"
-import { useFn, useComponent, useIsExpandedDeeply } from "../../hooks"
+import { useFn, useComponent, useIsExpanded, useIsExpandedDeeply } from "../../hooks"
 import { JSONSchemaDeepExpansionContext } from "../../context"
 
 const AnyOf = ({ schema }) => {
   const anyOf = schema?.anyOf || []
   const fn = useFn()
+  const isExpanded = useIsExpanded()
   const isExpandedDeeply = useIsExpandedDeeply()
-  const [expanded, setExpanded] = useState(isExpandedDeeply)
+  const [expanded, setExpanded] = useState(isExpanded || isExpandedDeeply)
   const [expandedDeeply, setExpandedDeeply] = useState(false)
   const Accordion = useComponent("Accordion")
   const ExpandDeepButton = useComponent("ExpandDeepButton")

--- a/src/core/plugins/json-schema-2020-12/components/keywords/OneOf.jsx
+++ b/src/core/plugins/json-schema-2020-12/components/keywords/OneOf.jsx
@@ -5,14 +5,15 @@ import React, { useCallback, useState } from "react"
 import classNames from "classnames"
 
 import { schema } from "../../prop-types"
-import { useFn, useComponent, useIsExpandedDeeply } from "../../hooks"
+import { useFn, useComponent, useIsExpandedDeeply, useIsExpanded } from "../../hooks"
 import { JSONSchemaDeepExpansionContext } from "../../context"
 
 const OneOf = ({ schema }) => {
   const oneOf = schema?.oneOf || []
   const fn = useFn()
+  const isExpanded = useIsExpanded()
   const isExpandedDeeply = useIsExpandedDeeply()
-  const [expanded, setExpanded] = useState(isExpandedDeeply)
+  const [expanded, setExpanded] = useState(isExpanded || isExpandedDeeply)
   const [expandedDeeply, setExpandedDeeply] = useState(false)
   const Accordion = useComponent("Accordion")
   const ExpandDeepButton = useComponent("ExpandDeepButton")

--- a/test/e2e-cypress/e2e/bugs/9508.cy.js
+++ b/test/e2e-cypress/e2e/bugs/9508.cy.js
@@ -1,0 +1,11 @@
+describe("#9508: defaultModelExpandDepth not applied to oneOf/anyOf", () => {
+    it("should expand oneOf/anyOf schemas", () => {
+        cy.visit("/pages/9508/").then(() => {
+            cy.get("div.model-example")
+                .find("span.json-schema-2020-12-accordion__icon--collapsed")
+                .should('have.length', 0)
+            cy.contains('anyOf1-p1-p2-p1')
+            cy.contains('oneOf1-p1-p2-p1')
+        })
+    })
+})

--- a/test/e2e-cypress/static/pages/9508/9508.yaml
+++ b/test/e2e-cypress/static/pages/9508/9508.yaml
@@ -1,0 +1,78 @@
+openapi: "3.1.0"
+info:
+  version: "0.0.1"
+  title: "Swagger UI Webpack Setup"
+  description: "Demonstrates Swagger UI"
+components:
+  schemas: {}
+security: []
+paths:
+  /pets:
+    get:
+      responses:
+        200:
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - oneOf:
+                      - type: object
+                        properties:
+                          oneOf1-p1:
+                            type: object
+                            properties:
+                              oneOf1-p1-p1:
+                                type: string
+                              oneOf1-p1-p2:
+                                type: object
+                                properties:
+                                  oneOf1-p1-p2-p1:
+                                    type: string
+                          oneOf1-p2:
+                            type: string
+                      - type: object
+                        properties:
+                          oneOf2-p1:
+                            type: string
+                          oneOf2-p2:
+                            type: string
+                  - anyOf:
+                      - type: object
+                        properties:
+                          anyOf1-p1:
+                            type: object
+                            properties:
+                              anyOf1-p1-p1:
+                                type: string
+                              anyOf1-p1-p2:
+                                type: object
+                                properties:
+                                  anyOf1-p1-p2-p1:
+                                    type: string
+                          anyOf1-p2:
+                            type: string
+                      - type: object
+                        properties:
+                          anyOf2-p1:
+                            type: object
+                            properties:
+                              anyOf2-p1-p1:
+                                type: string
+                          anyOf2-p2:
+                            type: string
+                  - type: object
+                    properties:
+                      p1:
+                        type: object
+                        properties:
+                          p1-p1:
+                            type: string
+                          p1-p2:
+                            type: object
+                            properties:
+                              p1-p2-p1:
+                                type: string
+                      p2:
+                        type: string
+tags: []

--- a/test/e2e-cypress/static/pages/9508/index.html
+++ b/test/e2e-cypress/static/pages/9508/index.html
@@ -1,0 +1,65 @@
+<!-- HTML for dev server -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Swagger UI</title>
+  <link rel="stylesheet" type="text/css" href="/swagger-ui.css">
+  <style>
+    html {
+      box-sizing: border-box;
+      overflow: -moz-scrollbars-vertical;
+      overflow-y: scroll;
+    }
+    *,
+    *:before,
+    *:after {
+      box-sizing: inherit;
+    }
+    body {
+      margin:0;
+      background: #fafafa;
+    }
+  </style>
+</head>
+
+<body>
+
+<div id="swagger-ui"></div>
+
+<script src="/swagger-ui-bundle.js" charset="UTF-8"> </script>
+<script src="/swagger-ui-standalone-preset.js" charset="UTF-8"> </script>
+<script>
+  window.onload = function() {
+    window["SwaggerUIBundle"] = window["swagger-ui-bundle"]
+    window["SwaggerUIStandalonePreset"] = window["swagger-ui-standalone-preset"]
+    // Build a system
+    const ui = SwaggerUIBundle({
+      url: "./9508.yaml",
+      dom_id: '#swagger-ui',
+      presets: [
+        SwaggerUIBundle.presets.apis,
+        SwaggerUIStandalonePreset
+      ],
+      plugins: [],
+      layout: "StandaloneLayout",
+      docExpansion: "full",
+      defaultModelExpandDepth: 100,
+      defaultModelRendering: "model",
+      onComplete: () => {
+        if(window.completeCount) {
+          window.completeCount++
+        } else {
+          window.completeCount = 1
+        }
+      },
+      queryConfigEnabled: true,
+    })
+
+    window.ui = ui
+  }
+</script>
+</body>
+
+</html>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Issue [9508](https://github.com/swagger-api/swagger-ui/issues/9508)
On openapi 3.1, defaultModelExpandDepth configuration is not applied to oneOf/anyOf schemas  

#### Limitation
Depth level for oneOf/anyOf schemas is not exactly respected due to title level

for example with a depth of 2, got
![image](https://github.com/swagger-api/swagger-ui/assets/21055755/b16aa756-6e1a-4804-9928-26a52349104d)
instead of
![image](https://github.com/swagger-api/swagger-ui/assets/21055755/6e726668-8c4c-4eaf-a3fb-a5f2d9f74e09)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->



### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Add one e2e test to check oneOf/anyOf subschema are well expended


### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
