### PR TITLE
fix: assure parameter is an immutable map when grouping parameters

### DIFF
--- a/src/core/components/parameters/parameters.jsx
+++ b/src/core/components/parameters/parameters.jsx
@@ -128,9 +128,11 @@ export default class Parameters extends Component {
 
     const groupedParametersArr = Object.values(parameters
       .reduce((acc, x) => {
-        const key = x.get("in")
-        acc[key] ??= []
-        acc[key].push(x)
+        if (Map.isMap(x)) {
+          const key = x.get("in")
+          acc[key] ??= []
+          acc[key].push(x)
+        }
         return acc
       }, {}))
       .reduce((acc, x) => acc.concat(x), [])


### PR DESCRIPTION
This PR fixes accessing properties of parameters that are empty, e.g.:

```yaml
openapi: 3.0.4
paths:
  /test:
    parameters:
      - 
    get:
      parameters:
        - 
```