### PR TITLE
Fix audio response playback for non-GET requests

### DIFF
--- a/src/core/components/live-response.jsx
+++ b/src/core/components/live-response.jsx
@@ -109,7 +109,8 @@ export default class LiveResponse extends React.Component {
                           : null
                 }
                 {
-                  body ? <ResponseBody content={ body }
+                  body ? <ResponseBody method={ method }
+                                       content={ body }
                                        contentType={ contentType }
                                        url={ url }
                                        headers={ headers }

--- a/src/core/components/response-body.jsx
+++ b/src/core/components/response-body.jsx
@@ -12,6 +12,7 @@ export default class ResponseBody extends React.PureComponent {
   }
 
   static propTypes = {
+    method: PropTypes.string,
     content: PropTypes.any.isRequired,
     contentType: PropTypes.string,
     getComponent: PropTypes.func.isRequired,
@@ -50,7 +51,7 @@ export default class ResponseBody extends React.PureComponent {
   }
 
   render() {
-    let { content, contentType, url, headers={}, getComponent } = this.props
+    let { method, content, contentType, url, headers={}, getComponent } = this.props
     const { parsedContent } = this.state
     const HighlightCode = getComponent("HighlightCode", true)
     const downloadName = "response_" + new Date().getTime()
@@ -135,6 +136,9 @@ export default class ResponseBody extends React.PureComponent {
 
       // Audio
     } else if (/^audio\//i.test(contentType)) {
+      if (method !== "get") {
+        url = window.URL.createObjectURL(content)
+      }
       bodyEl = <pre className="microlight"><audio controls key={ url }><source src={ url } type={ contentType } /></audio></pre>
     } else if (typeof content === "string") {
       bodyEl = <HighlightCode downloadable fileName={`${downloadName}.txt`} canCopy>{content}</HighlightCode>


### PR DESCRIPTION
This PR is another attempt to fix #8378 when audio playback controller point to the URL of dynamically generated content and not the actual returned content (in browser memory).

### Description
The difference of this PR from the previous attempt by the issue author is that this PR checks if the request method was other than GET (and thus is compatible with the default behavior) before trying to convert returned response content to a blob URL into browser cache memory.

### Motivation and Context
The problem with the default approach before this PR is that it assumes the URL points to a static resource on the remote host, but in case of dynamically generated audio content (as it usually is the case with Text-to-Speech APIs), the REST API call requires extra parameters (without such the response is invalid) and is not reasonable to be run implicitly by browser.

Fixes #8378.

### How Has This Been Tested?
Tested with POST request to a TTS (Text-to-Speech) API endpoint that generates audio response dynamically on-demand depending on extra parameters (query, body content etc.).

### Screenshots (if appropriate):

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
