### PR TITLE
fix(spec): avoid accessing $ref when path item is not an object

### DIFF
--- a/src/core/plugins/spec/wrap-actions.js
+++ b/src/core/plugins/spec/wrap-actions.js
@@ -1,4 +1,5 @@
 import get from "lodash/get"
+import isPlainObject from "lodash/isPlainObject"
 
 export const updateSpec = (ori, {specActions}) => (...args) => {
   ori(...args)
@@ -18,7 +19,7 @@ export const updateJsonSpec = (ori, {specActions}) => (...args) => {
   pathItemKeys.forEach(k => {
     const val = get(pathItems, [k])
 
-    if(val.$ref) {
+    if (isPlainObject(val) && val.$ref) {
       specActions.requestResolvedSubtree(["paths", k])
     }
   })


### PR DESCRIPTION
This PR avoids accessing `$ref` of Path Item that is not an object, e.g. when it is `null`:

```yaml
openapi: 3.0.4
paths:
  /test:
```