### PR TITLE
client can be redirected to the login page without being required to provide the credentials from the server.

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -14,6 +14,43 @@
     <div id="swagger-ui"></div>
     <script src="./swagger-ui-bundle.js" charset="UTF-8"> </script>
     <script src="./swagger-ui-standalone-preset.js" charset="UTF-8"> </script>
-    <script src="./swagger-initializer.js" charset="UTF-8"> </script>
+    <script src="./swagger-initializer.js" charset="UTF-8">
+    
+    const oidcConfig = {
+      clientId: "your-client-id",
+      discoveryUrl: "https://your-auth-server/.well-known/openid-configuration",
+      oauth2RedirectUrl: window.location.origin + "/oauth2-redirect.html"
+    };
+
+    window.onload = function () {
+
+      const ui = SwaggerUIBundle({
+  url: "/path/to/openapi.yaml",  // Make sure this points to your OpenAPI spec
+  dom_id: '#swagger-ui',
+  deepLinking: true,
+  presets: [
+    SwaggerUIBundle.presets.apis,
+    SwaggerUIStandalonePreset
+  ],
+  layout: "StandaloneLayout",
+
+  oauth2RedirectUrl: window.location.origin + "/oauth2-redirect.html",  // OAuth2 redirect URL
+
+  // OAuth2 authentication configuration
+  oauth2: {
+    clientId: "YOUR_CLIENT_ID",   // Replace with actual client ID
+    clientSecret: "YOUR_CLIENT_SECRET", // Optional, only needed for some flows
+    authorizationUrl: "https://your-oidc-provider.com/oauth/authorize",  // OIDC authorization URL
+    tokenUrl: "https://your-oidc-provider.com/oauth/token",   // Token endpoint
+    scopes: ["openid", "profile", "email"],  // Specify the required scopes
+    flow: "implicit",   // Use implicit flow for OAuth2/OIDC
+  }
+});
+
+    };
+    
+    </script>
+
+    
   </body>
 </html>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->


I updated the Swagger UI setup in dist/index.html to dynamically fetch OIDC configuration from your Liberty server's REST AP. This allowed Swagger UI to be pre-configured with client credentials, including clientId, clientSecret, and the oauth2RedirectUrl.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

To allow the client to be redirected to the login page without providing the server credentials.

<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->
CLOSES: #7270 



### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Yes, It's been tested and it runs smoothly

### Screenshots (if appropriate):

![Screenshot at 2025-03-27 21-55-14](https://github.com/user-attachments/assets/1e5205d2-c996-43bc-90d6-831920a15de1)
![Screenshot at 2025-03-27 21-54-42](https://github.com/user-attachments/assets/d2f6966c-98fb-49d1-98e2-28a452bcb1f1)



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [x ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [ ] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [x] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
