### PR TITLE
refactor(config): disect & compose

### DIFF
--- a/src/core/config/defaults.js
+++ b/src/core/config/defaults.js
@@ -1,13 +1,10 @@
 /**
  * @prettier
  */
-import deepExtend from "deep-extend"
-
 import ApisPreset from "core/presets/apis"
-import { parseSearch } from "core/utils"
 
-const defaultConfig = {
-  // eslint-disable-next-line camelcase
+const defaultOptions = Object.freeze({
+  dom_id: null,
   domNode: null,
   spec: {},
   url: "",
@@ -37,17 +34,14 @@ const defaultConfig = {
   requestSnippetsEnabled: false,
   requestSnippets: {
     generators: {
-      // eslint-disable-next-line camelcase
       curl_bash: {
         title: "cURL (bash)",
         syntax: "bash",
       },
-      // eslint-disable-next-line camelcase
       curl_powershell: {
         title: "cURL (PowerShell)",
         syntax: "powershell",
       },
-      // eslint-disable-next-line camelcase
       curl_cmd: {
         title: "cURL (CMD)",
         syntax: "bash",
@@ -82,7 +76,6 @@ const defaultConfig = {
     pluginLoadType: "legacy",
   },
 
-  // Initial state
   initialState: {},
 
   // Inline Plugin
@@ -93,52 +86,6 @@ const defaultConfig = {
     activated: true,
     theme: "agate",
   },
-}
+})
 
-export const getConfigs = (opts) => {
-  const queryConfig = opts.queryConfigEnabled ? parseSearch() : {}
-
-  const combinedConfig = deepExtend({}, defaultConfig, opts, queryConfig)
-
-  const storeConfig = {
-    system: {
-      configs: combinedConfig.configs,
-    },
-    plugins: combinedConfig.presets,
-    pluginsOptions: combinedConfig.pluginsOptions,
-    state: deepExtend(
-      {
-        layout: {
-          layout: combinedConfig.layout,
-          filter: combinedConfig.filter,
-        },
-        spec: {
-          spec: "",
-          // support Relative References
-          url: combinedConfig.url,
-        },
-        requestSnippets: combinedConfig.requestSnippets,
-      },
-      combinedConfig.initialState
-    ),
-  }
-
-  if (combinedConfig.initialState) {
-    // if the user sets a key as `undefined`, that signals to us that we
-    // should delete the key entirely.
-    // known usage: Swagger-Editor validate plugin tests
-    for (var key in combinedConfig.initialState) {
-      if (
-        Object.prototype.hasOwnProperty.call(
-          combinedConfig.initialState,
-          key
-        ) &&
-        combinedConfig.initialState[key] === undefined
-      ) {
-        delete storeConfig.state[key]
-      }
-    }
-  }
-
-  return { queryConfig, combinedConfig, storeConfig }
-}
+export default defaultOptions

--- a/src/core/config/factorization/inline-plugin.js
+++ b/src/core/config/factorization/inline-plugin.js
@@ -1,0 +1,11 @@
+/**
+ * @prettier
+ */
+
+const InlinePluginFactorization = (options) => () => ({
+  fn: options.fn,
+  components: options.components,
+  state: options.state,
+})
+
+export default InlinePluginFactorization

--- a/src/core/config/factorization/store.js
+++ b/src/core/config/factorization/store.js
@@ -1,0 +1,45 @@
+/**
+ * @prettier
+ */
+import merge from "../merge"
+
+const storeFactorization = (options) => {
+  const state = merge(
+    {
+      layout: {
+        layout: options.layout,
+        filter: options.filter,
+      },
+      spec: {
+        spec: "",
+        url: options.url,
+      },
+      requestSnippets: options.requestSnippets,
+    },
+    options.initialState
+  )
+
+  if (options.initialState) {
+    /**
+     * If the user sets a key as `undefined`, that signals to us that we
+     * should delete the key entirely.
+     * known usage: Swagger-Editor validate plugin tests
+     */
+    for (const [key, value] of Object.entries(options.initialState)) {
+      if (value === undefined) {
+        delete state[key]
+      }
+    }
+  }
+
+  return {
+    system: {
+      configs: options.configs,
+    },
+    plugins: options.presets,
+    pluginsOptions: options.pluginsOptions,
+    state,
+  }
+}
+
+export default storeFactorization

--- a/src/core/config/index.js
+++ b/src/core/config/index.js
@@ -1,0 +1,7 @@
+export { default as inlinePluginOptionsFactorization }  from "./factorization/inline-plugin"
+export { default as storeOptionsFactorization }  from "./factorization/store"
+export { default as optionsFromQuery }  from "./sources/query"
+export { default as optionsFromURL }  from "./sources/url"
+export { default as optionsFromYAMLFile }  from "./sources/yaml-file"
+export { default as defaultOptions }  from "./defaults"
+export { default as mergeOptions }  from "./merge"

--- a/src/core/config/index.js
+++ b/src/core/config/index.js
@@ -2,6 +2,6 @@ export { default as inlinePluginOptionsFactorization }  from "./factorization/in
 export { default as storeOptionsFactorization }  from "./factorization/store"
 export { default as optionsFromQuery }  from "./sources/query"
 export { default as optionsFromURL }  from "./sources/url"
-export { default as optionsFromYAMLFile }  from "./sources/yaml-file"
+export { default as optionsFromSystem }  from "./sources/system"
 export { default as defaultOptions }  from "./defaults"
 export { default as mergeOptions }  from "./merge"

--- a/src/core/config/merge.js
+++ b/src/core/config/merge.js
@@ -1,0 +1,6 @@
+/**
+ * @prettier
+ */
+import merge from "lodash/merge"
+
+export default merge

--- a/src/core/config/merge.js
+++ b/src/core/config/merge.js
@@ -1,6 +1,15 @@
 /**
  * @prettier
+ *
+ * We're currently stuck with using deep-extend as it handles the following case:
+ *
+ * deepExtend({ a: 1 }, { a: undefined }) => { a: undefined }
+ *
+ * NOTE1: lodash.merge & lodash.mergeWith prefers to ignore undefined values
+ * NOTE2: oauth2RedirectUrl and withCredentials options can be set to undefined. By expecting null instead of undefined, we can't use lodash.merge.
+ *
+ * TODO(vladimir.gorej@gmail.com): remove deep-extend in favor of lodash.merge
  */
-import merge from "lodash/merge"
+import deepExtend from "deep-extend"
 
-export default merge
+export default deepExtend

--- a/src/core/config/merge.js
+++ b/src/core/config/merge.js
@@ -6,10 +6,35 @@
  * deepExtend({ a: 1 }, { a: undefined }) => { a: undefined }
  *
  * NOTE1: lodash.merge & lodash.mergeWith prefers to ignore undefined values
- * NOTE2: oauth2RedirectUrl and withCredentials options can be set to undefined. By expecting null instead of undefined, we can't use lodash.merge.
+ * NOTE2: special handling of `domNode` option is now required as `deep-extend` will corrupt it (lodash.merge handles it correctly)
+ * NOTE3: oauth2RedirectUrl and withCredentials options can be set to undefined. By expecting null instead of undefined, we can't use lodash.merge.
  *
  * TODO(vladimir.gorej@gmail.com): remove deep-extend in favor of lodash.merge
  */
 import deepExtend from "deep-extend"
 
-export default deepExtend
+const merge = (target, ...sources) => {
+  let domNode = Symbol.for("domNode")
+  const sourcesWithoutDomNode = []
+
+  for (const source of sources) {
+    if (Object.hasOwn(source, "domNode")) {
+      domNode = source.domNode
+      const sourceWithoutDomNode = { ...source }
+      delete sourceWithoutDomNode.domNode
+      sourcesWithoutDomNode.push(sourceWithoutDomNode)
+    } else {
+      sourcesWithoutDomNode.push(source)
+    }
+  }
+
+  const merged = deepExtend(target, ...sourcesWithoutDomNode)
+
+  if (domNode !== Symbol.for("domNode")) {
+    merged.domNode = domNode
+  }
+
+  return merged
+}
+
+export default merge

--- a/src/core/config/sources/query.js
+++ b/src/core/config/sources/query.js
@@ -1,0 +1,15 @@
+/**
+ * @prettier
+ */
+import { parseSearch } from "core/utils"
+
+/**
+ * Receives options from the query string of the URL where SwaggerUI
+ * is being served.
+ */
+
+const optionsFromQuery = () => (options) => {
+  return options.queryConfigEnabled ? parseSearch() : {}
+}
+
+export default optionsFromQuery

--- a/src/core/config/sources/system.js
+++ b/src/core/config/sources/system.js
@@ -1,9 +1,11 @@
 /**
  * @prettier
- * Receives options from a local YAML file.
+ *
+ * Receives options from a System.
+ * These options are baked-in to the System during the compile time.
  */
 
-const optionsFromYAMLFile =
+const optionsFromSystem =
   ({ system }) =>
   () => {
     if (typeof system.specSelectors?.getLocalConfig !== "function") return {}
@@ -11,4 +13,4 @@ const optionsFromYAMLFile =
     return system.specSelectors.getLocalConfig()
   }
 
-export default optionsFromYAMLFile
+export default optionsFromSystem

--- a/src/core/config/sources/url.js
+++ b/src/core/config/sources/url.js
@@ -1,0 +1,33 @@
+/**
+ * @prettier
+ * Receives options from a remote URL.
+ */
+
+const optionsFromURL =
+  ({ url, system }) =>
+  async (options) => {
+    if (!url) return {}
+    if (typeof system.specActions?.getConfigByUrl !== "function") return {}
+    let resolve
+    const deferred = new Promise((res) => {
+      resolve = res
+    })
+    const callback = (fetchedOptions) => {
+      // receives null on remote URL fetch failure
+      resolve(fetchedOptions)
+    }
+
+    system.specActions.getConfigByUrl(
+      {
+        url,
+        loadRemoteConfig: true,
+        requestInterceptor: options.requestInterceptor,
+        responseInterceptor: options.responseInterceptor,
+      },
+      callback
+    )
+
+    return deferred
+  }
+
+export default optionsFromURL

--- a/src/core/config/sources/yaml-file.js
+++ b/src/core/config/sources/yaml-file.js
@@ -1,0 +1,14 @@
+/**
+ * @prettier
+ * Receives options from a local YAML file.
+ */
+
+const optionsFromYAMLFile =
+  ({ system }) =>
+  () => {
+    if (typeof system.specSelectors?.getLocalConfig !== "function") return {}
+
+    return system.specSelectors.getLocalConfig()
+  }
+
+export default optionsFromYAMLFile

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -1,5 +1,3 @@
-import deepExtend from "deep-extend"
-
 import System from "./system"
 // presets
 import BasePreset from "./presets/base"
@@ -30,14 +28,19 @@ import DownloadUrlPlugin from "./plugins/download-url"
 import SyntaxHighlightingPlugin from "core/plugins/syntax-highlighting"
 import SafeRenderPlugin from "./plugins/safe-render"
 
-import { getConfigs } from "./config"
 import win from "./window"
+import defaultOptions from "./config/defaults"
+import optionsFromQuery from "./config/sources/query"
+import optionsFromUrl from "./config/sources/url"
+import optionsFromYAMLFile from "./config/sources/yaml-file"
+import mergeOptions from "./config/merge"
+import storeOptionsFactorization from "./config/factorization/store"
+import inlinePluginOptionsFactorization from "./config/factorization/inline-plugin"
 
 // eslint-disable-next-line no-undef
 const { GIT_DIRTY, GIT_COMMIT, PACKAGE_VERSION, BUILD_TIME } = buildInfo
 
-export default function SwaggerUI(opts) {
-
+export default function SwaggerUI(options) {
   win.versions = win.versions || {}
   win.versions.swaggerUi = {
     version: PACKAGE_VERSION,
@@ -46,74 +49,50 @@ export default function SwaggerUI(opts) {
     buildTimestamp: BUILD_TIME,
   }
 
-  const domNode = opts.domNode
-  delete opts.domNode
+  const queryOptions = optionsFromQuery()(options)
+  let mergedOptions = mergeOptions({}, defaultOptions, options, queryOptions)
+  const storeOptions = storeOptionsFactorization(mergedOptions)
+  const InlinePlugin = inlinePluginOptionsFactorization(mergedOptions)
 
-  const { queryConfig, combinedConfig, storeConfig } = getConfigs(opts)
 
-  const inlinePlugin = ()=> {
-    return {
-      fn: combinedConfig.fn,
-      components: combinedConfig.components,
-      state: combinedConfig.state,
-    }
-  }
-
-  const store = new System(storeConfig)
-  store.register([combinedConfig.plugins, inlinePlugin])
-
+  const store = new System(storeOptions)
+  store.register([mergedOptions.plugins, InlinePlugin])
   const system = store.getSystem()
 
-  const downloadSpec = (fetchedConfig) => {
-    const localConfig = system.specSelectors.getLocalConfig ? system.specSelectors.getLocalConfig() : {}
-    const mergedConfig = deepExtend({}, localConfig, combinedConfig, fetchedConfig || {}, queryConfig)
+  const configURL = queryOptions.config ?? mergedOptions.configUrl
+  const yamlFileOptions = optionsFromYAMLFile({ system })(mergedOptions)
 
-    // deep extend mangles domNode, we need to set it manually
-    if(domNode) {
-      mergedConfig.domNode = domNode
-    }
+  optionsFromUrl({ url: configURL, system })(mergedOptions)
+    .then((urlOptions) => {
+      const urlOptionsFailedToFetch = urlOptions === null
 
-    store.setConfigs(mergedConfig)
-    system.configsActions.loaded()
+      mergedOptions = mergeOptions({}, yamlFileOptions, mergedOptions, urlOptions, queryOptions)
+      store.setConfigs(mergedOptions)
+      system.configsActions.loaded()
 
-    if (fetchedConfig !== null) {
-      if (!queryConfig.url && typeof mergedConfig.spec === "object" && Object.keys(mergedConfig.spec).length) {
-        system.specActions.updateUrl("")
-        system.specActions.updateLoadingStatus("success")
-        system.specActions.updateSpec(JSON.stringify(mergedConfig.spec))
-      } else if (system.specActions.download && mergedConfig.url && !mergedConfig.urls) {
-        system.specActions.updateUrl(mergedConfig.url)
-        system.specActions.download(mergedConfig.url)
+      if (!urlOptionsFailedToFetch) {
+        if (!queryOptions.url && typeof mergedOptions.spec === "object" && Object.keys(mergedOptions.spec).length > 0) {
+          system.specActions.updateUrl("")
+          system.specActions.updateLoadingStatus("success")
+          system.specActions.updateSpec(JSON.stringify(mergedOptions.spec))
+        } else if (typeof system.specActions.download === "function" && mergedOptions.url && !mergedOptions.urls) {
+          system.specActions.updateUrl(mergedOptions.url)
+          system.specActions.download(mergedOptions.url)
+        }
       }
-    }
 
-    if(mergedConfig.domNode) {
-      system.render(mergedConfig.domNode, "App")
-    } else if(mergedConfig.dom_id) {
-      let domNode = document.querySelector(mergedConfig.dom_id)
-      system.render(domNode, "App")
-    } else if(mergedConfig.dom_id === null || mergedConfig.domNode === null) {
-      // do nothing
-      // this is useful for testing that does not need to do any rendering
-    } else {
-      console.error("Skipped rendering: no `dom_id` or `domNode` was specified")
-    }
-
-    return system
-  }
-
-  const configUrl = combinedConfig.configUrl
-
-  if (configUrl && system.specActions && system.specActions.getConfigByUrl) {
-    system.specActions.getConfigByUrl({
-      url: configUrl,
-      loadRemoteConfig: true,
-      requestInterceptor: combinedConfig.requestInterceptor,
-      responseInterceptor: combinedConfig.responseInterceptor,
-    }, downloadSpec)
-  } else {
-    return downloadSpec()
-  }
+      if (mergedOptions.domNode) {
+        system.render(mergedOptions.domNode, "App")
+      } else if(mergedOptions.dom_id) {
+        let domNode = document.querySelector(mergedOptions.dom_id)
+        system.render(domNode, "App")
+      } else if(mergedOptions.dom_id === null || mergedOptions.domNode === null) {
+        // do nothing
+        // this is useful for testing that does not need to do any rendering
+      } else {
+        console.error("Skipped rendering: no `dom_id` or `domNode` was specified")
+      }
+    })
 
   return system
 }

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -29,13 +29,15 @@ import SyntaxHighlightingPlugin from "core/plugins/syntax-highlighting"
 import SafeRenderPlugin from "./plugins/safe-render"
 
 import win from "./window"
-import defaultOptions from "./config/defaults"
-import optionsFromQuery from "./config/sources/query"
-import optionsFromUrl from "./config/sources/url"
-import optionsFromYAMLFile from "./config/sources/yaml-file"
-import mergeOptions from "./config/merge"
-import storeOptionsFactorization from "./config/factorization/store"
-import inlinePluginOptionsFactorization from "./config/factorization/inline-plugin"
+import {
+  defaultOptions,
+  optionsFromQuery,
+  optionsFromURL,
+  optionsFromYAMLFile,
+  mergeOptions,
+  inlinePluginOptionsFactorization,
+  storeOptionsFactorization
+} from "./config"
 
 // eslint-disable-next-line no-undef
 const { GIT_DIRTY, GIT_COMMIT, PACKAGE_VERSION, BUILD_TIME } = buildInfo
@@ -62,7 +64,7 @@ export default function SwaggerUI(options) {
   const configURL = queryOptions.config ?? mergedOptions.configUrl
   const yamlFileOptions = optionsFromYAMLFile({ system })(mergedOptions)
 
-  optionsFromUrl({ url: configURL, system })(mergedOptions)
+  optionsFromURL({ url: configURL, system })(mergedOptions)
     .then((urlOptions) => {
       const urlOptionsFailedToFetch = urlOptions === null
 

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -33,7 +33,7 @@ import {
   defaultOptions,
   optionsFromQuery,
   optionsFromURL,
-  optionsFromYAMLFile,
+  optionsFromSystem,
   mergeOptions,
   inlinePluginOptionsFactorization,
   storeOptionsFactorization
@@ -42,7 +42,7 @@ import {
 // eslint-disable-next-line no-undef
 const { GIT_DIRTY, GIT_COMMIT, PACKAGE_VERSION, BUILD_TIME } = buildInfo
 
-export default function SwaggerUI(options) {
+export default function SwaggerUI(userOptions) {
   win.versions = win.versions || {}
   win.versions.swaggerUi = {
     version: PACKAGE_VERSION,
@@ -51,8 +51,8 @@ export default function SwaggerUI(options) {
     buildTimestamp: BUILD_TIME,
   }
 
-  const queryOptions = optionsFromQuery()(options)
-  let mergedOptions = mergeOptions({}, defaultOptions, options, queryOptions)
+  const queryOptions = optionsFromQuery()(userOptions)
+  let mergedOptions = mergeOptions({}, defaultOptions, userOptions, queryOptions)
   const storeOptions = storeOptionsFactorization(mergedOptions)
   const InlinePlugin = inlinePluginOptionsFactorization(mergedOptions)
 
@@ -62,13 +62,13 @@ export default function SwaggerUI(options) {
   const system = store.getSystem()
 
   const configURL = queryOptions.config ?? mergedOptions.configUrl
-  const yamlFileOptions = optionsFromYAMLFile({ system })(mergedOptions)
+  const systemOptions = optionsFromSystem({ system })(mergedOptions)
 
   optionsFromURL({ url: configURL, system })(mergedOptions)
     .then((urlOptions) => {
       const urlOptionsFailedToFetch = urlOptions === null
 
-      mergedOptions = mergeOptions({}, yamlFileOptions, mergedOptions, urlOptions, queryOptions)
+      mergedOptions = mergeOptions({}, systemOptions, mergedOptions, urlOptions, queryOptions)
       store.setConfigs(mergedOptions)
       system.configsActions.loaded()
 


### PR DESCRIPTION
I've used your PR as a base of my further work. I've dissected & composed back the entire config and operations around it.

I've identified following components:

### Options defaults

These are just default options

### Merge mechanism

I've tried to use standard `lodash.merge`. But unless we do two small changes, we're stuck with `deep-extend`. Here are my notes:

```js
/**
 * We're currently stuck with using deep-extend as it handles the following case:
 *
 * deepExtend({ a: 1 }, { a: undefined }) => { a: undefined }
 *
 * NOTE1: lodash.merge & lodash.mergeWith prefers to ignore undefined values
 * NOTE2: special handling of `domNode` option is now required as `deep-extend` will corrupt it (lodash.merge handles it correctly)
 * NOTE3: oauth2RedirectUrl and withCredentials options can be set to undefined. By expecting null instead of undefined, we can't use lodash.merge.
 *
 * TODO(vladimir.gorej@gmail.com): remove deep-extend in favor of lodash.merge
 */
```

### Config options sources

I've identified 4 distinct sources of config options. All these config option sources are now consolidated into `./config/sources` (except `1. user defined options`).

#### 1. user defined options

Options passed to SwaggerUI constructor

#### 2. query options

Options passed to SwaggerUI via URL query string

#### 3. remote URL options

Options fetched from remote URL

#### 4. options parsed from local filesystem yaml file

Options are stored in YAML file and parsed 

### Config options factorization

`Config factorization` is a term used for a process of creating a tailored configuration subset of the larger one. I've identified two distinct factorizations:

### 1. redux store factorization

Factoring a redux store config options from the SwaggerUI config options

### 2. InlinePlugin factorization

Factoring an ad-hoc InlinePlugin from the SwaggerUI config options

---

Have a look at the changes at your convenience please.

