### PR TITLE
Fix: optional enum array schema for query parameters should not populate parameter when -- is selected

### DIFF
--- a/src/core/components/layout-utils.jsx
+++ b/src/core/components/layout-utils.jsx
@@ -166,12 +166,10 @@ export class Select extends React.Component {
 
 
     if (multiple) {
-      value = options.filter(function (option) {
-          return option.selected
-        })
-        .map(function (option){
-          return option.value
-        })
+      value = options
+        .filter((option) => option.selected)
+        .map((option) => option.value)
+        .filter((value) => !!value)
     } else {
       value = e.target.value
     }

--- a/test/e2e-cypress/e2e/bugs/5176.cy.js
+++ b/test/e2e-cypress/e2e/bugs/5176.cy.js
@@ -1,0 +1,26 @@
+describe("#5176: Optional array query params with enum schema are always sent when '--' is selected in options list", () => {
+    beforeEach(() => {
+        cy.intercept("GET", "/5176*", {
+            body: "OK",
+        }).as("request")
+    })
+
+
+    it("should only forget the value of the auth the user logged out from", () => {
+        cy
+            .visit("/?url=/documents/bugs/5176.yaml")
+            .get("#operations-default-get_5176") // expand the route details onClick
+            .click()
+            .get(".btn.try-out__btn") // expand "try it out"
+            .click()
+            .get(".parameters select")
+            .select("--")
+            .get(".btn.execute") // execute request
+            .click()
+            .wait("@request")
+            .its("request")
+            .then((req) => {
+                expect(req.query, "request query params").to.not.have.property("fields")
+            })
+    })
+})

--- a/test/e2e-cypress/static/documents/bugs/5176.yaml
+++ b/test/e2e-cypress/static/documents/bugs/5176.yaml
@@ -1,0 +1,37 @@
+openapi: '3.0.0'
+info:
+  description: >-
+    Repro API
+  title: Repro API
+  version: '1.0'
+paths:
+  /5176:
+    get:
+      summary: Test get
+      parameters:
+        - name: fields
+          in: query
+          required: false
+          allowEmptyValue: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - friends
+                - family
+          example:
+            - friends
+          style: form
+      responses:
+        200:
+          description: Success!
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
- Updated logic on the `Select` component in `layout-utils.jsx` to ignore empty value when computing the parameters
- Added an e2e test for this issue


### Motivation and Context
Fixes #5176 



### How Has This Been Tested?
New cypress test added for the specific issue


### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
