### PR TITLE
Replace confusing "Cancel" label on clickbox.

### DIFF
--- a/src/core/components/try-it-out-button.jsx
+++ b/src/core/components/try-it-out-button.jsx
@@ -28,8 +28,8 @@ export default class TryItOutButton extends React.Component {
     return (
       <div className={showReset ? "try-out btn-group" : "try-out"}>
         {
-          enabled ? <button className="btn try-out__btn cancel" onClick={ onCancelClick }>Cancel</button>
-                  : <button className="btn try-out__btn" onClick={ onTryoutClick }>Try it out </button>
+          enabled ? <button className="btn try-out__btn cancel" onClick={ onCancelClick }>Close</button>
+                  : <button className="btn try-out__btn" onClick={ onTryoutClick }>Try it out</button>
 
         }
         {


### PR DESCRIPTION
Replace confusing "Cancel" label on clickbox.
<!--- Provide a general summary of your changes in the Title above -->

### Description
Replace "Cancel" by "Close".

### Motivation and Context
The red "Cancel" box makes it look like a request was already issued (by the "Try it out" button). First-time users of this UI might think that there is a pending request to be canceled. Replacing "Cancel" by "Close" clarifies this a little.

