### PR TITLE
fix(oauth2): avoid processing authorizationUrl when it is not a string

### DIFF
--- a/src/core/oauth2-authorize.js
+++ b/src/core/oauth2-authorize.js
@@ -109,7 +109,11 @@ export default function authorize ( { auth, authActions, errActions, configs, au
   } else {
     sanitizedAuthorizationUrl = sanitizeUrl(authorizationUrl)
   }
-  let url = [sanitizedAuthorizationUrl, query.join("&")].join(authorizationUrl.indexOf("?") === -1 ? "?" : "&")
+  let url = [sanitizedAuthorizationUrl, query.join("&")].join(
+    typeof authorizationUrl === "string" && authorizationUrl.indexOf("?") === -1
+      ? "?"
+      : "&"
+  )
 
   // pass action authorizeOauth2 and authentication data through window
   // to authorize with oauth2

--- a/src/core/oauth2-authorize.js
+++ b/src/core/oauth2-authorize.js
@@ -110,7 +110,7 @@ export default function authorize ( { auth, authActions, errActions, configs, au
     sanitizedAuthorizationUrl = sanitizeUrl(authorizationUrl)
   }
   let url = [sanitizedAuthorizationUrl, query.join("&")].join(
-    typeof authorizationUrl === "string" && authorizationUrl.indexOf("?") === -1
+    typeof authorizationUrl === "string" && !authorizationUrl.includes("?")
       ? "?"
       : "&"
   )


### PR DESCRIPTION
This PR avoids treating `authorizationUrl` as a `string` when it is not a `string`, e.g. when it is not defined:

```yaml
openapi: 3.0.4
components:
  securitySchemes:
    oAuthSample: 
      type: oauth2
      flows:
        implicit:
          # authorizationUrl: https://example.com/oauth/authorize  
          scopes:
            read_pets: read your pets
            write_pets: modify pets in your account
paths:
  /pets:
    patch:
      summary: Add a new pet
      security:
        - oAuthSample:
          - write_pets
          - read_pets
```