### PR TITLE
doc(usage.configuration.tagsSorter): fix wrong declaration

### DIFF
--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -171,7 +171,7 @@ Parameter name | Docker variable | Description
         <td><a name="user-content-tagsorter"></a><code>tagsSorter</code></td>
         <td><em>Unavailable</em></td>
         <td><code>Function=(a =&gt; a)</code>. Apply a sort to the tag list of
-            each API. It can be 'alpha' (sort by paths alphanumerically) or a
+            each API. It can be 'alpha' (sort by tags alphanumerically) or a
             function (see <a
                     href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort"
                     rel="nofollow">Array.prototype.sort()</a> to learn how to


### PR DESCRIPTION
### Description
* Fix wrong definition of `tagsSorter` for `alpha`


---
### Motivation and Context
* Why is this change required? What problem does it solve? 
  * value wrongly defined

---
### How Has This Been Tested?
* Extend the sample 'webpack-getting-started' -- Check [theProjectInMyForkedBranch](https://github.com/dancer1325/swagger-ui/tree/master/docs/samples/webpack-getting-started) --
  * my set up: NodeJs v20.11.0, NPM 10.4.0
  * OpenAPI sample extended -- https://github.com/dancer1325/swagger-ui/blob/master/docs/samples/webpack-getting-started/src/swagger-config.yaml --
  * `tagsSorter:"alpha"` -- https://github.com/dancer1325/swagger-ui/blob/master/docs/samples/webpack-getting-started/src/index.js#L20 -- 
* isolated changes -> just affected this sample project


---
### Screenshots (if appropriate):
<img width="782" alt="image" src="https://github.com/swagger-api/swagger-ui/assets/39351487/74f393dd-c4ea-4154-8d24-291b6d8fea6a">


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [] My changes do not require a change to the project documentation.
- [x] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
