### PR TITLE
chore(docker): remove explicit Node.js install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,6 @@
 
 FROM nginx:1.27.2-alpine
 
-RUN apk update && apk add --no-cache "nodejs>=18.20.1-r0 "
-
 LABEL maintainer="char0n"
 
 ENV API_KEY="**None**" \


### PR DESCRIPTION
No need for explicit Node.js install as the base image comes with Node.js@20.12.1 already.