### PR TITLE
fix(system): allow wrapping components both from presets and plugins

### DIFF
--- a/docs/customization/plugin-api.md
+++ b/docs/customization/plugin-api.md
@@ -388,10 +388,6 @@ const MyWrapComponentPlugin = function(system) {
 }
 ```
 
-**Note:**
-
-If you have multiple plugins wrapping the same component, you may want to change the [`pluginsOptions.pluginLoadType`](/docs/usage/configuration.md#Plugins-options) parameter to `chain`.
-
 #### `rootInjects`
 
 The `rootInjects` interface allows you to inject values at the top level of the system.

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -39,15 +39,8 @@ Read more about the plugin system in the [Customization documentation](/docs/cus
 Parameter name | Docker variable | Description
 --- | --- | -----
 <a name="layout"></a>`layout` | _Unavailable_ | `String="BaseLayout"`. The name of a component available via the plugin system to use as the top-level layout for Swagger UI.
-<a name="pluginsOptions"></a>`pluginsOptions` | _Unavailable_ | `Object`. A Javascript object to configure plugin integration and behaviors (see below).
 <a name="plugins"></a>`plugins` | _Unavailable_ | `Array=[]`. An array of plugin functions to use in Swagger UI.
 <a name="presets"></a>`presets` | _Unavailable_ | `Array=[SwaggerUI.presets.ApisPreset]`. An array of presets to use in Swagger UI. Usually, you'll want to include `ApisPreset` if you use this option.
-
-##### Plugins options
-
-Parameter name | Docker variable | Description
---- | --- | -----
-<a name="pluginLoadType"></a>`pluginLoadType` | _Unavailable_ | `String=["legacy", "chain"]`. Control behavior of plugins when targeting the same component with wrapComponent.<br/>- `legacy` (default) : last plugin takes precedence over the others<br/>- `chain` : chain wrapComponents when targeting the same core component, allowing multiple plugins to wrap the same component
 
 ##### Display
 

--- a/src/core/config/defaults.js
+++ b/src/core/config/defaults.js
@@ -70,13 +70,6 @@ const defaultOptions = Object.freeze({
   // Plugins; ( loaded after presets )
   plugins: [],
 
-  pluginsOptions: {
-    // Behavior during plugin registration. Can be :
-    // - legacy (default) : the current behavior for backward compatibility – last plugin takes precedence over the others
-    // - chain : chain wrapComponents when targeting the same core component
-    pluginLoadType: "legacy",
-  },
-
   initialState: {},
 
   // Inline Plugin

--- a/src/core/config/factorization/system.js
+++ b/src/core/config/factorization/system.js
@@ -37,7 +37,6 @@ const systemFactorization = (options) => {
       configs: options.configs,
     },
     plugins: options.presets,
-    pluginsOptions: options.pluginsOptions,
     state,
   }
 }

--- a/src/core/config/type-cast/mappings.js
+++ b/src/core/config/type-cast/mappings.js
@@ -55,11 +55,6 @@ const mappings = {
     typeCaster: arrayTypeCaster,
     defaultValue: defaultOptions.plugins,
   },
-  pluginsOptions: {
-    typeCaster: objectTypeCaster,
-    pluginsOptions: defaultOptions.pluginsOptions,
-  },
-  "pluginsOptions.pluginsLoadType": { typeCaster: stringTypeCaster },
   presets: {
     typeCaster: arrayTypeCaster,
     defaultValue: defaultOptions.presets,

--- a/src/core/system.js
+++ b/src/core/system.js
@@ -35,7 +35,6 @@ export default class Store {
     deepExtend(this, {
       state: {},
       plugins: [],
-      pluginsOptions: {},
       system: {
         configs: {},
         fn: {},
@@ -64,7 +63,7 @@ export default class Store {
   }
 
   register(plugins, rebuild=true) {
-    var pluginSystem = combinePlugins(plugins, this.getSystem(), this.pluginsOptions)
+    var pluginSystem = combinePlugins(plugins, this.getSystem())
     systemExtend(this.system, pluginSystem)
     if(rebuild) {
       this.buildSystem()
@@ -311,21 +310,19 @@ export default class Store {
 
 }
 
-function combinePlugins(plugins, toolbox, pluginOptions) {
+function combinePlugins(plugins, toolbox) {
   if(isObject(plugins) && !isArray(plugins)) {
     return merge({}, plugins)
   }
 
   if(isFunc(plugins)) {
-    return combinePlugins(plugins(toolbox), toolbox, pluginOptions)
+    return combinePlugins(plugins(toolbox), toolbox)
   }
 
   if(isArray(plugins)) {
-    const dest = pluginOptions.pluginLoadType === "chain" ? toolbox.getComponents() : {}
-
     return plugins
-    .map(plugin => combinePlugins(plugin, toolbox, pluginOptions))
-    .reduce(systemExtend, dest)
+      .map(plugin => combinePlugins(plugin, toolbox))
+      .reduce(systemExtend, { components: { ...toolbox.getComponents() } })
   }
 
   return {}

--- a/test/unit/core/system/wrapComponent.jsx
+++ b/test/unit/core/system/wrapComponent.jsx
@@ -187,14 +187,11 @@ describe("wrapComponents", () => {
     expect(children.eq(1).text()).toEqual("WOW much data")
   })
 
-  it("should wrap correctly when registering multiple plugins targeting the same component", function () {
+  it("should wrap component correctly when performing subsequent plugin registering targeting the same component", function () {
 
     // Given
 
     const mySystem = new System({
-      pluginsOptions: {
-        pluginLoadType: "chain"
-      },
       plugins: [
         () => {
           return {


### PR DESCRIPTION
Refs https://github.com/swagger-api/swagger-ui/issues/7232#issuecomment-2097751759
Refs https://github.com/swagger-api/swagger-ui/pull/7304

### Motivation and Context

The expected behavior described in this issue has always been intended. It shouldn't matter if whether the plugins have been registered via `presets` or passed by the `plugins` option. Having said that, this is just a bug in the original behavior, and the expected  behavior (called chaining in this issue) should be the default one. Wrapping actions and selectors already works like that (ref https://github.com/swagger-api/swagger-ui/pull/7304).

In https://github.com/swagger-api/swagger-ui/pull/7236, the remediation was provided, but unfortunately  it also contains hidden bug, where the original components objects is being mutated by the combined plugins because of this line:

```js
 const dest = pluginOptions.pluginLoadType === "chain" ? toolbox.getComponents() : {}
```

---

Action: we're gonna revert https://github.com/swagger-api/swagger-ui/commit/516e666f1c4c118fbf60456869a01f892eef8b0c  and replace it with non-configurable solution. We're going  to fix the mutation bug introduced by the line above.


### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->



### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
