### PR TITLE
feat(plugins): Show multipart/form-data example and schema

### DIFF
--- a/src/core/components/parameters/parameters.jsx
+++ b/src/core/components/parameters/parameters.jsx
@@ -75,7 +75,7 @@ export default class Parameters extends Component {
       })
     }
   }
-  
+
   onChangeMediaType = ({ value, pathMethod }) => {
     let { specActions, oas3Selectors, oas3Actions } = this.props
     const userHasEditedBody = oas3Selectors.hasUserEditedBody(...pathMethod)
@@ -83,7 +83,7 @@ export default class Parameters extends Component {
     oas3Actions.setRequestContentType({ value, pathMethod })
     oas3Actions.initRequestBodyValidateError({ pathMethod })
     if (!userHasEditedBody) {
-      if(!shouldRetainRequestBodyValue) {
+      if (!shouldRetainRequestBodyValue) {
         oas3Actions.setRequestBodyValue({ value: undefined, pathMethod })
       }
       specActions.clearResponse(...pathMethod)
@@ -166,7 +166,7 @@ export default class Parameters extends Component {
               enabled={tryItOutEnabled}
               onCancelClick={this.props.onCancelClick}
               onTryoutClick={onTryoutClick}
-              onResetClick={() => onResetClick(pathMethod)}/>
+              onResetClick={() => onResetClick(pathMethod)} />
           ) : null}
         </div>
         {this.state.parametersVisible ? <div className="parameters-container">
@@ -226,7 +226,7 @@ export default class Parameters extends Component {
                     this.onChangeMediaType({ value, pathMethod })
                   }}
                   className="body-param-content-type"
-                  ariaLabel="Request content type" 
+                  ariaLabel="Request content type"
                   controlId={controlId}
                 />
               </label>

--- a/src/core/plugins/oas3/components/request-body.jsx
+++ b/src/core/plugins/oas3/components/request-body.jsx
@@ -15,7 +15,7 @@ export const getDefaultRequestBodyValue = (requestBody, mediaType, activeExample
     ? mediaTypeValue.getIn([
       "examples",
       activeExamplesKey,
-      "value"
+      "value",
     ])
     : exampleSchema
 
@@ -23,34 +23,33 @@ export const getDefaultRequestBodyValue = (requestBody, mediaType, activeExample
     schema,
     mediaType,
     {
-      includeWriteOnly: true
+      includeWriteOnly: true,
     },
-    mediaTypeExample
+    mediaTypeExample,
   )
   return stringify(exampleValue)
 }
 
 
-
 const RequestBody = ({
-  userHasEditedBody,
-  requestBody,
-  requestBodyValue,
-  requestBodyInclusionSetting,
-  requestBodyErrors,
-  getComponent,
-  getConfigs,
-  specSelectors,
-  fn,
-  contentType,
-  isExecute,
-  specPath,
-  onChange,
-  onChangeIncludeEmpty,
-  activeExamplesKey,
-  updateActiveExamplesKey,
-  setRetainRequestBodyValueFlag
-}) => {
+                       userHasEditedBody,
+                       requestBody,
+                       requestBodyValue,
+                       requestBodyInclusionSetting,
+                       requestBodyErrors,
+                       getComponent,
+                       getConfigs,
+                       specSelectors,
+                       fn,
+                       contentType,
+                       isExecute,
+                       specPath,
+                       onChange,
+                       onChangeIncludeEmpty,
+                       activeExamplesKey,
+                       updateActiveExamplesKey,
+                       setRetainRequestBodyValueFlag,
+                     }) => {
   const handleFile = (e) => {
     onChange(e.target.files[0])
   }
@@ -58,7 +57,7 @@ const RequestBody = ({
     let options = {
       key,
       shouldDispatchInit: false,
-      defaultValue: true
+      defaultValue: true,
     }
     let currentInclusion = requestBodyInclusionSetting.get(key, "no value")
     if (currentInclusion === "no value") {
@@ -87,7 +86,7 @@ const RequestBody = ({
   const rawExamplesOfMediaType = mediaTypeValue.get("examples", null)
   const sampleForMediaType = rawExamplesOfMediaType?.map((container, key) => {
     const val = container?.get("value", null)
-    if(val) {
+    if (val) {
       container = container.set("value", getDefaultRequestBodyValue(
         requestBody,
         contentType,
@@ -103,7 +102,7 @@ const RequestBody = ({
   }
   requestBodyErrors = List.isList(requestBodyErrors) ? requestBodyErrors : List()
 
-  if(!mediaTypeValue.size) {
+  if (!mediaTypeValue.size) {
     return null
   }
 
@@ -111,7 +110,7 @@ const RequestBody = ({
   const isBinaryFormat = mediaTypeValue.getIn(["schema", "format"]) === "binary"
   const isBase64Format = mediaTypeValue.getIn(["schema", "format"]) === "base64"
 
-  if(
+  if (
     contentType === "application/octet-stream"
     || contentType.indexOf("image/") === 0
     || contentType.indexOf("audio/") === 0
@@ -121,7 +120,7 @@ const RequestBody = ({
   ) {
     const Input = getComponent("Input")
 
-    if(!isExecute) {
+    if (!isExecute) {
       return <i>
         Example values are not available for <code>{contentType}</code> media types.
       </i>
@@ -144,67 +143,67 @@ const RequestBody = ({
     requestBodyValue = Map.isMap(requestBodyValue) ? requestBodyValue : OrderedMap()
 
     return <div className="table-container">
-      { requestBodyDescription &&
+      {requestBodyDescription &&
         <Markdown source={requestBodyDescription} />
       }
       <table>
         <tbody>
-          {
-            Map.isMap(bodyProperties) && bodyProperties.entrySeq().map(([key, schema]) => {
-              if (schema.get("readOnly")) return
+        {
+          Map.isMap(bodyProperties) && bodyProperties.entrySeq().map(([key, schema]) => {
+            if (schema.get("readOnly")) return
 
-              const oneOf = schema.get("oneOf")?.get(0)?.toJS()
-              const anyOf = schema.get("anyOf")?.get(0)?.toJS()
-              schema = fromJS(fn.mergeJsonSchema(schema.toJS(), oneOf ?? anyOf ?? {}))
+            const oneOf = schema.get("oneOf")?.get(0)?.toJS()
+            const anyOf = schema.get("anyOf")?.get(0)?.toJS()
+            schema = fromJS(fn.mergeJsonSchema(schema.toJS(), oneOf ?? anyOf ?? {}))
 
-              let commonExt = showCommonExtensions ? getCommonExtensions(schema) : null
-              const required = schemaForMediaType.get("required", List()).includes(key)
-              const type = schema.get("type")
-              const format = schema.get("format")
-              const description = schema.get("description")
-              const currentValue = requestBodyValue.getIn([key, "value"])
-              const currentErrors = requestBodyValue.getIn([key, "errors"]) || requestBodyErrors
-              const included = requestBodyInclusionSetting.get(key) || false
+            let commonExt = showCommonExtensions ? getCommonExtensions(schema) : null
+            const required = schemaForMediaType.get("required", List()).includes(key)
+            const type = schema.get("type")
+            const format = schema.get("format")
+            const description = schema.get("description")
+            const currentValue = requestBodyValue.getIn([key, "value"])
+            const currentErrors = requestBodyValue.getIn([key, "errors"]) || requestBodyErrors
+            const included = requestBodyInclusionSetting.get(key) || false
 
-              let initialValue = fn.getSampleSchema(schema, false, {
-                includeWriteOnly: true
-              })
+            let initialValue = fn.getSampleSchema(schema, false, {
+              includeWriteOnly: true,
+            })
 
-              if (initialValue === false) {
-                initialValue = "false"
-              }
+            if (initialValue === false) {
+              initialValue = "false"
+            }
 
-              if (initialValue === 0) {
-                initialValue = "0"
-              }
+            if (initialValue === 0) {
+              initialValue = "0"
+            }
 
-              if (typeof initialValue !== "string" && type === "object") {
-               initialValue = stringify(initialValue)
-              }
+            if (typeof initialValue !== "string" && type === "object") {
+              initialValue = stringify(initialValue)
+            }
 
-              if (typeof initialValue === "string" && type === "array") {
-                initialValue = JSON.parse(initialValue)
-              }
+            if (typeof initialValue === "string" && type === "array") {
+              initialValue = JSON.parse(initialValue)
+            }
 
-              const isFile = type === "string" && (format === "binary" || format === "base64")
+            const isFile = type === "string" && (format === "binary" || format === "base64")
 
-              return <tr key={key} className="parameters" data-property-name={key}>
+            return <tr key={key} className="parameters" data-property-name={key}>
               <td className="parameters-col_name">
                 <div className={required ? "parameter__name required" : "parameter__name"}>
-                  { key }
-                  { !required ? null : <span>&nbsp;*</span> }
+                  {key}
+                  {!required ? null : <span>&nbsp;*</span>}
                 </div>
                 <div className="parameter__type">
-                  { type }
-                  { format && <span className="prop-format">(${format})</span>}
+                  {type}
+                  {format && <span className="prop-format">(${format})</span>}
                   {!showCommonExtensions || !commonExt.size ? null : commonExt.entrySeq().map(([key, v]) => <ParameterExt key={`${key}-${v}`} xKey={key} xVal={v} />)}
                 </div>
                 <div className="parameter__deprecated">
-                  { schema.get("deprecated") ? "deprecated": null }
+                  {schema.get("deprecated") ? "deprecated" : null}
                 </div>
               </td>
               <td className="parameters-col_description">
-                <Markdown source={ description }></Markdown>
+                <Markdown source={description}></Markdown>
                 {isExecute ? <div>
                   <JsonSchemaForm
                     fn={fn}
@@ -213,8 +212,8 @@ const RequestBody = ({
                     description={key}
                     getComponent={getComponent}
                     value={currentValue === undefined ? initialValue : currentValue}
-                    required = { required }
-                    errors = { currentErrors }
+                    required={required}
+                    errors={currentErrors}
                     onChange={(value) => {
                       onChange(value, [key])
                     }}
@@ -227,11 +226,11 @@ const RequestBody = ({
                       isDisabled={Array.isArray(currentValue) ? currentValue.length !== 0 : !isEmptyValue(currentValue)}
                     />
                   )}
-                </div> : null }
+                </div> : null}
               </td>
-              </tr>
-            })
-          }
+            </tr>
+          })
+        }
         </tbody>
       </table>
     </div>
@@ -250,22 +249,22 @@ const RequestBody = ({
   }
 
   return <div>
-    { requestBodyDescription &&
+    {requestBodyDescription &&
       <Markdown source={requestBodyDescription} />
     }
     {
       sampleForMediaType ? (
         <ExamplesSelectValueRetainer
-            userHasEditedBody={userHasEditedBody}
-            examples={sampleForMediaType}
-            currentKey={activeExamplesKey}
-            currentUserInputValue={requestBodyValue}
-            onSelect={handleExamplesSelect}
-            updateValue={onChange}
-            defaultToFirstExample={true}
-            getComponent={getComponent}
-            setRetainRequestBodyValueFlag={setRetainRequestBodyValueFlag}
-          />
+          userHasEditedBody={userHasEditedBody}
+          examples={sampleForMediaType}
+          currentKey={activeExamplesKey}
+          currentUserInputValue={requestBodyValue}
+          onSelect={handleExamplesSelect}
+          updateValue={onChange}
+          defaultToFirstExample={true}
+          getComponent={getComponent}
+          setRetainRequestBodyValueFlag={setRetainRequestBodyValueFlag}
+        />
       ) : null
     }
     {
@@ -281,9 +280,9 @@ const RequestBody = ({
         </div>
       ) : (
         <ModelExample
-          getComponent={ getComponent }
-          getConfigs={ getConfigs }
-          specSelectors={ specSelectors }
+          getComponent={getComponent}
+          getConfigs={getConfigs}
+          specSelectors={specSelectors}
           expandDepth={1}
           isExecute={isExecute}
           schema={mediaTypeValue.get("schema")}
@@ -327,7 +326,7 @@ RequestBody.propTypes = {
   activeExamplesKey: PropTypes.string,
   updateActiveExamplesKey: PropTypes.func,
   setRetainRequestBodyValueFlag: PropTypes.func,
-  oas3Actions: PropTypes.object.isRequired
+  oas3Actions: PropTypes.object.isRequired,
 }
 
 export default RequestBody

--- a/src/core/plugins/oas3/components/request-body.jsx
+++ b/src/core/plugins/oas3/components/request-body.jsx
@@ -129,11 +129,12 @@ const RequestBody = ({
     return <Input type={"file"} onChange={handleFile} />
   }
 
+  const isContentTypeMultipart = contentType.indexOf("multipart/") === 0
   if (
     isObjectContent &&
     (
       contentType === "application/x-www-form-urlencoded" ||
-      contentType.indexOf("multipart/") === 0
+      isContentTypeMultipart
     ) &&
     schemaForMediaType.get("properties", OrderedMap()).size > 0
   ) {

--- a/src/core/plugins/oas3/components/request-body.jsx
+++ b/src/core/plugins/oas3/components/request-body.jsx
@@ -188,6 +188,10 @@ const RequestBody = ({
 
             const isFile = type === "string" && (format === "binary" || format === "base64")
 
+            const schemaPartForKey = mediaTypeValue
+              .get("schema")
+              .update("properties", (properties) => properties.filter((v, k) => k === key))
+
             return <tr key={key} className="parameters" data-property-name={key}>
               <td className="parameters-col_name">
                 <div className={required ? "parameter__name required" : "parameter__name"}>
@@ -228,6 +232,23 @@ const RequestBody = ({
                     />
                   )}
                 </div> : null}
+                {!isExecute && isContentTypeMultipart && type === "object" ? (
+                  <ModelExample
+                    getComponent={getComponent}
+                    getConfigs={getConfigs}
+                    specSelectors={specSelectors}
+                    expandDepth={1}
+                    isExecute={false}
+                    schema={schemaPartForKey}
+                    specPath={specPath.push("content", contentType)}
+                    example={
+                      <HighlightCode className="body-param__example" language={"json"}>
+                        {initialValue}
+                      </HighlightCode>
+                    }
+                    includeWriteOnly={true}
+                  />
+                ) : null}
               </td>
             </tr>
           })

--- a/test/e2e-cypress/e2e/features/oas3-request-body-default-views.cy.js
+++ b/test/e2e-cypress/e2e/features/oas3-request-body-default-views.cy.js
@@ -12,5 +12,29 @@ describe("OAS3 default views", () => {
         .get(".parameters-col_description textarea")
         .should("contains.text", "\"stuff\": \"string\"")
     })
+
+    it("should display calculated object string as example (#4581, #5169, #9756)", () => {
+      cy.visit(
+        "/?url=/documents/features/request-body/multipart/default-views.yaml",
+      )
+        .get("#operations-default-post_test")
+        .click()
+        // Show example
+        .get(".parameters-col_description code")
+        .should("contains.text", "\"stuff\": \"string\"")
+        // Switch to schema
+        .get(".parameters-col_description")
+        .contains("Schema")
+        .click()
+        .get(".parameters-col_description")
+        .should("contains.text", "parameters")
+        .should("not.contain.text", "file")
+        .should("contains.text", "TestBody")
+        // Expand Try It Out to hide example
+        .get(".try-out__btn")
+        .click()
+        .get(".parameters-col_description textarea")
+        .should("contains.text", "\"stuff\": \"string\"")
+    })
   })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Request objects for `multipart/form-data` current don't show the example structure or schema, as `application/json` do. This PR reuses `<ModelExample />` to also show example data for `multipart/form-data`. Also I enabled `prettier` with the projects settings, so some spacing inconsistencies are fixed as well.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

Fixes #4581
Fixes #5169
Fixes #9756


### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I used `npm run dev` and an oas3 file with `multipart/form-data`.

### Screenshots (if appropriate):

Before
![image](https://github.com/user-attachments/assets/fe2cb32d-41d1-4acc-9f64-3fd1f396212b)

Example object
![image](https://github.com/user-attachments/assets/28091b84-39a0-4ac8-9aef-14ae7c223f3f)

Partial schema
![image](https://github.com/user-attachments/assets/50c90c68-3633-44c0-bc55-3d093b4de9f2)

Unchanged Try It Out
![image](https://github.com/user-attachments/assets/14e147af-92a7-49bd-9566-759c26e12191)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
