### PR TITLE
feat(json-schema): support propertyNames for sample generation

### DIFF
--- a/src/core/plugins/json-schema-2020-12-samples/fn/api/formatAPI.js
+++ b/src/core/plugins/json-schema-2020-12-samples/fn/api/formatAPI.js
@@ -2,9 +2,9 @@
  * @prettier
  */
 
-import Registry from "../class/Registry"
+import FormatRegistry from "../class/FormatRegistry"
 
-const registry = new Registry()
+const registry = new FormatRegistry()
 
 const formatAPI = (format, generator) => {
   if (typeof generator === "function") {
@@ -15,5 +15,6 @@ const formatAPI = (format, generator) => {
 
   return registry.get(format)
 }
+formatAPI.getDefaults = () => registry.defaults
 
 export default formatAPI

--- a/src/core/plugins/json-schema-2020-12-samples/fn/class/FormatRegistry.js
+++ b/src/core/plugins/json-schema-2020-12-samples/fn/class/FormatRegistry.js
@@ -1,0 +1,65 @@
+/**
+ * @prettier
+ */
+import Registry from "./Registry"
+import int32Generator from "../generators/int32"
+import int64Generator from "../generators/int64"
+import floatGenerator from "../generators/float"
+import doubleGenerator from "../generators/double"
+import emailGenerator from "../generators/email"
+import idnEmailGenerator from "../generators/idn-email"
+import hostnameGenerator from "../generators/hostname"
+import idnHostnameGenerator from "../generators/idn-hostname"
+import ipv4Generator from "../generators/ipv4"
+import ipv6Generator from "../generators/ipv6"
+import uriGenerator from "../generators/uri"
+import uriReferenceGenerator from "../generators/uri-reference"
+import iriGenerator from "../generators/iri"
+import iriReferenceGenerator from "../generators/iri-reference"
+import uuidGenerator from "../generators/uuid"
+import uriTemplateGenerator from "../generators/uri-template"
+import jsonPointerGenerator from "../generators/json-pointer"
+import relativeJsonPointerGenerator from "../generators/relative-json-pointer"
+import dateTimeGenerator from "../generators/date-time"
+import dateGenerator from "../generators/date"
+import timeGenerator from "../generators/time"
+import durationGenerator from "../generators/duration"
+import passwordGenerator from "../generators/password"
+import regexGenerator from "../generators/regex"
+
+class FormatRegistry extends Registry {
+  #defaults = {
+    int32: int32Generator,
+    int64: int64Generator,
+    float: floatGenerator,
+    double: doubleGenerator,
+    email: emailGenerator,
+    "idn-email": idnEmailGenerator,
+    hostname: hostnameGenerator,
+    "idn-hostname": idnHostnameGenerator,
+    ipv4: ipv4Generator,
+    ipv6: ipv6Generator,
+    uri: uriGenerator,
+    "uri-reference": uriReferenceGenerator,
+    iri: iriGenerator,
+    "iri-reference": iriReferenceGenerator,
+    uuid: uuidGenerator,
+    "uri-template": uriTemplateGenerator,
+    "json-pointer": jsonPointerGenerator,
+    "relative-json-pointer": relativeJsonPointerGenerator,
+    "date-time": dateTimeGenerator,
+    date: dateGenerator,
+    time: timeGenerator,
+    duration: durationGenerator,
+    password: passwordGenerator,
+    regex: regexGenerator,
+  }
+
+  data = { ...this.#defaults }
+
+  get defaults() {
+    return { ...this.#defaults }
+  }
+}
+
+export default FormatRegistry

--- a/src/core/plugins/json-schema-2020-12-samples/fn/core/example.js
+++ b/src/core/plugins/json-schema-2020-12-samples/fn/core/example.js
@@ -55,3 +55,25 @@ export const extractExample = (schema) => {
 
   return undefined
 }
+
+export const extractExamples = (schema) => {
+  if (!isJSONSchemaObject(schema)) return []
+
+  const { examples, example, default: defaultVal } = schema
+
+  let allExamples = []
+
+  if (typeof defaultVal !== "undefined") {
+    allExamples.push(defaultVal)
+  }
+
+  if (Array.isArray(examples) && examples.length >= 1) {
+    allExamples.push(...examples)
+  }
+
+  if (typeof example !== "undefined") {
+    allExamples.push(example)
+  }
+
+  return allExamples
+}

--- a/src/core/plugins/json-schema-2020-12-samples/fn/core/utils.js
+++ b/src/core/plugins/json-schema-2020-12-samples/fn/core/utils.js
@@ -21,3 +21,11 @@ export const typeCast = (schema) => {
 
   return schema
 }
+
+export const padZeros = (number, targetLength) => {
+  let numString = "" + number
+  while (numString.length < targetLength) {
+    numString = "0" + numString
+  }
+  return numString
+}

--- a/src/core/plugins/json-schema-2020-12-samples/fn/generators/date-time.js
+++ b/src/core/plugins/json-schema-2020-12-samples/fn/generators/date-time.js
@@ -1,6 +1,9 @@
 /**
  * @prettier
  */
-const dateTimeGenerator = () => new Date().toISOString()
+import { padZeros } from "../core/utils"
+
+const dateTimeGenerator = (_, {idx} = {}) =>
+  Number.isInteger(idx) ? `2${padZeros(idx, 3)}-10-04T20:20:39Z` : new Date().toISOString()
 
 export default dateTimeGenerator

--- a/src/core/plugins/json-schema-2020-12-samples/fn/generators/date.js
+++ b/src/core/plugins/json-schema-2020-12-samples/fn/generators/date.js
@@ -1,6 +1,9 @@
 /**
  * @prettier
  */
-const dateGenerator = () => new Date().toISOString().substring(0, 10)
+import { padZeros } from "../core/utils"
+
+const dateGenerator = (_, {idx} = {}) =>
+  Number.isInteger(idx) ? `2${padZeros(idx, 3)}-10-04` : new Date().toISOString().substring(0, 10)
 
 export default dateGenerator

--- a/src/core/plugins/json-schema-2020-12-samples/fn/generators/duration.js
+++ b/src/core/plugins/json-schema-2020-12-samples/fn/generators/duration.js
@@ -1,6 +1,7 @@
 /**
  * @prettier
  */
-const durationGenerator = () => "P3D" // expresses a duration of 3 days
+const durationGenerator = (_, {idx} = {}) =>
+  Number.isInteger(idx) ? `P${idx}D` : "P3D" // expresses a duration of 3 days
 
 export default durationGenerator

--- a/src/core/plugins/json-schema-2020-12-samples/fn/generators/email.js
+++ b/src/core/plugins/json-schema-2020-12-samples/fn/generators/email.js
@@ -1,6 +1,7 @@
 /**
  * @prettier
  */
-const emailGenerator = () => "user@example.com"
+const emailGenerator = (_, {idx} = {}) =>
+  Number.isInteger(idx) ? `user${idx}@example.com` : "user@example.com"
 
 export default emailGenerator

--- a/src/core/plugins/json-schema-2020-12-samples/fn/generators/hostname.js
+++ b/src/core/plugins/json-schema-2020-12-samples/fn/generators/hostname.js
@@ -1,6 +1,7 @@
 /**
  * @prettier
  */
-const hostnameGenerator = () => "example.com"
+const hostnameGenerator = (_, {idx} = {}) =>
+  Number.isInteger(idx) ? `example${idx}.com` : "example.com"
 
 export default hostnameGenerator

--- a/src/core/plugins/json-schema-2020-12-samples/fn/generators/idn-email.js
+++ b/src/core/plugins/json-schema-2020-12-samples/fn/generators/idn-email.js
@@ -1,6 +1,7 @@
 /**
  * @prettier
  */
-const idnEmailGenerator = () => "실례@example.com"
+const idnEmailGenerator = (_, {idx} = {}) =>
+  Number.isInteger(idx) ? `실례${idx}@example.com` : "실례@example.com"
 
 export default idnEmailGenerator

--- a/src/core/plugins/json-schema-2020-12-samples/fn/generators/idn-hostname.js
+++ b/src/core/plugins/json-schema-2020-12-samples/fn/generators/idn-hostname.js
@@ -1,6 +1,7 @@
 /**
  * @prettier
  */
-const idnHostnameGenerator = () => "실례.com"
+const idnHostnameGenerator = (_, {idx} = {}) =>
+  Number.isInteger(idx) ? `실례${idx}.com` : "실례.com"
 
 export default idnHostnameGenerator

--- a/src/core/plugins/json-schema-2020-12-samples/fn/generators/ipv4.js
+++ b/src/core/plugins/json-schema-2020-12-samples/fn/generators/ipv4.js
@@ -1,6 +1,7 @@
 /**
  * @prettier
  */
-const ipv4Generator = () => "198.51.100.42"
+const ipv4Generator = (_, {idx} = {}) =>
+  Number.isInteger(idx) ? `198.51.${idx}.42` : "198.51.100.42"
 
 export default ipv4Generator

--- a/src/core/plugins/json-schema-2020-12-samples/fn/generators/ipv6.js
+++ b/src/core/plugins/json-schema-2020-12-samples/fn/generators/ipv6.js
@@ -1,6 +1,9 @@
 /**
  * @prettier
  */
-const ipv6Generator = () => "2001:0db8:5b96:0000:0000:426f:8e17:642a"
+import { padZeros } from "../core/utils"
+
+const ipv6Generator = (_, {idx} = {}) =>
+  Number.isInteger(idx) ? `2${padZeros(idx, 3)}:0db8:5b96:0000:0000:426f:8e17:642a` : "2001:0db8:5b96:0000:0000:426f:8e17:642a"
 
 export default ipv6Generator

--- a/src/core/plugins/json-schema-2020-12-samples/fn/generators/iri-reference.js
+++ b/src/core/plugins/json-schema-2020-12-samples/fn/generators/iri-reference.js
@@ -1,6 +1,7 @@
 /**
  * @prettier
  */
-const iriReferenceGenerator = () => "path/실례.html"
+const iriReferenceGenerator = (_, {idx} = {}) =>
+  Number.isInteger(idx) ? `path${idx}/실례.html` : "path/실례.html"
 
 export default iriReferenceGenerator

--- a/src/core/plugins/json-schema-2020-12-samples/fn/generators/iri.js
+++ b/src/core/plugins/json-schema-2020-12-samples/fn/generators/iri.js
@@ -1,6 +1,7 @@
 /**
  * @prettier
  */
-const iriGenerator = () => "https://실례.com/"
+const iriGenerator = (_, {idx} = {}) =>
+  Number.isInteger(idx) ? `https://실례${idx}.com/` : "https://실례.com/"
 
 export default iriGenerator

--- a/src/core/plugins/json-schema-2020-12-samples/fn/generators/json-pointer.js
+++ b/src/core/plugins/json-schema-2020-12-samples/fn/generators/json-pointer.js
@@ -1,6 +1,7 @@
 /**
  * @prettier
  */
-const jsonPointerGenerator = () => "/a/b/c"
+const jsonPointerGenerator = (_, {idx} = {}) =>
+  Number.isInteger(idx) ? `/a${idx}/b/c` : "/a/b/c"
 
 export default jsonPointerGenerator

--- a/src/core/plugins/json-schema-2020-12-samples/fn/generators/media-types/application.js
+++ b/src/core/plugins/json-schema-2020-12-samples/fn/generators/media-types/application.js
@@ -5,12 +5,12 @@ import { bytes } from "../../core/random"
 
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
 const applicationMediaTypesGenerators = {
-  "application/json": () => '{"key":"value"}',
-  "application/ld+json": () => '{"name": "John Doe"}',
-  "application/x-httpd-php": () => "<?php echo '<p>Hello World!</p>'; ?>",
-  "application/rtf": () => String.raw`{\rtf1\adeflang1025\ansi\ansicpg1252\uc1`,
-  "application/x-sh": () => 'echo "Hello World!"',
-  "application/xhtml+xml": () => "<p>content</p>",
+  "application/json": (_, {idx} = {}) => Number.isInteger(idx) ? `{"key${idx}":"value${idx}"}` : '{"key":"value"}',
+  "application/ld+json": (_, {idx} = {}) => Number.isInteger(idx) ? `{"name": "John Doe${idx}"}` : '{"name": "John Doe"}',
+  "application/x-httpd-php": (_, {idx} = {}) => Number.isInteger(idx) ? `<?php echo '<p>Hello World${idx}!</p>'; ?>` : "<?php echo '<p>Hello World!</p>'; ?>",
+  "application/rtf": (_, {idx} = {}) => Number.isInteger(idx) ? String.raw`{\rtf1\adeflang${idx}025\ansi\ansicpg1252\uc1` : String.raw`{\rtf1\adeflang1025\ansi\ansicpg1252\uc1`,
+  "application/x-sh": (_, {idx} = {}) => Number.isInteger(idx) ? `echo "Hello World${idx}!"` : 'echo "Hello World!"',
+  "application/xhtml+xml": (_, {idx} = {}) => Number.isInteger(idx) ? `<p>content${idx}</p>` : "<p>content</p>",
   "application/*": () => bytes(25).toString("binary"),
 }
 

--- a/src/core/plugins/json-schema-2020-12-samples/fn/generators/media-types/text.js
+++ b/src/core/plugins/json-schema-2020-12-samples/fn/generators/media-types/text.js
@@ -4,14 +4,14 @@
 
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
 const textMediaTypesGenerators = {
-  "text/plain": () => "string",
-  "text/css": () => ".selector { border: 1px solid red }",
-  "text/csv": () => "value1,value2,value3",
-  "text/html": () => "<p>content</p>",
-  "text/calendar": () => "BEGIN:VCALENDAR",
-  "text/javascript": () => "console.dir('Hello world!');",
-  "text/xml": () => '<person age="30">John Doe</person>',
-  "text/*": () => "string",
+  "text/plain": (_, {idx} = {}) => Number.isInteger(idx) ? `string${idx}` : "string",
+  "text/css": (_, {idx} = {}) => Number.isInteger(idx) ? `.selector { border: ${idx}px solid red }` : ".selector { border: 1px solid red }",
+  "text/csv": (_, {idx} = {}) => Number.isInteger(idx) ? `value${idx},value${idx+1},value${idx+2}` : "value1,value2,value3",
+  "text/html": (_, {idx} = {}) => Number.isInteger(idx) ? `<p>content${idx}</p>` : "<p>content</p>",
+  "text/calendar": (_, {idx} = {}) => Number.isInteger(idx) ? `BEGIN:VCALENDAR\nSEQUENCE:${idx}` : "BEGIN:VCALENDAR",
+  "text/javascript": (_, {idx} = {}) => Number.isInteger(idx) ? `console.dir('Hello world${idx}!');` : "console.dir('Hello world!');",
+  "text/xml": (_, {idx} = {}) => Number.isInteger(idx) ? `<person age="${idx}">John Doe</person>` : '<person age="30">John Doe</person>',
+  "text/*": (_, {idx} = {}) => Number.isInteger(idx) ? `string${idx}` : "string",
 }
 
 export default textMediaTypesGenerators

--- a/src/core/plugins/json-schema-2020-12-samples/fn/generators/regex.js
+++ b/src/core/plugins/json-schema-2020-12-samples/fn/generators/regex.js
@@ -1,6 +1,7 @@
 /**
  * @prettier
  */
-const regexGenerator = () => "^[a-z]+$"
+const regexGenerator = (_, {idx} = {}) =>
+  Number.isInteger(idx) ? `^[a-z]{${idx}}$` : "^[a-z]+$"
 
 export default regexGenerator

--- a/src/core/plugins/json-schema-2020-12-samples/fn/generators/relative-json-pointer.js
+++ b/src/core/plugins/json-schema-2020-12-samples/fn/generators/relative-json-pointer.js
@@ -1,6 +1,7 @@
 /**
  * @prettier
  */
-const relativeJsonPointerGenerator = () => "1/0"
+const relativeJsonPointerGenerator = (_, {idx} = {}) =>
+  Number.isInteger(idx) ? idx + "/0" : "1/0"
 
 export default relativeJsonPointerGenerator

--- a/src/core/plugins/json-schema-2020-12-samples/fn/generators/time.js
+++ b/src/core/plugins/json-schema-2020-12-samples/fn/generators/time.js
@@ -1,6 +1,9 @@
 /**
  * @prettier
  */
-const timeGenerator = () => new Date().toISOString().substring(11)
+import { padZeros } from "../core/utils"
+
+const timeGenerator = (_, {idx} = {}) =>
+  Number.isInteger(idx) ? `20:20:${padZeros(idx, 2)}Z` : new Date().toISOString().substring(11)
 
 export default timeGenerator

--- a/src/core/plugins/json-schema-2020-12-samples/fn/generators/uri-reference.js
+++ b/src/core/plugins/json-schema-2020-12-samples/fn/generators/uri-reference.js
@@ -1,6 +1,7 @@
 /**
  * @prettier
  */
-const uriReferenceGenerator = () => "path/index.html"
+const uriReferenceGenerator = (_, {idx} = {}) =>
+  Number.isInteger(idx) ? `path${idx}/index.html` : "path/index.html"
 
 export default uriReferenceGenerator

--- a/src/core/plugins/json-schema-2020-12-samples/fn/generators/uri-template.js
+++ b/src/core/plugins/json-schema-2020-12-samples/fn/generators/uri-template.js
@@ -1,7 +1,7 @@
 /**
  * @prettier
  */
-const uriTemplateGenerator = () =>
-  "https://example.com/dictionary/{term:1}/{term}"
+const uriTemplateGenerator = (_, {idx} = {}) =>
+  Number.isInteger(idx) ? `https://example${idx}.com/dictionary/{term:1}/{term}` : "https://example.com/dictionary/{term:1}/{term}"
 
 export default uriTemplateGenerator

--- a/src/core/plugins/json-schema-2020-12-samples/fn/generators/uri.js
+++ b/src/core/plugins/json-schema-2020-12-samples/fn/generators/uri.js
@@ -1,6 +1,7 @@
 /**
  * @prettier
  */
-const uriGenerator = () => "https://example.com/"
+const uriGenerator = (_, {idx} = {}) =>
+  Number.isInteger(idx) ? `https://example${idx}.com/` : "https://example.com/"
 
 export default uriGenerator

--- a/src/core/plugins/json-schema-2020-12-samples/fn/generators/uuid.js
+++ b/src/core/plugins/json-schema-2020-12-samples/fn/generators/uuid.js
@@ -1,6 +1,9 @@
 /**
  * @prettier
  */
-const uuidGenerator = () => "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+import { padZeros } from "../core/utils"
+
+const uuidGenerator = (_, {idx} = {}) =>
+  Number.isInteger(idx) ? padZeros(idx, 8) + "-5717-4562-b3fc-2c963f66afa6" : "3fa85f64-5717-4562-b3fc-2c963f66afa6"
 
 export default uuidGenerator

--- a/src/core/plugins/json-schema-2020-12-samples/fn/types/integer.js
+++ b/src/core/plugins/json-schema-2020-12-samples/fn/types/integer.js
@@ -3,8 +3,6 @@
  */
 import { integer as randomInteger } from "../core/random"
 import formatAPI from "../api/formatAPI"
-import int32Generator from "../generators/int32"
-import int64Generator from "../generators/int64"
 
 const generateFormat = (schema) => {
   const { format } = schema
@@ -12,15 +10,6 @@ const generateFormat = (schema) => {
   const formatGenerator = formatAPI(format)
   if (typeof formatGenerator === "function") {
     return formatGenerator(schema)
-  }
-
-  switch (format) {
-    case "int32": {
-      return int32Generator()
-    }
-    case "int64": {
-      return int64Generator()
-    }
   }
 
   return randomInteger()

--- a/src/core/plugins/json-schema-2020-12-samples/fn/types/number.js
+++ b/src/core/plugins/json-schema-2020-12-samples/fn/types/number.js
@@ -3,8 +3,6 @@
  */
 import { number as randomNumber } from "../core/random"
 import formatAPI from "../api/formatAPI"
-import floatGenerator from "../generators/float"
-import doubleGenerator from "../generators/double"
 
 const generateFormat = (schema) => {
   const { format } = schema
@@ -12,15 +10,6 @@ const generateFormat = (schema) => {
   const formatGenerator = formatAPI(format)
   if (typeof formatGenerator === "function") {
     return formatGenerator(schema)
-  }
-
-  switch (format) {
-    case "float": {
-      return floatGenerator()
-    }
-    case "double": {
-      return doubleGenerator()
-    }
   }
 
   return randomNumber()

--- a/test/unit/core/plugins/json-schema-2020-12-samples/fn.js
+++ b/test/unit/core/plugins/json-schema-2020-12-samples/fn.js
@@ -1451,6 +1451,472 @@ describe("sampleFromSchema", () => {
     expect(sampleFromSchema(definition)).toEqual(expected)
   })
 
+  it("should handle additionalProperties with propertyNames examples", () => {
+    const definition = {
+      type: "object",
+      propertyNames: {
+        examples: ["firstprop", "secondprop"]
+      },
+      additionalProperties: {
+        type: "string",
+      },
+    }
+
+    const expected = {
+      firstprop: "string",
+      secondprop: "string",
+    }
+
+    expect(sampleFromSchema(definition)).toEqual(expected)
+  })
+
+  it("should handle additionalProperties with propertyNames examples in conjunction with minProperties", () => {
+    const definition = {
+      type: "object",
+      minProperties: 4,
+      propertyNames: {
+        examples: ["firstprop", "secondprop"]
+      },
+      additionalProperties: {
+        type: "string",
+      },
+    }
+
+    const expected = {
+      firstprop: "string",
+      secondprop: "string",
+      additionalProp3: "string",
+      additionalProp4: "string",
+    }
+
+    expect(sampleFromSchema(definition)).toEqual(expected)
+  })
+
+  it("should handle additionalProperties with propertyNames const", () => {
+    const definition = {
+      type: "object",
+      propertyNames: {
+        const: "constprop"
+      },
+      additionalProperties: {
+        type: "string",
+      },
+    }
+
+    const expected = {
+      constprop: "string",
+    }
+
+    expect(sampleFromSchema(definition)).toEqual(expected)
+  })
+
+  it("should handle additionalProperties with propertyNames enum", () => {
+    const definition = {
+      type: "object",
+      propertyNames: {
+        enum: ["firstprop", "secondprop"]
+      },
+      additionalProperties: {
+        type: "string",
+      },
+    }
+
+    const expected = {
+      firstprop: "string",
+      secondprop: "string",
+    }
+
+    expect(sampleFromSchema(definition)).toEqual(expected)
+  })
+
+  it("should handle additionalProperties with propertyNames pattern", () => {
+    const definition = {
+      type: "object",
+      propertyNames: {
+        pattern: "^abc$"
+      },
+      maxProperties: 1,
+      additionalProperties: {
+        type: "string",
+      },
+    }
+
+    const expected = {
+      abc: "string",
+    }
+
+    expect(sampleFromSchema(definition)).toEqual(expected)
+  })
+
+  it("should handle additionalProperties with propertyNames format", () => {
+    const definition = {
+      type: "object",
+      properties: {
+        email: {
+          type: "object",
+          propertyNames: {
+            format: "email"
+          },
+          maxProperties: 2,
+          additionalProperties: {
+            type: "integer",
+          },
+        },
+        "idn-email": {
+          type: "object",
+          propertyNames: {
+            format: "idn-email"
+          },
+          maxProperties: 2,
+          additionalProperties: {
+            type: "integer",
+          },
+        },
+        hostname: {
+          type: "object",
+          propertyNames: {
+            format: "hostname"
+          },
+          maxProperties: 2,
+          additionalProperties: {
+            type: "integer",
+          },
+        },
+        "idn-hostname": {
+          type: "object",
+          propertyNames: {
+            format: "idn-hostname"
+          },
+          maxProperties: 2,
+          additionalProperties: {
+            type: "integer",
+          },
+        },
+        ipv4: {
+          type: "object",
+          propertyNames: {
+            format: "ipv4"
+          },
+          maxProperties: 2,
+          additionalProperties: {
+            type: "integer",
+          },
+        },
+        ipv6: {
+          type: "object",
+          propertyNames: {
+            format: "ipv6"
+          },
+          maxProperties: 2,
+          additionalProperties: {
+            type: "integer",
+          },
+        },
+        uri: {
+          propertyNames: {
+            format: "uri"
+          },
+          maxProperties: 2,
+          additionalProperties: {
+            type: "integer",
+          },
+        },
+        "uri-reference": {
+          propertyNames: {
+            format: "uri-reference"
+          },
+          maxProperties: 2,
+          additionalProperties: {
+            type: "integer",
+          },
+        },
+        iri: {
+          propertyNames: {
+            format: "iri"
+          },
+          maxProperties: 2,
+          additionalProperties: {
+            type: "integer",
+          },
+        },
+        "iri-reference": {
+          propertyNames: {
+            format: "iri-reference"
+          },
+          maxProperties: 2,
+          additionalProperties: {
+            type: "integer",
+          },
+        },
+        "uri-template": {
+          propertyNames: {
+            format: "uri-template"
+          },
+          maxProperties: 2,
+          additionalProperties: {
+            type: "integer",
+          },
+        },
+        uuid: {
+          type: "object",
+          propertyNames: {
+            format: "uuid"
+          },
+          maxProperties: 2,
+          additionalProperties: {
+            type: "integer",
+          },
+        },
+        "json-pointer": {
+          type: "object",
+          propertyNames: {
+            format: "json-pointer"
+          },
+          maxProperties: 2,
+          additionalProperties: {
+            type: "integer",
+          },
+        },
+        "relative-json-pointer": {
+          type: "object",
+          propertyNames: {
+            format: "relative-json-pointer"
+          },
+          maxProperties: 2,
+          additionalProperties: {
+            type: "integer",
+          },
+        },
+        regex: {
+          type: "object",
+          propertyNames: {
+            format: "regex"
+          },
+          maxProperties: 2,
+          additionalProperties: {
+            type: "integer",
+          },
+        },
+        date: {
+          type: "object",
+          propertyNames: {
+            format: "date"
+          },
+          maxProperties: 2,
+          additionalProperties: {
+            type: "integer",
+          },
+        },
+        "date-time": {
+          type: "object",
+          propertyNames: {
+            format: "date-time"
+          },
+          maxProperties: 2,
+          additionalProperties: {
+            type: "integer",
+          },
+        },
+        time: {
+          type: "object",
+          propertyNames: {
+            format: "time"
+          },
+          maxProperties: 2,
+          additionalProperties: {
+            type: "integer",
+          },
+        },
+        duration: {
+          type: "object",
+          propertyNames: {
+            format: "duration"
+          },
+          maxProperties: 2,
+          additionalProperties: {
+            type: "integer",
+          },
+        },
+      }
+    }
+
+    const expected = {
+      "email": {
+        "user1@example.com": 0,
+        "user2@example.com": 0,
+      },
+      "idn-email": {
+        "실례1@example.com": 0,
+        "실례2@example.com": 0,
+      },
+      "hostname": {
+        "example1.com": 0,
+        "example2.com": 0,
+      },
+      "idn-hostname": {
+        "실례1.com": 0,
+        "실례2.com": 0,
+      },
+      "ipv4": {
+        "198.51.1.42": 0,
+        "198.51.2.42": 0,
+      },
+      "ipv6": {
+        "2001:0db8:5b96:0000:0000:426f:8e17:642a": 0,
+        "2002:0db8:5b96:0000:0000:426f:8e17:642a": 0,
+      },
+      "uri": {
+        "https://example1.com/": 0,
+        "https://example2.com/": 0,
+      },
+      "uri-reference": {
+        "path1/index.html": 0,
+        "path2/index.html": 0,
+      },
+      "iri": {
+        "https://실례1.com/": 0,
+        "https://실례2.com/": 0,
+      },
+      "iri-reference": {
+        "path1/실례.html": 0,
+        "path2/실례.html": 0,
+      },
+      "uri-template": {
+        "https://example1.com/dictionary/{term:1}/{term}": 0,
+        "https://example2.com/dictionary/{term:1}/{term}": 0,
+      },
+      "uuid": {
+        "00000001-5717-4562-b3fc-2c963f66afa6": 0,
+        "00000002-5717-4562-b3fc-2c963f66afa6": 0,
+      },
+      "json-pointer": {
+        "/a1/b/c": 0,
+        "/a2/b/c": 0,
+      },
+      "relative-json-pointer": {
+        "1/0": 0,
+        "2/0": 0,
+      },
+      "regex": {
+        "^[a-z]{1}$": 0,
+        "^[a-z]{2}$": 0,
+      },
+      "date": {
+        "2001-10-04": 0,
+        "2002-10-04": 0,
+      },
+      "date-time": {
+        "2001-10-04T20:20:39Z": 0,
+        "2002-10-04T20:20:39Z": 0,
+      },
+      "time": {
+        "20:20:01Z": 0,
+        "20:20:02Z": 0,
+      },
+      "duration": {
+        "P1D": 0,
+        "P2D": 0,
+      },
+    }
+
+    expect(sampleFromSchema(definition)).toEqual(expected)
+  })
+
+  it("should handle additionalProperties with propertyNames mediaType", () => {
+    const definition = {
+      type: "object",
+      properties: {
+        "text/plain": {
+          type: "object",
+          propertyNames: {
+            contentMediaType: "text/plain"
+          },
+          maxProperties: 2,
+          additionalProperties: {
+            type: "boolean",
+          },
+        },
+        "text/html": {
+          type: "object",
+          propertyNames: {
+            contentMediaType: "text/html"
+          },
+          maxProperties: 2,
+          additionalProperties: {
+            type: "boolean",
+          },
+        },
+        "application/json": {
+          type: "object",
+          propertyNames: {
+            contentMediaType: "application/json"
+          },
+          maxProperties: 2,
+          additionalProperties: {
+            type: "boolean",
+          },
+        },
+      }
+    }
+
+    const expected = {
+      "text/plain": {
+        "string1": true,
+        "string2": true,
+      },
+      "text/html": {
+        "<p>content1</p>": true,
+        "<p>content2</p>": true,
+      },
+      "application/json": {
+        '{"key1":"value1"}': true,
+        '{"key2":"value2"}': true,
+      },
+    }
+
+    expect(sampleFromSchema(definition)).toEqual(expected)
+  })
+
+  it("should handle additionalProperties with propertyNames minLength", () => {
+    const definition = {
+      type: "object",
+      propertyNames: {
+        minLength: 17
+      },
+      additionalProperties: {
+        type: "string",
+      },
+    }
+
+    const expected = {
+      additionalProp001: "string",
+      additionalProp002: "string",
+      additionalProp003: "string",
+    }
+
+    expect(sampleFromSchema(definition)).toEqual(expected)
+  })
+
+  it("should handle additionalProperties with propertyNames maxLength", () => {
+    const definition = {
+      type: "object",
+      propertyNames: {
+        maxLength: 1
+      },
+      additionalProperties: {
+        type: "string",
+      },
+    }
+
+    const expected = {
+      1: "string",
+      2: "string",
+      3: "string",
+    }
+
+    expect(sampleFromSchema(definition)).toEqual(expected)
+  })
+
   it("should handle minItems", () => {
     const definition = {
       type: "array",


### PR DESCRIPTION
Use propertyNames schema to generate property names for samples with additionalProperties

Refs #8913
Resolves #5713

### Description
Json Schema 2020-12 has support for supplying a propertyNames schema, which the names of the (additional) properties in the object have to adhere to. However when generating samples this was currently ignored and the the properties would always be named additionalProp1, additionalProp2 etc. With this PR, the property names in the samples will follow the propertyNames schema. Property names are always strings, so this is mostly reusing the existing code of sample generation for string values. Except objects cannot have multiple properties with the same name, so the string generation now supports adding in an index in the places where it was previously producing fixed values.

### Motivation and Context
Many schemas describe dictionaries that map variable property names to property values, which is modeled with additionalProperties. As described in #5713 , the generated samples with additionalPropx have issues: 1) they are not good for readability as they don't provide any context; 2) they may actually be violating the propertyNames schema; and 3) the number of additional property samples cannot be controlled. Writing custom examples is not a good solution, because typically these additional properties have full-fledged object schemas as values, so then all the power of the very useful auto-generated samples is lost. This feature generates additional property names according to the propertyNames schema (partial implementation of #8913), and the propertyNames examples can optionally be used to control the names and number of sample properties (resolution for #5713).

### How Has This Been Tested?
Added unit tests
Performed manual test

### Screenshots (if appropriate):
![propertynames](https://github.com/swagger-api/swagger-ui/assets/16798453/781ba894-7f1e-4259-baa3-3f73bc111430)

## Checklist

### My PR contains... 
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
