### PR TITLE
feat(analytics): use Scarf.js to provide anonymized installation analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,23 @@ The OpenAPI Specification has undergone 5 revisions since initial creation in 20
 | 1.0.13             | 2013-03-08   | 1.1, 1.2                               | [tag v1.0.13](https://github.com/swagger-api/swagger-ui/tree/v1.0.13) |
 | 1.0.1              | 2011-10-11   | 1.0, 1.1                               | [tag v1.0.1](https://github.com/swagger-api/swagger-ui/tree/v1.0.1)   |
 
+## Anonymized analytics
+
+SwaggerUI uses [Scarf](https://scarf.sh/) to collect [anonymized installation analytics](https://github.com/scarf-sh/scarf-js?tab=readme-ov-file#as-a-user-of-a-package-using-scarf-js-what-information-does-scarf-js-send-about-me). These analytics help support the maintainers of this library and ONLY run during installation. To [opt out](https://github.com/scarf-sh/scarf-js?tab=readme-ov-file#as-a-user-of-a-package-using-scarf-js-how-can-i-opt-out-of-analytics), you can set the `scarfSettings.enabled` field to `false` in your project's `package.json`:
+
+```
+// package.json
+{
+  // ...
+  "scarfSettings": {
+    "enabled": false
+  }
+  // ...
+}
+```
+
+Alternatively, you can set the environment variable `SCARF_ANALYTICS` to `false` as part of the environment that installs your npm packages, e.g., `SCARF_ANALYTICS=false npm install`.
+
 ## Documentation
 
 #### Usage

--- a/flavors/swagger-ui-react/README.md
+++ b/flavors/swagger-ui-react/README.md
@@ -10,6 +10,24 @@ It has a few differences from the main version of Swagger UI:
 
 Versions of this module mirror the version of Swagger UI included in the distribution.
 
+## Anonymized analytics
+
+`swagger-ui-react` uses [Scarf](https://scarf.sh/) to collect [anonymized installation analytics](https://github.com/scarf-sh/scarf-js?tab=readme-ov-file#as-a-user-of-a-package-using-scarf-js-what-information-does-scarf-js-send-about-me). These analytics help support the maintainers of this library and ONLY run during installation. To [opt out](https://github.com/scarf-sh/scarf-js?tab=readme-ov-file#as-a-user-of-a-package-using-scarf-js-how-can-i-opt-out-of-analytics), you can set the `scarfSettings.enabled` field to `false` in your project's `package.json`:
+
+```
+// package.json
+{
+  // ...
+  "scarfSettings": {
+    "enabled": false
+  }
+  // ...
+}
+```
+
+Alternatively, you can set the environment variable `SCARF_ANALYTICS` to `false` as part of the environment that installs your npm packages, e.g., `SCARF_ANALYTICS=false npm install`.
+
+
 ## Quick start
 
 Install `swagger-ui-react`:

--- a/flavors/swagger-ui-react/release/run.sh
+++ b/flavors/swagger-ui-react/release/run.sh
@@ -35,8 +35,8 @@ cp ../../../NOTICE ../dist
 # Run the release from the dist folder
 cd ../dist
 
-if [ "$PUBLISH_FLAVOR_REACT" = "true" ] ; then
-  npm publish .
-else
-  npm pack .
-fi
+#if [ "$PUBLISH_FLAVOR_REACT" = "true" ] ; then
+#  npm publish .
+#else
+#  npm pack .
+#fi

--- a/flavors/swagger-ui-react/release/run.sh
+++ b/flavors/swagger-ui-react/release/run.sh
@@ -35,8 +35,8 @@ cp ../../../NOTICE ../dist
 # Run the release from the dist folder
 cd ../dist
 
-#if [ "$PUBLISH_FLAVOR_REACT" = "true" ] ; then
-#  npm publish .
-#else
-#  npm pack .
-#fi
+if [ "$PUBLISH_FLAVOR_REACT" = "true" ] ; then
+  npm publish .
+else
+  npm pack .
+fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@babel/runtime-corejs3": "^7.24.7",
         "@braintree/sanitize-url": "=7.0.4",
+        "@scarf/scarf": "=1.3.0",
         "base64-js": "^1.5.1",
         "classnames": "^2.5.1",
         "css.escape": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
   "dependencies": {
     "@babel/runtime-corejs3": "^7.24.7",
     "@braintree/sanitize-url": "=7.0.4",
+    "@scarf/scarf": "=1.3.0",
     "base64-js": "^1.5.1",
     "classnames": "^2.5.1",
     "css.escape": "1.5.1",

--- a/swagger-ui-dist-package/README.md
+++ b/swagger-ui-dist-package/README.md
@@ -1,6 +1,24 @@
 # Swagger UI Dist
 [![NPM version](https://badge.fury.io/js/swagger-ui-dist.svg)](http://badge.fury.io/js/swagger-ui-dist)
 
+## Anonymized analytics
+
+SwaggerUI Dist uses [Scarf](https://scarf.sh/) to collect [anonymized installation analytics](https://github.com/scarf-sh/scarf-js?tab=readme-ov-file#as-a-user-of-a-package-using-scarf-js-what-information-does-scarf-js-send-about-me). These analytics help support the maintainers of this library and ONLY run during installation. To [opt out](https://github.com/scarf-sh/scarf-js?tab=readme-ov-file#as-a-user-of-a-package-using-scarf-js-how-can-i-opt-out-of-analytics), you can set the `scarfSettings.enabled` field to `false` in your project's `package.json`:
+
+```
+// package.json
+{
+  // ...
+  "scarfSettings": {
+    "enabled": false
+  }
+  // ...
+}
+```
+
+Alternatively, you can set the environment variable `SCARF_ANALYTICS` to `false` as part of the environment that installs your npm packages, e.g., `SCARF_ANALYTICS=false npm install`.
+
+
 # API
 
 This module, `swagger-ui-dist`, exposes Swagger-UI's entire dist folder as a dependency-free npm module.

--- a/swagger-ui-dist-package/package.json
+++ b/swagger-ui-dist-package/package.json
@@ -13,6 +13,8 @@
     "Sahar Jafari <shr.jafari@gmail.com>"
   ],
   "license": "Apache-2.0",
-  "dependencies": {},
+  "dependencies": {
+    "@scarf/scarf": "=1.3.0"
+  },
   "devDependencies": {}
 }


### PR DESCRIPTION
## Anonymized analytics

SwaggerUI uses [Scarf](https://scarf.sh/) to collect [anonymized installation analytics](https://github.com/scarf-sh/scarf-js?tab=readme-ov-file#as-a-user-of-a-package-using-scarf-js-what-information-does-scarf-js-send-about-me). These analytics help support the maintainers of this library and ONLY run during installation. To [opt out](https://github.com/scarf-sh/scarf-js?tab=readme-ov-file#as-a-user-of-a-package-using-scarf-js-how-can-i-opt-out-of-analytics), you can set the `scarfSettings.enabled` field to `false` in your project's `package.json`:

```
// package.json
{
  // ...
  "scarfSettings": {
    "enabled": false
  }
  // ...
}
```

Alternatively, you can set the environment variable `SCARF_ANALYTICS` to `false` as part of the environment that installs your npm packages, e.g., `SCARF_ANALYTICS=false npm install`.
