### PR TITLE
build(webpack): remove need for process provide

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -109,7 +109,6 @@
         "postcss-loader": "^8.1.1",
         "postcss-preset-env": "^9.5.2",
         "prettier": "^3.2.5",
-        "process": "^0.11.10",
         "react-refresh": "^0.14.0",
         "react-test-renderer": "^18.2.0",
         "release-it": "=17.1.1",

--- a/package.json
+++ b/package.json
@@ -171,7 +171,6 @@
     "postcss-loader": "^8.1.1",
     "postcss-preset-env": "^9.5.2",
     "prettier": "^3.2.5",
-    "process": "^0.11.10",
     "react-refresh": "^0.14.0",
     "react-test-renderer": "^18.2.0",
     "release-it": "=17.1.1",

--- a/webpack/_config-builder.js
+++ b/webpack/_config-builder.js
@@ -61,7 +61,6 @@ function buildConfig(
       }),
     }),
     new webpack.ProvidePlugin({
-      process: "process/browser",
       Buffer: ["buffer", "Buffer"],
     }),
   ]

--- a/webpack/es-bundle-core.js
+++ b/webpack/es-bundle-core.js
@@ -56,7 +56,6 @@ const result = configBuilder(
           "randombytes", // uses require('safe-buffer')
           "sha.js", // uses require('safe-buffer')
           "xml", // uses require('stream')
-          "process/browser", // is injected via ProvidePlugin
           /^readable-stream/, // byproduct of buffer ProvidePlugin injection
           "util-deprecate", // dependency of readable-stream
           "inherits", // dependency of readable-stream


### PR DESCRIPTION
There is now no dependency that use `process` without explicit import