### PR TITLE
Fix Content-Type for docker container.

### DIFF
--- a/docker/default.conf.template
+++ b/docker/default.conf.template
@@ -3,6 +3,8 @@
     text/plain yml;
   }
 
+  charset utf-8;
+
   gzip on;
   gzip_static on;
   gzip_disable "msie6";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Configure nginx in the docker container to return 'charset=utf-8'.

### Description
<!--- Describe your changes in detail -->
HTML that doesn't set charset in the script tag that invokes swagger that is being served from the docker container at https://hub.docker.com/r/swaggerapi/swagger-ui will fail.


### Motivation and Context
Fixes #10082.


### How Has This Been Tested?

```
$ cat > docker-compose.yaml <<EOF
services:
  swagger-ui:
    image: swagger-ui
    build:
      context: .
    ports:
      - "8081:8080"
EOF
$ docker compose up --build -d
$ curl -s -D - -o /dev/null localhost:8081/swagger-ui-bundle.js | grep Content-Type:
Content-Type: application/javascript; charset=utf-8
```

### Screenshots (if appropriate):

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
