### PR TITLE
Add support for expandable OpenAPI.webhooks grouped by tags

### DIFF
--- a/src/core/plugins/oas31/index.js
+++ b/src/core/plugins/oas31/index.js
@@ -28,6 +28,8 @@ import {
   license as selectLicense,
   contact as selectContact,
   webhooks as selectWebhooks,
+  webhooksWithTags as selectWebhooksWithTags,
+  taggedWebhooks as selectTaggedWebhooks,
   selectLicenseNameField,
   selectLicenseUrlField,
   selectLicenseIdentifierField,
@@ -143,6 +145,8 @@ const OAS31Plugin = ({ fn }) => {
 
           webhooks: createOnlyOAS31Selector(selectWebhooks),
           selectWebhooksOperations: createOnlyOAS31Selector(createSystemSelector(selectWebhooksOperations)), // prettier-ignore
+          webhooksWithTags: createOnlyOAS31Selector(createSystemSelector(selectWebhooksWithTags)), // prettier-ignore
+          taggedWebhooks: createOnlyOAS31Selector(createSystemSelector(selectTaggedWebhooks)), // prettier-ignore
 
           selectJsonSchemaDialectField,
           selectJsonSchemaDialectDefault,

--- a/src/core/plugins/oas31/spec-extensions/selectors.js
+++ b/src/core/plugins/oas31/spec-extensions/selectors.js
@@ -1,13 +1,15 @@
 /**
  * @prettier
  */
-import { List, Map } from "immutable"
+import { List, Map, Set, OrderedMap } from "immutable"
 import { createSelector } from "reselect"
 
 import { safeBuildUrl } from "core/utils/url"
 import { isOAS31 as isOAS31Fn } from "../fn"
+import { sorters } from "core/utils"
 
 const map = Map()
+const DEFAULT_TAG = "default"
 
 export const isOAS31 = createSelector(
   (state, system) => system.specSelectors.specJson(),
@@ -50,6 +52,83 @@ export const selectWebhooksOperations = createSelector(
       .groupBy((operationDTO) => operationDTO.path)
       .map((operations) => operations.toArray())
       .toObject()
+)
+
+/**
+ * Selectors for grouping webhooks by tags
+ */
+export const webhooksWithTags = createSelector(
+  [
+    (state, system) => system.specSelectors.webhooks(),
+    (state, system) => system.specSelectors.validOperationMethods(),
+    (state, system) => system.specSelectors.specResolvedSubtree(["webhooks"]),
+    (state, system) => system.specSelectors.tags(),
+  ],
+  (webhooks, validOperationMethods, resolvedWebhooks, tags) => {
+    return webhooks
+      .reduce((taggedMap, pathItem, pathItemName) => {
+        if (!Map.isMap(pathItem)) return taggedMap
+
+        const pathItemOperations = pathItem
+          .entrySeq()
+          .filter(([key]) => validOperationMethods.includes(key))
+          .map(([method, operation]) => {
+            return Map({
+              operation,
+              method,
+              path: pathItemName,
+              specPath: ["webhooks", pathItemName, method],
+              operationTags: Set(operation.get("tags", List()))
+            })
+          })
+
+        return pathItemOperations.reduce((acc, operation) => {
+          const operationTags = operation.get("operationTags")
+
+          if (operationTags.count() < 1) {
+            return acc.update(DEFAULT_TAG, List(), ar => ar.push(operation))
+          }
+
+          return operationTags.reduce(
+            (res, tag) => res.update(tag, List(), ar => ar.push(operation)),
+            acc
+          )
+        }, taggedMap)
+      }, tags.reduce((taggedMap, tag) => {
+        return taggedMap.set(tag.get("name"), List())
+      }, OrderedMap()))
+  }
+)
+
+export const taggedWebhooks = createSelector(
+  [
+    (state, system) => system.specSelectors.webhooksWithTags(state),
+    (state, system) => system.specSelectors.tags(),
+    (state, system) => system.specSelectors.tagDetails,
+  ],
+  (webhooksWithTags, tags, tagDetailsSelector) => ({ getConfigs }) => {
+    let { tagsSorter, operationsSorter } = getConfigs()
+    return webhooksWithTags
+      .sortBy(
+        (val, key) => key, // get the name of the tag to be passed to the sorter
+        (tagA, tagB) => {
+          let sortFn = (typeof tagsSorter === "function" ? tagsSorter : sorters.tagsSorter[tagsSorter])
+          return (!sortFn ? null : sortFn(tagA, tagB))
+        }
+      )
+      .map((ops, tag) => {
+        let sortFn = (typeof operationsSorter === "function" ? operationsSorter : sorters.operationsSorter[operationsSorter])
+        let operations = (!sortFn ? ops : ops.sort(sortFn))
+        
+        // Find the tag details in the tags array
+        const tagDetail = tags.find(t => t.get("name") === tag)
+        
+        return Map({ 
+          tagDetails: tagDetail || null, 
+          operations: operations 
+        })
+      })
+  }
 )
 
 export const license = () => (system) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
# Add support for expandable OpenAPI.webhooks grouped by tags

### Description
<!--- Describe your changes in detail -->
This PR implements support for expandable OpenAPI.webhooks grouped by tags in Swagger UI, similar to how OpenAPI.paths are currently handled. The implementation provides:

- New selectors (`webhooksWithTags` and `taggedWebhooks`) to properly group webhooks by their tags
- Updated Webhooks component to use these selectors for proper rendering
- Expandable/collapsible sections for each tag group
- Support for webhooks with multiple tags (appearing in each relevant section)
- Default tag section for untagged webhooks

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->
Fixes #8490 

This change improves the user experience for OpenAPI 3.1.0 specifications that include webhooks by organizing them into collapsible tag groups, consistent with how paths are displayed. Previously, webhooks were displayed as a flat list without tag organization.

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
 I've verified my changes in a local environment using webpack dev server with a test OpenAPI 3.1.0 document containing tagged webhooks.

### Screenshots (if appropriate):
Webhook Tags Overview :

![Screenshot 2025-04-07 200933](https://github.com/user-attachments/assets/bb23d7e9-e09c-4d11-b114-6cf1c42f6b93)

Expanded Webhook Sections :

![Screenshot 2025-04-07 200953](https://github.com/user-attachments/assets/b9a63439-9ba9-46e3-953a-a6f59f08e2d8)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.