### PR TITLE
fix(auth): use password type for API key input

### DIFF
--- a/docs/development/setting-up.md
+++ b/docs/development/setting-up.md
@@ -10,10 +10,11 @@ Swagger UI includes a development server that provides hot module reloading and 
 ### Steps
 
 1. `git clone https://github.com/swagger-api/swagger-ui.git`
-2. `cd swagger-ui`
-3. `npm run dev`
-4. Wait a bit
-5. Open http://localhost:3200/
+1. `cd swagger-ui`
+1. `npm install`
+1. `npm run dev`
+1. Wait a bit
+1. Open http://localhost:3200/
 
 ### Using your own local api definition with local dev build
 

--- a/src/core/components/auth/api-key-auth.jsx
+++ b/src/core/components/auth/api-key-auth.jsx
@@ -72,7 +72,7 @@ export default class ApiKeyAuth extends React.Component {
                   : <Col>
                       <Input 
                         id="api_key_value" 
-                        type="text" 
+                        type="password" 
                         onChange={ this.onChange } 
                         autoFocus
                       />


### PR DESCRIPTION
### Description

This uses the `password` type for the input filed for `api_key_value` to hide the value and not expose it via autocomplete. This makes it consistent with the client secret input and basic auth password fields that already do this. See screenshots below

I also added a small docs change in a separate commit, let me know if that needs a separate PR.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

With a plan `text` type the API key would be shown during entry, which can be an issue when sharing or demoing API specs using swagger UI.
It was also remembered across sessions by browsers so it could be exposed via autocomplete.

With this, autocomplete still works with password managers but is not automatically exposed.

I could not find any open issues related to this but let me know if I missed any!

⚒️ with ❤️ by [Siemens](https://opensource.siemens.com/)

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

See screenshots below, following the `setting-up.md` guide and running the petstore locally.

### Screenshots (if appropriate):

| before | after |
| - | - |
| ![image](https://github.com/swagger-api/swagger-ui/assets/16777978/547882de-099a-4572-8c42-7be63671186b) | ![image](https://github.com/swagger-api/swagger-ui/assets/16777978/94e09329-dbbf-4f3f-9193-1128454f2dad) |

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [ ] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
