### PR TITLE
fix(json-schema-2020-12): infer type string when contentEncoding or contentMediaType is present

### DIFF
--- a/src/core/plugins/json-schema-2020-12/fn.js
+++ b/src/core/plugins/json-schema-2020-12/fn.js
@@ -96,7 +96,9 @@ export const makeGetType = (fnAccessor) => {
         Object.hasOwn(schema, "pattern") ||
         Object.hasOwn(schema, "format") ||
         Object.hasOwn(schema, "minLength") ||
-        Object.hasOwn(schema, "maxLength")
+        Object.hasOwn(schema, "maxLength") ||
+        Object.hasOwn(schema, "contentEncoding") ||
+        Object.hasOwn(schema, "contentMediaType")
       ) {
         return "string"
       } else if (typeof schema.const !== "undefined") {


### PR DESCRIPTION
Refs https://github.com/swagger-api/swagger-ui/issues/9278

Implements layer 2 of https://github.com/swagger-api/swagger-ui/pull/10335#issuecomment-2789455652