### PR TITLE
fix: Add case to handle x-examples value of body param.

### DIFF
--- a/src/core/components/param-body.jsx
+++ b/src/core/components/param-body.jsx
@@ -47,11 +47,19 @@ export default class ParamBody extends PureComponent {
   }
 
   updateValues = (props) => {
-    let { param, isExecute, consumesValue="" } = props
+    let { param, isExecute, consumesValue="", specSelectors, pathMethod } = props
+    let parameter = specSelectors ? specSelectors.parameterWithMetaByIdentity(pathMethod, param) : param
     let isXml = /xml/i.test(consumesValue)
     let isJson = /json/i.test(consumesValue)
     let paramValue = isXml ? param.get("value_xml") : param.get("value")
-
+    let xExample = parameter.get("x-examples")
+    if (xExample) {
+      paramValue = xExample.get('default') !== undefined ? xExample.get('default') : paramValue
+      if (typeof paramValue !== "string") {
+        paramValue = JSON.stringify(paramValue, null, 2)
+      }
+      isJson = true
+    }
     if ( paramValue !== undefined ) {
       let val = !paramValue && isJson ? "{}" : paramValue
       this.setState({ value: val })


### PR DESCRIPTION
Allow populating `body` with default values described in `x-examples`

### Description
Changes done here are to allow the use of `x-examples` inside a (`body`) `parameter` in order to populate it with default values.

### Motivation and Context
Fixes: #3233 

### How Has This Been Tested?
Manually.
Attempts were made to write unit tests, but I could not get the code (`test\unit\components\parameter-row.jsx`) to render **deep** enough in order to get the text of the `code` element.

The change in the Api declaration I used to test looks like this (can be compared with screenshots bellow).
This is the `parameters` declaration on the `POST /pet` method I used to test.
```
"parameters":[
    {
        "in":"body",
        "name":"body",
        "description":"Pet object that needs to be added to the store",
        "required":true,
        "schema":{
            "$ref":"#/definitions/Pet"
        },
        "x-examples":{
            "default":{
            "id": 101,
            "name":"brand-new-doggie",
            "photoUrls":[
                "http://example.com/doggie.jpg"
            ],
            "tags":[
                {
                    "id": 101,
                    "name":"tag101"
                }
            ],
            "status":"custom-available"
            }
        }
    }
],
```

### Screenshots (if appropriate):

The above changed declaration resulted in the following:
![image](https://github.com/user-attachments/assets/3e19d633-3c25-404b-a9e2-cc5e39eaf3a4)




## Checklist
### My PR contains... 
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
Attempts to add `unit` tests were unsuccessful because I could not get the whole DOM subtree to render.
Last thing it gave me was a `div` with with objects passed as `attributes` to it. If you have an idea how this can be tested or know of tests I could use as example just point it out to me and Im see if I can introduce tests.

- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
