### PR TITLE
fix(style): make operation section and parameters responsive

### DIFF
--- a/src/style/_buttons.scss
+++ b/src/style/_buttons.scss
@@ -73,8 +73,14 @@
 .btn-group
 {
   display: flex;
+  flex-wrap: wrap;
+  gap: .5rem;
 
   padding: 30px;
+
+  @media screen and (max-width: 968px) {
+    padding: 10px 20px;
+  }
 
   .btn
   {

--- a/src/style/_layout.scss
+++ b/src/style/_layout.scss
@@ -19,10 +19,6 @@
     flex: 0.1 2 auto;
 }
 
-.try-out__btn {
-    margin-left: 1.25rem;
-}
-
 .opblock-tag
 {
     display: flex;
@@ -262,6 +258,9 @@
     {
         display: flex;
         align-items: center;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: .5rem 1rem;
 
         padding: 8px 20px;
 
@@ -277,9 +276,10 @@
 
             display: flex;
             align-items: center;
+            flex-wrap: wrap;
+            row-gap: .3rem;
 
             margin: 0;
-            margin-left: auto;
 
             @include text_headline();
 

--- a/src/style/_table.scss
+++ b/src/style/_table.scss
@@ -181,6 +181,10 @@ table
 .table-container
 {
     padding: 20px;
+
+    @media screen and (max-width: 968px) {
+        padding: 0;
+    }
 }
 
 
@@ -204,4 +208,41 @@ table
     font-style: italic;
 
     @include text_code($table-parameter-in-font-color);
+}
+
+@media (max-width: 968px) {
+    table.parameters {
+
+        &>thead {
+            display: none;
+        }
+
+        &>tbody {
+            display: grid;
+
+            tr {
+                display: flex;
+                flex-direction: column;
+                flex-wrap: wrap;
+                column-gap: .5rem;
+                padding: 10px 20px;
+                border-bottom: 1px solid rgba($opblock-tag-border-bottom-color, .3);;
+
+                &>td.parameters-col_description {
+                    width: auto;
+                    margin-bottom: 0;
+                }
+
+                .parameters-col_name {
+                    display: flex;
+                    align-items: center;
+                    flex-wrap: wrap;
+                }
+            }
+        }
+    }
+
+    table tbody tr td:first-of-type {
+        min-width: 3em;
+    }
 }


### PR DESCRIPTION
Make the Swagger operation section and parameters component responsive and smooth

### Description
This PR does the following:


Ensure that the operation block and parameters section are responsive



### Motivation and Context
Resolves #8940



### How Has This Been Tested?
I tested these style changes with different screen sizes and make sure that all existing tests pass.


### Screenshots (if appropriate):

#### Operation section and parameters before changes



https://github.com/swagger-api/swagger-ui/assets/167549638/3e59b2ae-06a2-4d28-aad7-caf45b09340a





#### Operation section and parameters after changes


https://github.com/swagger-api/swagger-ui/assets/167549638/a301d6a6-aa8f-4831-8e5d-5f0c9b4687bb







## Checklist

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
