### PR TITLE
chore(docker): disable apk cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM nginx:1.27.2-alpine
 
-RUN apk update && apk add "nodejs"
+RUN apk add --update-cache --no-cache "nodejs"
 
 LABEL maintainer="char0n"
 


### PR DESCRIPTION
Restore `apk --no-cache` flags after #10192 and #10198 as Dockerfile best practice.
Also replaced `apk update` by `--update-cache` flag.