### PR TITLE
fix(swagger-ui-react): display definition defined as YAML or JSON string

### DIFF
--- a/flavors/swagger-ui-react/index.jsx
+++ b/flavors/swagger-ui-react/index.jsx
@@ -99,7 +99,7 @@ const SwaggerUI = ({
         system.specActions.updateSpec(updatedSpec)
       }
     }
-  }, [url, spec])
+  }, [system, url, spec])
 
   return SwaggerUIComponent ? <SwaggerUIComponent /> : null
 }


### PR DESCRIPTION
Refs #9915 