### PR TITLE
fix: avoid accessing properties of empty Example Objects

### DIFF
--- a/src/core/components/examples-select-value-retainer.jsx
+++ b/src/core/components/examples-select-value-retainer.jsx
@@ -187,10 +187,11 @@ export default class ExamplesSelectValueRetainer extends React.PureComponent {
 
     const examplesMatchingNewValue = examples.filter(
       (example) =>
-        example.get("value") === newValue ||
-        // sometimes data is stored as a string (e.g. in Request Bodies), so
-        // let's check against a stringified version of our example too
-        stringify(example.get("value")) === newValue
+        Map.isMap(example) &&
+        (example.get("value") === newValue ||
+          // sometimes data is stored as a string (e.g. in Request Bodies), so
+          // let's check against a stringified version of our example too
+          stringify(example.get("value")) === newValue)
     )
 
     if (examplesMatchingNewValue.size) {


### PR DESCRIPTION
This PR avoids accessing properties of empty Example Objects, e.g.:
```yaml
openapi: 3.0.4
paths:
  /test:
    put:
      parameters:
        - in: query
          name: test
          examples:
            test:
      responses:
        '200':
          description: OK
```