### PR TITLE
feat(json-schema): support x-additionalPropertiesName

### DIFF
--- a/src/core/plugins/json-schema-2020-12-samples/fn/main.js
+++ b/src/core/plugins/json-schema-2020-12-samples/fn/main.js
@@ -482,6 +482,8 @@ export const sampleFromSchemaGeneric = (
       ) {
         res[displayName].push(additionalPropSample)
       } else {
+        const keyName =
+          additionalProps?.["x-additionalPropertiesName"] || "additionalProp"
         const toGenerateCount =
           Number.isInteger(schema.minProperties) &&
           schema.minProperties > 0 &&
@@ -494,10 +496,10 @@ export const sampleFromSchemaGeneric = (
           }
           if (respectXML) {
             const temp = {}
-            temp["additionalProp" + i] = additionalPropSample["notagname"]
+            temp[keyName + i] = additionalPropSample["notagname"]
             res[displayName].push(temp)
           } else {
-            res["additionalProp" + i] = additionalPropSample
+            res[keyName + i] = additionalPropSample
           }
           propertyAddedCounter++
         }

--- a/src/core/plugins/json-schema-5-samples/fn/index.js
+++ b/src/core/plugins/json-schema-5-samples/fn/index.js
@@ -518,6 +518,7 @@ export const sampleFromSchemaGeneric = (schema, config={}, exampleOverride = und
       {
         res[displayName].push(additionalPropSample)
       } else {
+        const keyName = additionalProps["x-additionalPropertiesName"] || "additionalProp"
         const toGenerateCount = schema.minProperties !== null && schema.minProperties !== undefined && propertyAddedCounter < schema.minProperties
           ? schema.minProperties - propertyAddedCounter
           : 3
@@ -527,10 +528,10 @@ export const sampleFromSchemaGeneric = (schema, config={}, exampleOverride = und
           }
           if(respectXML) {
             const temp = {}
-            temp["additionalProp" + i] = additionalPropSample["notagname"]
+            temp[keyName + i] = additionalPropSample["notagname"]
             res[displayName].push(temp)
           } else {
-            res["additionalProp" + i] = additionalPropSample
+            res[keyName + i] = additionalPropSample
           }
           propertyAddedCounter++
         }

--- a/test/unit/core/plugins/json-schema-2020-12-samples/fn.js
+++ b/test/unit/core/plugins/json-schema-2020-12-samples/fn.js
@@ -1263,6 +1263,30 @@ describe("sampleFromSchema", () => {
     expect(sampleFromSchema(definition)).toEqual(expected)
   })
 
+  it("should handle additionalProperties with x-additionalPropertiesName", () => {
+    const definition = {
+      type: "object",
+      additionalProperties: {
+        type: "string",
+        "x-additionalPropertiesName": "bar",
+      },
+      properties: {
+        foo: {
+          type: "string",
+        },
+      },
+    }
+
+    const expected = {
+      foo: "string",
+      bar1: "string",
+      bar2: "string",
+      bar3: "string",
+    }
+
+    expect(sampleFromSchema(definition)).toEqual(expected)
+  })
+
   it("should handle additionalProperties=true", () => {
     const definition = {
       type: "object",
@@ -2756,6 +2780,28 @@ describe("createXMLExample", function () {
         },
         additionalProperties: {
           type: "string",
+        },
+        xml: {
+          name: "animals",
+        },
+      }
+
+      expect(sut(definition)).toEqual(expected)
+    })
+
+    it("returns object with additional props with x-additionalPropertiesName", function () {
+      const expected =
+        '<?xml version="1.0" encoding="UTF-8"?>\n<animals>\n\t<dog>string</dog>\n\t<animal1>string</animal1>\n\t<animal2>string</animal2>\n\t<animal3>string</animal3>\n</animals>'
+      const definition = {
+        type: "object",
+        properties: {
+          dog: {
+            type: "string",
+          },
+        },
+        additionalProperties: {
+          type: "string",
+          "x-additionalPropertiesName": "animal",
         },
         xml: {
           name: "animals",

--- a/test/unit/core/plugins/json-schema-5-samples/fn/index.js
+++ b/test/unit/core/plugins/json-schema-5-samples/fn/index.js
@@ -969,6 +969,30 @@ describe("sampleFromSchema", () => {
     expect(sampleFromSchema(definition)).toEqual(expected)
   })
 
+  it("should handle additionalProperties with x-additionalPropertiesName", () => {
+    const definition = {
+      type: "object",
+      additionalProperties: {
+        type: "string",
+        "x-additionalPropertiesName": "bar",
+      },
+      properties: {
+        foo: {
+          type: "string",
+        },
+      },
+    }
+
+    const expected = {
+      foo: "string",
+      bar1: "string",
+      bar2: "string",
+      bar3: "string",
+    }
+
+    expect(sampleFromSchema(definition)).toEqual(expected)
+  })
+
   it("should handle additionalProperties=true", () => {
     const definition = {
       type: "object",
@@ -2214,6 +2238,27 @@ describe("createXMLExample", function () {
         },
         additionalProperties: {
           type: "string"
+        },
+        xml: {
+          name: "animals"
+        }
+      }
+
+      expect(sut(definition)).toEqual(expected)
+    })
+
+    it("returns object with additional props with x-additionalPropertiesName", function () {
+      let expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<animals>\n\t<dog>string</dog>\n\t<animal1>string</animal1>\n\t<animal2>string</animal2>\n\t<animal3>string</animal3>\n</animals>"
+      let definition = {
+        type: "object",
+        properties: {
+          dog: {
+            type: "string"
+          }
+        },
+        additionalProperties: {
+          type: "string",
+          "x-additionalPropertiesName": "animal"
         },
         xml: {
           name: "animals"


### PR DESCRIPTION
x-additionalPropertiesName is a Redocly extension to display more descriptive property names in objects with additionalProperties[1]. This allows generating nicer looking and more informative documentation and examples than Swagger UI's current "additionalProp" name.

[1] https://redocly.com/docs/api-reference-docs/specification-extensions/x-additional-properties-name/

### My PR contains... 
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [x] are not breaking changes.

### Documentation
I haven't found the right place to document the change, but happy to add documentation if such a place exists.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
