### PR TITLE
feat(oas31): add support for file upload

### DIFF
--- a/src/core/plugins/oas3/components/request-body.jsx
+++ b/src/core/plugins/oas3/components/request-body.jsx
@@ -1,4 +1,3 @@
-
 import React from "react"
 import PropTypes from "prop-types"
 import ImPropTypes from "react-immutable-proptypes"
@@ -34,24 +33,24 @@ export const getDefaultRequestBodyValue = (requestBody, mediaType, activeExample
 
 
 const RequestBody = ({
-                       userHasEditedBody,
-                       requestBody,
-                       requestBodyValue,
-                       requestBodyInclusionSetting,
-                       requestBodyErrors,
-                       getComponent,
-                       getConfigs,
-                       specSelectors,
-                       fn,
-                       contentType,
-                       isExecute,
-                       specPath,
-                       onChange,
-                       onChangeIncludeEmpty,
-                       activeExamplesKey,
-                       updateActiveExamplesKey,
-                       setRetainRequestBodyValueFlag
-                     }) => {
+  userHasEditedBody,
+  requestBody,
+  requestBodyValue,
+  requestBodyInclusionSetting,
+  requestBodyErrors,
+  getComponent,
+  getConfigs,
+  specSelectors,
+  fn,
+  contentType,
+  isExecute,
+  specPath,
+  onChange,
+  onChangeIncludeEmpty,
+  activeExamplesKey,
+  updateActiveExamplesKey,
+  setRetainRequestBodyValueFlag
+}) => {
   const handleFile = (e) => {
     onChange(e.target.files[0])
   }
@@ -111,7 +110,7 @@ const RequestBody = ({
   if (!mediaTypeValue.size && !isOAS31FileSchema) {
     return null
   }
-
+  
   if (isFileContentType || isFileFormat) {
     const Input = getComponent("Input")
 
@@ -145,62 +144,62 @@ const RequestBody = ({
       }
       <table>
         <tbody>
-        {
-          Map.isMap(bodyProperties) && bodyProperties.entrySeq().map(([key, schema]) => {
-            if (schema.get("readOnly")) return
+          {
+            Map.isMap(bodyProperties) && bodyProperties.entrySeq().map(([key, schema]) => {
+              if (schema.get("readOnly")) return
 
-            const oneOf = schema.get("oneOf")?.get(0)?.toJS()
-            const anyOf = schema.get("anyOf")?.get(0)?.toJS()
-            schema = fromJS(fn.mergeJsonSchema(schema.toJS(), oneOf ?? anyOf ?? {}))
+              const oneOf = schema.get("oneOf")?.get(0)?.toJS()
+              const anyOf = schema.get("anyOf")?.get(0)?.toJS()
+              schema = fromJS(fn.mergeJsonSchema(schema.toJS(), oneOf ?? anyOf ?? {}))
 
-            let commonExt = showCommonExtensions ? getCommonExtensions(schema) : null
-            const required = schemaForMediaType.get("required", List()).includes(key)
-            const typeLabel = fn.jsonSchema202012.getType(immutableToJS(schema))
-            const type = fn.jsonSchema202012.foldType(immutableToJS(schema?.get("type")))
-            const itemType = fn.jsonSchema202012.foldType(immutableToJS(schema?.getIn(["items", "type"])))
-            const format = schema.get("format")
-            const description = schema.get("description")
-            const currentValue = requestBodyValue.getIn([key, "value"])
-            const currentErrors = requestBodyValue.getIn([key, "errors"]) || requestBodyErrors
-            const included = requestBodyInclusionSetting.get(key) || false
+              let commonExt = showCommonExtensions ? getCommonExtensions(schema) : null
+              const required = schemaForMediaType.get("required", List()).includes(key)
+              const typeLabel = fn.jsonSchema202012.getType(immutableToJS(schema))
+              const type = fn.jsonSchema202012.foldType(immutableToJS(schema?.get("type"))) 
+              const itemType = fn.jsonSchema202012.foldType(immutableToJS(schema?.getIn(["items", "type"]))) 
+              const format = schema.get("format")
+              const description = schema.get("description")
+              const currentValue = requestBodyValue.getIn([key, "value"])
+              const currentErrors = requestBodyValue.getIn([key, "errors"]) || requestBodyErrors
+              const included = requestBodyInclusionSetting.get(key) || false
 
-            let initialValue = fn.getSampleSchema(schema, false, {
-              includeWriteOnly: true
-            })
+              let initialValue = fn.getSampleSchema(schema, false, {
+                includeWriteOnly: true
+              })
 
-            if (initialValue === false) {
-              initialValue = "false"
-            }
+              if (initialValue === false) {
+                initialValue = "false"
+              }
 
-            if (initialValue === 0) {
-              initialValue = "0"
-            }
+              if (initialValue === 0) {
+                initialValue = "0"
+              }
 
-            if (typeof initialValue !== "string" && type === "object") {
-              initialValue = stringify(initialValue)
-            }
+              if (typeof initialValue !== "string" && type === "object") {
+               initialValue = stringify(initialValue)
+              }
 
-            if (typeof initialValue === "string" && type === "array") {
-              initialValue = JSON.parse(initialValue)
-            }
+              if (typeof initialValue === "string" && type === "array") {
+                initialValue = JSON.parse(initialValue)
+              }
 
-            const isFile = fn.getIsFileFormat(schema)
+              const isFile = fn.getIsFileFormat(schema)
 
-            const jsonSchemaForm = <JsonSchemaForm
-              fn={fn}
-              dispatchInitialValue={!isFile}
-              schema={schema}
-              description={key}
-              getComponent={getComponent}
-              value={currentValue === undefined ? initialValue : currentValue}
-              required={required}
-              errors={currentErrors}
-              onChange={(value) => {
-                onChange(value, [key])
-              }}
-            />
+              const jsonSchemaForm = <JsonSchemaForm
+                fn={fn}
+                dispatchInitialValue={!isFile}
+                schema={schema}
+                description={key}
+                getComponent={getComponent}
+                value={currentValue === undefined ? initialValue : currentValue}
+                required={required}
+                errors={currentErrors}
+                onChange={(value) => {
+                  onChange(value, [key])
+                }}
+              />
 
-            return <tr key={key} className="parameters" data-property-name={key}>
+              return <tr key={key} className="parameters" data-property-name={key}>
               <td className="parameters-col_name">
                 <div className={required ? "parameter__name required" : "parameter__name"}>
                   { key }
@@ -219,7 +218,7 @@ const RequestBody = ({
                 <Markdown source={ description }></Markdown>
                 {isExecute ? <div>
                   {(type === "object" || itemType === "object") ? (
-                    <ModelExample
+                    <ModelExample 
                       getComponent={getComponent}
                       specPath={specPath.push("schema")}
                       getConfigs={getConfigs}
@@ -228,7 +227,7 @@ const RequestBody = ({
                       schema={schema}
                       example={jsonSchemaForm}
                     />
-                  ) : jsonSchemaForm
+                    ) : jsonSchemaForm
                   }
                   {required ? null : (
                     <ParameterIncludeEmpty
@@ -240,9 +239,9 @@ const RequestBody = ({
                   )}
                 </div> : null }
               </td>
-            </tr>
-          })
-        }
+              </tr>
+            })
+          }
         </tbody>
       </table>
     </div>
@@ -267,16 +266,16 @@ const RequestBody = ({
     {
       sampleForMediaType ? (
         <ExamplesSelectValueRetainer
-          userHasEditedBody={userHasEditedBody}
-          examples={sampleForMediaType}
-          currentKey={activeExamplesKey}
-          currentUserInputValue={requestBodyValue}
-          onSelect={handleExamplesSelect}
-          updateValue={onChange}
-          defaultToFirstExample={true}
-          getComponent={getComponent}
-          setRetainRequestBodyValueFlag={setRetainRequestBodyValueFlag}
-        />
+            userHasEditedBody={userHasEditedBody}
+            examples={sampleForMediaType}
+            currentKey={activeExamplesKey}
+            currentUserInputValue={requestBodyValue}
+            onSelect={handleExamplesSelect}
+            updateValue={onChange}
+            defaultToFirstExample={true}
+            getComponent={getComponent}
+            setRetainRequestBodyValueFlag={setRetainRequestBodyValueFlag}
+          />
       ) : null
     }
     {

--- a/src/core/plugins/oas3/fn.js
+++ b/src/core/plugins/oas3/fn.js
@@ -1,0 +1,20 @@
+/**
+ * @prettier
+ */
+
+export const getIsFileFormat = (schema) => {
+  if (!schema) return false
+
+  const isStringType = schema.get("type") === "string"
+  const format = schema.get("format")
+  const isBinaryFormat = format === "binary"
+  const isBase64Format = format === "base64" || format === "byte"
+
+  return isStringType && (isBinaryFormat || isBase64Format)
+}
+
+export const getIsFileContentType = (contentType) =>
+  contentType === "application/octet-stream" ||
+  contentType?.indexOf("image/") === 0 ||
+  contentType?.indexOf("audio/") === 0 ||
+  contentType?.indexOf("video/") === 0

--- a/src/core/plugins/oas3/index.js
+++ b/src/core/plugins/oas3/index.js
@@ -9,6 +9,7 @@ import wrapComponents from "./wrap-components"
 import * as actions from "./actions"
 import * as selectors from "./selectors"
 import reducers from "./reducers"
+import * as fn from "./fn"
 
 export default function () {
   return {
@@ -28,5 +29,6 @@ export default function () {
         selectors: { ...selectors },
       },
     },
+    fn,
   }
 }

--- a/src/core/plugins/oas3/wrap-components/json-schema-string.jsx
+++ b/src/core/plugins/oas3/wrap-components/json-schema-string.jsx
@@ -15,12 +15,12 @@ export default OAS3ComponentWrapFactory(({ Ori, ...props }) => {
 
   if (isFileFormat) {
     return <Input type="file"
-                  className={ errors.length ? "invalid" : ""}
-                  title={ errors.length ? errors : ""}
-                  onChange={(e) => {
-                    onChange(e.target.files[0])
-                  }}
-                  disabled={Ori.isDisabled}/>
+                   className={ errors.length ? "invalid" : ""}
+                   title={ errors.length ? errors : ""}
+                   onChange={(e) => {
+                     onChange(e.target.files[0])
+                   }}
+                   disabled={Ori.isDisabled}/>
   } else {
     return <Ori {...props} />
   }

--- a/src/core/plugins/oas3/wrap-components/json-schema-string.jsx
+++ b/src/core/plugins/oas3/wrap-components/json-schema-string.jsx
@@ -6,21 +6,21 @@ export default OAS3ComponentWrapFactory(({ Ori, ...props }) => {
     schema,
     getComponent,
     errors,
-    onChange
+    onChange,
+    fn
   } = props
 
-  const format = schema && schema.get ? schema.get("format") : null
-  const type = schema && schema.get ? schema.get("type") : null
+  const isFileFormat = fn.getIsFileFormat(schema)
   const Input = getComponent("Input")
 
-  if(type && type === "string" && (format && (format === "binary" || format === "base64"))) {
+  if (isFileFormat) {
     return <Input type="file"
-                   className={ errors.length ? "invalid" : ""}
-                   title={ errors.length ? errors : ""}
-                   onChange={(e) => {
-                     onChange(e.target.files[0])
-                   }}
-                   disabled={Ori.isDisabled}/>
+                  className={ errors.length ? "invalid" : ""}
+                  title={ errors.length ? errors : ""}
+                  onChange={(e) => {
+                    onChange(e.target.files[0])
+                  }}
+                  disabled={Ori.isDisabled}/>
   } else {
     return <Ori {...props} />
   }

--- a/src/core/plugins/oas31/after-load.js
+++ b/src/core/plugins/oas31/after-load.js
@@ -6,6 +6,7 @@ import {
   getProperties,
 } from "./json-schema-2020-12-extensions/fn"
 import { wrapOAS31Fn } from "./fn"
+import { makeGetIsFileFormat } from "./oas3-extensions/fn"
 
 function afterLoad({ fn, getSystem }) {
   // overrides for fn.jsonSchema202012
@@ -32,6 +33,7 @@ function afterLoad({ fn, getSystem }) {
         getXmlSampleSchema: fn.jsonSchema202012.getXmlSampleSchema,
         getSampleSchema: fn.jsonSchema202012.getSampleSchema,
         mergeJsonSchema: fn.jsonSchema202012.mergeJsonSchema,
+        getIsFileFormat: makeGetIsFileFormat(fn),
       },
       getSystem()
     )

--- a/src/core/plugins/oas31/oas3-extensions/fn.js
+++ b/src/core/plugins/oas31/oas3-extensions/fn.js
@@ -1,0 +1,23 @@
+/**
+ * @prettier
+ */
+import { immutableToJS } from "core/utils"
+
+export const makeGetIsFileFormat = (fn) => {
+  const getIsFileFormat = (schema) => {
+    if (!schema) return null
+
+    const type = fn.jsonSchema202012.getType(immutableToJS(schema))
+    const isFileContentMediaType = fn.getIsFileContentType(
+      schema.get("contentMediaType")
+    )
+    const isBase64Encoding = schema.get("contentEncoding") === "base64"
+
+    return (
+      (type === "string" || type === "any") &&
+      (isFileContentMediaType || isBase64Encoding)
+    )
+  }
+
+  return getIsFileFormat
+}

--- a/test/e2e-cypress/e2e/features/plugins/oas31/oas31-file-upload.cy.js
+++ b/test/e2e-cypress/e2e/features/plugins/oas31/oas31-file-upload.cy.js
@@ -1,0 +1,65 @@
+/**
+ * @prettier
+ */
+
+describe("OpenAPI 3.1.0 file upload", () => {
+  beforeEach(() => {
+    cy.visit("/?url=/documents/features/oas31-file-upload.yaml")
+  })
+
+  it("should render file input when contentMediaType of request body schema is application/octet-stream", () => {
+    cy.get(".opblock-summary-path span")
+      .contains("/requestBody-contentMediaType")
+      .click()
+    cy.contains("Try it out").click()
+    cy.get(".opblock-description-wrapper input[type=file]").should("exist")
+  })
+
+  it("should render file input when contentEncoding of request body schema is base64", () => {
+    cy.get(".opblock-summary-path span")
+      .contains("/requestBody-contentEncoding")
+      .click()
+    cy.contains("Try it out").click()
+    cy.get(".opblock-description-wrapper input[type=file]").should("exist")
+  })
+
+  it("should render file input when Media Type Object for file upload is empty", () => {
+    cy.get(".opblock-summary-path span")
+      .contains("/requestBody-noSchema")
+      .click()
+    cy.contains("Try it out").click()
+    cy.get(".opblock-description-wrapper input[type=file]").should("exist")
+  })
+
+  it("should render file input when contentMediaType of a parameter schema is application/octet-stream", () => {
+    cy.get(".opblock-summary-path span")
+      .contains("/parameter-contentMediaType")
+      .click()
+    cy.contains("Try it out").click()
+    cy.get(".parameters-col_description input[type=file]").should("exist")
+  })
+
+  it("should render file input when contentEncoding of a parameter schema is base64", () => {
+    cy.get(".opblock-summary-path span")
+      .contains("/parameter-contentEncoding")
+      .click()
+    cy.contains("Try it out").click()
+    cy.get(".parameters-col_description input[type=file]").should("exist")
+  })
+
+  it("should render file input when contentMediaType of a multipart/form-data object property is application/octet-stream", () => {
+    cy.get(".opblock-summary-path span")
+      .contains("/property-contentMediaType")
+      .click()
+    cy.contains("Try it out").click()
+    cy.get(".opblock-description-wrapper input[type=file]").should("exist")
+  })
+
+  it("should render file input when contentEncoding of a multipart/form-data object property is base64", () => {
+    cy.get(".opblock-summary-path span")
+      .contains("/property-contentEncoding")
+      .click()
+    cy.contains("Try it out").click()
+    cy.get(".opblock-description-wrapper input[type=file]").should("exist")
+  })
+})

--- a/test/e2e-cypress/static/documents/features/oas31-file-upload.yaml
+++ b/test/e2e-cypress/static/documents/features/oas31-file-upload.yaml
@@ -1,0 +1,59 @@
+openapi: 3.1.0
+paths:
+  /requestBody-contentMediaType:
+    post:
+      requestBody:
+        content:
+          application/unknown:
+            schema:
+              contentMediaType: application/octet-stream
+  /requestBody-contentEncoding:
+    post:
+      requestBody:
+        content:
+          application/unknown:
+            schema:
+              contentEncoding: base64
+  /requestBody-noSchema:
+    post:
+      requestBody:
+        content:
+          application/octet-stream: {}
+  /parameter-contentMediaType:
+    post:
+      parameters:
+        - in: query
+          name: file
+          schema:
+            type: string
+            contentMediaType: application/octet-stream
+  /parameter-contentEncoding:
+    post:
+      parameters:
+        - in: query
+          name: file
+          schema:
+            type: string
+            contentEncoding: base64
+  /property-contentMediaType:
+    post:
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  contentMediaType: application/octet-stream
+  /property-contentEncoding:
+    post:
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  contentEncoding: base64


### PR DESCRIPTION
Related to OpenAPI 3.1.x.

We should now display file input when:
- `contentEncoding` is `base64`
- `contentMediaType` is `application/octet-stream`, `image/*`, `video/*` or `audio/*`
- Media Type Object is empty

Does not add support for file upload if schema has union type or if `type` and `contentEncoding/contentMediaType` are defined in `oneOf/anyOf`.

---

`base64` vs `byte`

Refs https://github.com/swagger-api/swagger-ui/issues/9278

Attribution: @glowcloud 