### PR TITLE
Correctly match oneOf mappings when generating example values

### DIFF
--- a/src/core/plugins/json-schema-5-samples/fn/index.js
+++ b/src/core/plugins/json-schema-5-samples/fn/index.js
@@ -351,13 +351,24 @@ export const sampleFromSchemaGeneric = (schema, config={}, exampleOverride = und
         schema.discriminator &&
         Object.prototype.hasOwnProperty.call(schema.discriminator, "mapping") &&
         schema.discriminator.mapping &&
-        Object.prototype.hasOwnProperty.call(schema, "$$ref") &&
-        schema.$$ref &&
+        Object.prototype.hasOwnProperty.call(schema, "oneOf") &&
+        schema.oneOf &&
         schema.discriminator.propertyName === propName) {
-        for (let pair in schema.discriminator.mapping){
-          if (schema.$$ref.search(schema.discriminator.mapping[pair]) !== -1) {
-            res[propName] = pair
-            break
+
+        for (let option of schema.oneOf) {
+          if (Object.prototype.hasOwnProperty.call(option, "$$ref")) {
+            let found = false
+            for (let pair in schema.discriminator.mapping){
+              if (option.$$ref.search(schema.discriminator.mapping[pair]) !== -1) {
+                res[propName] = pair
+                found = true
+                break
+              }
+            }
+            
+            if (found) {
+              break
+            }
           }
         }
       } else {

--- a/src/core/plugins/json-schema-5-samples/fn/index.js
+++ b/src/core/plugins/json-schema-5-samples/fn/index.js
@@ -356,7 +356,7 @@ export const sampleFromSchemaGeneric = (schema, config={}, exampleOverride = und
         schema.discriminator.propertyName === propName) {
 
         for (let option of schema.oneOf) {
-          if (Object.prototype.hasOwnProperty.call(option, "$$ref")) {
+          if (Object.prototype.hasOwnProperty.call(option, "$$ref") && option.$$ref) {
             let found = false
             for (let pair in schema.discriminator.mapping){
               if (option.$$ref.search(schema.discriminator.mapping[pair]) !== -1) {


### PR DESCRIPTION
Correctly match oneOf mappings when generating example values for oneOf's with discriminators.
Previously it was trying to match the mapping against the parent entity (the one with the oneOf set), which would fail to match, therefore excluding the discriminator property (#8336)

### Motivation and Context
Fixes #8336



### How Has This Been Tested?
Manually tested to see that the discriminator property now shows up

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
