### PR TITLE
Disable autocompletion for authorization secrets

### DIFF
--- a/src/core/components/auth/api-key-auth.jsx
+++ b/src/core/components/auth/api-key-auth.jsx
@@ -73,7 +73,8 @@ export default class ApiKeyAuth extends React.Component {
                       <Input 
                         id="api_key_value" 
                         type="text" 
-                        onChange={ this.onChange } 
+                        onChange={ this.onChange }
+                        autoComplete='off'
                         autoFocus
                       />
                     </Col>

--- a/src/core/plugins/oas3/components/auth/http-auth.jsx
+++ b/src/core/plugins/oas3/components/auth/http-auth.jsx
@@ -82,6 +82,7 @@ export default class HttpAuth extends React.Component {
                     name="username"
                     aria-label="auth-basic-username"
                     onChange={ this.onChange }
+                    autoComplete='off'
                     autoFocus
                   />
                 </Col>


### PR DESCRIPTION
### Description
This pull request set `autoComplete=off` to the inputs below so as not to expose the bearer's API key and token by autocompletion when typed.

https://github.com/swagger-api/swagger-ui/blob/1367a8fbdfddd697b8c71493bb09c01baf17d5a3/src/core/components/auth/api-key-auth.jsx#L73-L78

https://github.com/swagger-api/swagger-ui/blob/1367a8fbdfddd697b8c71493bb09c01baf17d5a3/src/core/plugins/oas3/components/auth/http-auth.jsx#L132-L138


### Motivation and Context
close #9921 


### How Has This Been Tested?
I opened my browser with `localhost:3200` . I clicked on authorize, start typing a secret and closed the modal window.
I reopened the modal window, logged out and started typing a secret again. Autocomplete did not appear.

### Screenshots (if appropriate):
[Screencast from 2024-05-13 20-47-19.webm](https://github.com/swagger-api/swagger-ui/assets/167549638/dc0c52df-9abf-4e71-b885-7b316c8a198d)



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
