### PR TITLE
feature: added scroll to top button

### DIFF
--- a/src/core/components/app.jsx
+++ b/src/core/components/app.jsx
@@ -3,6 +3,7 @@
  */
 import React from "react"
 import PropTypes from "prop-types"
+import ScrollToTopButton from "./scroll-to-top"
 
 class App extends React.Component {
   getLayout() {
@@ -18,7 +19,12 @@ class App extends React.Component {
   render() {
     const Layout = this.getLayout()
 
-    return <Layout />
+    return (
+      <>
+      <ScrollToTopButton />
+      <Layout />
+      </>
+    )
   }
 }
 

--- a/src/core/components/scroll-to-top.jsx
+++ b/src/core/components/scroll-to-top.jsx
@@ -1,0 +1,85 @@
+import React, { useState, useEffect } from "react"
+
+const ScrollToTopButton = () => {
+  const [isVisible, setIsVisible] = useState(false)
+  const [hideTimeout, setHideTimeout] = useState(null) 
+
+  const styles = {
+    button: {
+      position: "fixed",
+      bottom: "20px",
+      right: "20px",
+      padding: "10px 20px",
+      fontSize: "18px",
+      backgroundColor: "rgba(125, 132, 146, 0.8)",
+      color: "#fff",
+      border: "2px solid rgba(125, 132, 146, 0.8)",
+      borderRadius: "5px",
+      cursor: "pointer",
+      boxShadow: "0px 4px 6px rgba(0, 0, 0, 0.1), 0 0 15px rgba(125, 132, 146, 0.6)",
+      transition: "opacity 0.5s ease, box-shadow 0.3s ease",
+      opacity: isVisible ? 1 : 0,
+      pointerEvents: isVisible ? "auto" : "none",
+    },
+    icon: {
+      width: "20px",
+      height: "20px",
+      fill: "#fff",
+    },
+  }
+
+  const toggleVisibility = () => {
+    if (window.scrollY > 300) {
+      setIsVisible(true)
+
+      if (hideTimeout) {
+        clearTimeout(hideTimeout)
+      }
+
+      const timeout = setTimeout(() => {
+        setIsVisible(false)
+      }, 3000)
+
+      setHideTimeout(timeout)
+    } else {
+      setIsVisible(false)
+    }
+  }
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    })
+  }
+
+  useEffect(() => {
+    window.addEventListener("scroll", toggleVisibility)
+
+    return () => {
+      window.removeEventListener("scroll", toggleVisibility)
+      if (hideTimeout) {
+        clearTimeout(hideTimeout)
+      }
+    }
+  }, [hideTimeout])
+
+  return (
+    <div>
+      {isVisible && (
+        <button 
+            onClick={scrollToTop} 
+            style={styles.button}
+            title="Go to top"
+            aria-label="Go to top"
+        >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" style={styles.icon} aria-hidden="true">
+                <path d="M 17.418 14.908 C 17.69 15.176 18.127 15.176 18.397 14.908 C 18.667 14.64 18.668 14.207 18.397 13.939 L 10.489 6.109 C 10.219 5.841 9.782 5.841 9.51 6.109 L 1.602 13.939 C 1.332 14.207 1.332 14.64 1.602 14.908 C 1.873 15.176 2.311 15.176 2.581 14.908 L 10 7.767 L 17.418 14.908 Z"></path>         
+            </svg>
+        </button>
+      )}
+    </div>
+  )
+}
+
+export default ScrollToTopButton


### PR DESCRIPTION
I added a scroll to top button which enhances user experiences by enabling them to quickly go to top of the page when they have many APIs in the page.

### Description
I created a component to implement the functionality of the scroll to top and rendered it in the main app. When the user scrolls down the scroll to top icon appears on the bottom right of the page for 3 seconds until the users scrolls again. The button's appearance is consistent with the Swagger UI theme and style.

Fixes #10169

### Screenshots (if appropriate):

https://github.com/user-attachments/assets/e90419a5-5e1d-4c13-97ef-b6681a9037b8


### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.