### PR TITLE
Ft/3832 add switches for disabling rendering of large payloads

### DIFF
--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -226,11 +226,19 @@ Parameter name | Docker variable | Description
         </td>
     </tr>
     <tr>
-        <td><a name="user-content-syntaxhighlight.activate"></a><code>syntaxHighlight.activate</code>
+        <td><a name="user-content-syntaxhighlight.activated"></a><code>syntaxHighlight.activated</code>
         </td>
         <td><em>Unavailable</em></td>
         <td><code>Boolean=true</code>. Whether syntax highlighting should be
             activated or not.
+        </td>
+    </tr>
+    <tr>
+        <td><a name="user-content-syntaxhighlight.sizethreshold"></a><code>syntaxHighlight.sizeThreshold</code>
+        </td>
+        <td><em>Unavailable</em></td>
+        <td>The maximum size (in bytes) of a payload to syntax highlight.
+        Any payload above this will not be syntax highlighted. Use this to avoid long delays caused by larged payloads.
         </td>
     </tr>
     <tr>

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -208,6 +208,15 @@ Parameter name | Docker variable | Description
     </tr>
     <tr>
         <td>
+            <a name="user-content-renderSizeThreshold"></a><code>renderSizeThreshold</code>
+        </td>
+        <td><em>Unavailable</em></td>
+        <td>The maximum size (in bytes) of a payload to render.
+        Any payload above this will not be rendered, but may be available for copy or download.
+        </td>
+    </tr>
+    <tr>
+        <td>
             <a name="user-content-syntaxhighlight"></a><code>syntaxHighlight</code>
         </td>
         <td><em>Unavailable</em></td>

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -208,7 +208,7 @@ Parameter name | Docker variable | Description
     </tr>
     <tr>
         <td>
-            <a name="user-content-renderSizeThreshold"></a><code>renderSizeThreshold</code>
+            <a name="user-content-payload.render.sizeThreshold"></a><code>payload.render.sizeThreshold</code>
         </td>
         <td><em>Unavailable</em></td>
         <td>The maximum size (in bytes) of a payload to render.

--- a/src/core/components/highlight-code.jsx
+++ b/src/core/components/highlight-code.jsx
@@ -9,7 +9,7 @@ import { CopyToClipboard } from "react-copy-to-clipboard"
 
 const HighlightCode = ({value, fileName = "response.txt", className, downloadable, getConfigs, canCopy, language}) => {
   const config = isFunction(getConfigs) ? getConfigs() : null
-  const renderSizeThreshold = get(config, "renderSizeThreshold")
+  const renderSizeThreshold = get(config, "payload.render.sizeThreshold")
   const canSyntaxHighlight = get(config, "syntaxHighlight") !== false && get(config, "syntaxHighlight.activated", true)
   const syntaxHighlightSizeThreshold = canSyntaxHighlight ? get(config, "syntaxHighlight.sizeThreshold", undefined) : undefined
   const rootRef = useRef(null)

--- a/test/unit/components/highlight-code.jsx
+++ b/test/unit/components/highlight-code.jsx
@@ -3,28 +3,44 @@ import expect from "expect"
 import { shallow, mount } from "enzyme"
 import HighlightCode from "core/components/highlight-code"
 
-const fakeGetConfigs = () => ({syntaxHighlight: {activated: true, theme: "agate"}})
+const fakeGetConfigs = (renderSizeThreshold = undefined) => (
+  {
+    renderSizeThreshold: renderSizeThreshold,
+    syntaxHighlight: {
+      activated: true,
+      theme: "agate"
+    }
+  })
 
 describe("<HighlightCode />", () => {
   it("should render a Download button if downloadable", () => {
-    const props = {downloadable: true, getConfigs: fakeGetConfigs }
+    const props = { downloadable: true, getConfigs: fakeGetConfigs }
     const wrapper = shallow(<HighlightCode {...props} />)
     expect(wrapper.find(".download-contents").length).toEqual(1)
   })
 
   it("should render a Copy To Clipboard button if copyable", () => {
-    const props = {canCopy: true, getConfigs: fakeGetConfigs }
+    const props = { canCopy: true, getConfigs: fakeGetConfigs }
     const wrapper = shallow(<HighlightCode {...props} />)
     expect(wrapper.find("CopyToClipboard").length).toEqual(1)
   })
 
   it("should render values in a preformatted element", () => {
     const value = "test text"
-    const props = {value: value, getConfigs: fakeGetConfigs}
+    const props = { value: value, getConfigs: fakeGetConfigs }
     const wrapper = mount(<HighlightCode {...props} />)
     const preTag = wrapper.find("pre")
 
     expect(preTag.length).toEqual(1)
     expect(preTag.text()).toEqual(value)
+  })
+
+  it("should not render values larger than threshold", () => {
+    const value = "aaaaaaaa" //8 bytes
+    const props = { value: value, getConfigs: () => fakeGetConfigs(7) }
+    const wrapper = mount(<HighlightCode {...props} />)
+    const infoTag = wrapper.find("div.microlight")
+
+    expect(infoTag.text()).toEqual("Value is too large (8 bytes), rendering disabled.")
   })
 })

--- a/test/unit/components/highlight-code.jsx
+++ b/test/unit/components/highlight-code.jsx
@@ -9,10 +9,14 @@ const defaultSyntaxHighlightConfig = {
 }
 
 const fakeGetConfigs = (
-    renderSizeThreshold = undefined,
-    syntaxHighlight = defaultSyntaxHighlightConfig) => (
+  renderSizeThreshold = undefined,
+  syntaxHighlight = defaultSyntaxHighlightConfig) => (
   {
-    renderSizeThreshold: renderSizeThreshold,
+    payload: {
+      render: {
+        sizeThreshold: renderSizeThreshold,
+      }
+    },
     syntaxHighlight: syntaxHighlight
   })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Adds two configuration options to control if/how payloads gets rendered, depending on the size of the payload.
1. Disable rendering of payloads with size above X (new config option `renderSizeThreshold`)
2. Disable pretty-printing / syntax highlighting of payloads with size above Y (new config option `syntaxHighlight.sizeThreshold`)


### Motivation and Context
If a response is too large, the UI hangs for a very long time - sometimes crashes. This is discussed in both #3832 and #4018.
~I am not entirely sure if these options counts as solving those issues, but at least it provides a way of letting users download large responses without waiting for the UI to render, and avoids crashes of even larger responses.~
Edit (see comments below):
Fixes #3832 
Fixes #4018 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

### How Has This Been Tested?
Added unit tests to cover the new functionality.
Also tested on a simple service running locally, which allowed me to control the size of the response. I configured `renderSizeThreshold` to `6000000` (~6MB) and `syntaxHighlight.sizeThreshold` to 1000000 (~1MB). I could see that responses with size just under 6MB were very slow, and responses just over 6MB were very quick (but response is not displayed). Responses just under 1MB were very slow, and responses just over 1MB significantly quicker.
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


### Screenshots (if appropriate):
![image](https://github.com/swagger-api/swagger-ui/assets/46819699/0327f2c2-8d5d-41e5-a0a5-70a54434dbe3)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [x] My changes require a change to the project documentation.
- [x] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
