### PR TITLE
fix: page title color contrast meets WCAG AA requirements

### DIFF
--- a/src/style/_information.scss
+++ b/src/style/_information.scss
@@ -89,7 +89,7 @@
             
             &.version-stamp
             {
-                background-color: #89bf04;
+                background-color: $color-primary;
             }
 
             pre

--- a/src/style/_variables.scss
+++ b/src/style/_variables.scss
@@ -35,7 +35,7 @@ $mango-tango: #e97500 !default;
 
 // Theme
 
-$color-primary: #89bf04 !default;
+$color-primary: $japanese-laurel !default;
 $color-secondary: #9012fe !default;
 $color-info: #4990e2 !default;
 $color-warning: #ff6060 !default;

--- a/src/style/_variables.scss
+++ b/src/style/_variables.scss
@@ -114,7 +114,7 @@ $info-code-font-color: $_color-head !default;
 $info-link-font-color: $color-info !default;
 $info-link-font-color-hover: $info-link-font-color !default;
 
-$info-title-small-background-color: $waterloo-gray !default;
+$info-title-small-background-color: $gray-500 !default;
 
 $info-title-small-pre-font-color: $white !default;
 


### PR DESCRIPTION
### Description
The background colors for the version and version-stamp badges in the title do not pass WCAG AA color contrast standards. 

- Updating the grey for the version to `$gray-50` is the closest to the original `$waterloo-gray` that passes testing when using the WAVE testing tool. 
- The green used for the version-stamp was the same as the `$color-primary` but the style definition didn't use the variable. This change updates the style to use the color variable and changes to darker `$japanse-laurel` which passes WCAG AA testing.

I looked through the style folder and couldn't find the `$color-primary` used anywhere else. If the color works for the version-stamp, but not as color primary, I can always switch it back to the previous value and just use `$japanese-laurel` in the information.scss file. 



### Motivation and Context
Fixes #9583 



### How Has This Been Tested?
Using the WAVE Chrome extension, I tested out the various greens and grays in the _variables file until I found some that were close but passed WCAG AA. I didn't go for WCAG AAA as it was a significant change in style. 


### Screenshots:
Original:
![original-page-title-color-contrast](https://github.com/swagger-api/swagger-ui/assets/2748839/a43f642d-5de4-474e-be73-ddfad61de1e2)
After fix:
![bug-fix-9583-color-contrast-screenshot](https://github.com/swagger-api/swagger-ui/assets/2748839/d0e603c6-d636-4019-a561-fbdfe0e9289b)




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ x] Bug fixes (non-breaking change which fixes an issue)
- [ x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [ x] are not breaking changes.

### Documentation
- [x ] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
