### PR TITLE
feat: ✨ add support for SEARCH verb

### DIFF
--- a/flavors/swagger-ui-react/README.md
+++ b/flavors/swagger-ui-react/README.md
@@ -102,7 +102,7 @@ An array of objects that augment and modify Swagger UI's functionality. See Swag
 
 ⚠️ This prop is currently only applied once, on mount. Changes to this prop's value will not be propagated to the underlying Swagger UI instance. A future version of this module will remove this limitation, and the change will not be considered a breaking change.
 
-#### `supportedSubmitMethods`: PropTypes.arrayOf(PropTypes.oneOf(['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace']))
+#### `supportedSubmitMethods`: PropTypes.arrayOf(PropTypes.oneOf(['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace', 'search']))
 
 HTTP methods that have the Try it out feature enabled. An empty array disables Try it out for all operations. This does not filter the operations from the display.
 

--- a/flavors/swagger-ui-react/index.jsx
+++ b/flavors/swagger-ui-react/index.jsx
@@ -140,6 +140,7 @@ SwaggerUI.propTypes = {
       "head",
       "patch",
       "trace",
+      "search",
     ])
   ),
   queryConfigEnabled: PropTypes.bool,

--- a/src/core/config/defaults.js
+++ b/src/core/config/defaults.js
@@ -62,6 +62,7 @@ const defaultOptions = Object.freeze({
     "head",
     "patch",
     "trace",
+    "search",
   ],
   queryConfigEnabled: false,
 

--- a/src/core/plugins/oas3/selectors.js
+++ b/src/core/plugins/oas3/selectors.js
@@ -305,4 +305,5 @@ export const validOperationMethods = constant([
   "head",
   "patch",
   "trace",
+  "search",
 ])

--- a/src/core/plugins/spec/selectors.js
+++ b/src/core/plugins/spec/selectors.js
@@ -6,7 +6,7 @@ import { fromJS, Set, Map, OrderedMap, List } from "immutable"
 const DEFAULT_TAG = "default"
 
 const OPERATION_METHODS = [
-  "get", "put", "post", "delete", "options", "head", "patch", "trace"
+  "get", "put", "post", "delete", "options", "head", "patch", "trace", "search"
 ]
 
 const state = state => {
@@ -262,7 +262,7 @@ export const operationsWithTags = createSelector(
 
 export const taggedOperations = (state) => ({ getConfigs }) => {
   let { tagsSorter, operationsSorter } = getConfigs()
-  return operationsWithTags(state)
+  const opsWithTags = operationsWithTags(state)
     .sortBy(
       (val, key) => key, // get the name of the tag to be passed to the sorter
       (tagA, tagB) => {
@@ -276,6 +276,7 @@ export const taggedOperations = (state) => ({ getConfigs }) => {
 
       return Map({ tagDetails: tagDetails(state, tag), operations: operations })
     })
+    return opsWithTags
 }
 
 export const responses = createSelector(
@@ -499,8 +500,8 @@ export const validationErrors = (state, pathMethod) => {
   const getErrorsWithPaths = (errors, path = []) => {
     const getNestedErrorsWithPaths = (e, path) => {
       const currPath = [...path, e.get("propKey") || e.get("index")]
-      return Map.isMap(e.get("error")) 
-        ? getErrorsWithPaths(e.get("error"), currPath) 
+      return Map.isMap(e.get("error"))
+        ? getErrorsWithPaths(e.get("error"), currPath)
         : { error: e.get("error"), path: currPath }
     }
 
@@ -511,10 +512,10 @@ export const validationErrors = (state, pathMethod) => {
 
   const formatError = (error, path, paramName) => {
     path = path.reduce((acc, curr) => {
-      return typeof curr === "number" 
-        ? `${acc}[${curr}]` 
-        : acc 
-        ? `${acc}.${curr}` 
+      return typeof curr === "number"
+        ? `${acc}[${curr}]`
+        : acc
+        ? `${acc}.${curr}`
         : curr
     }, "")
     return `For '${paramName}'${path ? ` at path '${path}'` : ""}: ${error}.`

--- a/src/style/_layout.scss
+++ b/src/style/_layout.scss
@@ -463,6 +463,11 @@
         @include method($_color-options);
     }
 
+    &.opblock-search
+    {
+        @include method($_color-search);
+    }
+
     &.opblock-deprecated
     {
         opacity: .6;

--- a/src/style/_variables.scss
+++ b/src/style/_variables.scss
@@ -51,6 +51,7 @@ $_color-head: #9012fe !default;
 $_color-patch: #50e3c2 !default;
 $_color-disabled: #ebebeb !default;
 $_color-options: #0d5aa7 !default;
+$_color-search: #6179fe !default;
 
 // Authorize
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Added support for SEARCH verb/method


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->
- Fixes https://github.com/swagger-api/swagger-ui/issues/10085


### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
using `npm run dev` with the provided schema


### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/4a475db1-77da-4c14-80d5-ddb0812fa0c0)



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [x] My changes require a change to the project documentation.
- [x] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
