### PR TITLE
feat(observability): allow defining custom uncaught exception handler

### DIFF
--- a/flavors/swagger-ui-react/README.md
+++ b/flavors/swagger-ui-react/README.md
@@ -201,7 +201,7 @@ Passes initial values to the Swagger UI state.
 ⚠️ This prop is currently only applied once, on mount. Changes to this prop's value will not be propagated to the underlying Swagger UI instance. A future version of this module will remove this limitation, and the change will not be considered a breaking change.
 
 
-#### `uncaughtExceptionHandler`: PropTypes.string
+#### `uncaughtExceptionHandler`: PropTypes.func
 
 Allows to define a custom uncaught exception handler. The default is `null`, which means that the default handler will be used. 
 The default handler will log the error to the console.

--- a/flavors/swagger-ui-react/README.md
+++ b/flavors/swagger-ui-react/README.md
@@ -200,6 +200,15 @@ Passes initial values to the Swagger UI state.
 
 ⚠️ This prop is currently only applied once, on mount. Changes to this prop's value will not be propagated to the underlying Swagger UI instance. A future version of this module will remove this limitation, and the change will not be considered a breaking change.
 
+
+#### `uncaughtExceptionHandler`: PropTypes.string
+
+Allows to define a custom uncaught exception handler. The default is `null`, which means that the default handler will be used. 
+The default handler will log the error to the console.
+
+⚠️ This prop is currently only applied once, on mount. Changes to this prop's value will not be propagated to the underlying Swagger UI instance. A future version of this module will remove this limitation, and the change will not be considered a breaking change.
+
+
 ## Limitations
 
 * Not all configuration bindings are available.

--- a/flavors/swagger-ui-react/index.jsx
+++ b/flavors/swagger-ui-react/index.jsx
@@ -46,6 +46,7 @@ const SwaggerUI = ({
   oauth2RedirectUrl = config.defaults.oauth2RedirectUrl,
   onComplete = null,
   initialState = config.defaults.initialState,
+  uncaughtExceptionHandler = config.defaults.uncaughtExceptionHandler,
 }) => {
   const [system, setSystem] = useState(null)
   const SwaggerUIComponent = system?.getComponent("App", "root")
@@ -85,6 +86,7 @@ const SwaggerUI = ({
       persistAuthorization,
       withCredentials,
       initialState,
+      uncaughtExceptionHandler,
       ...(typeof oauth2RedirectUrl === "string"
         ? { oauth2RedirectUrl: oauth2RedirectUrl }
         : {}),
@@ -168,6 +170,7 @@ SwaggerUI.propTypes = {
   withCredentials: PropTypes.bool,
   oauth2RedirectUrl: PropTypes.string,
   initialState: PropTypes.object,
+  uncaughtExceptionHandler: PropTypes.func,
 }
 SwaggerUI.System = SwaggerUIConstructor.System
 SwaggerUI.presets = SwaggerUIConstructor.presets

--- a/src/core/config/defaults.js
+++ b/src/core/config/defaults.js
@@ -94,6 +94,8 @@ const defaultOptions = Object.freeze({
     "audio/",
     "video/",
   ],
+
+  uncaughtExceptionHandler: null,
 })
 
 export default defaultOptions

--- a/src/core/config/type-cast/mappings.js
+++ b/src/core/config/type-cast/mappings.js
@@ -133,6 +133,7 @@ const mappings = {
     typeCaster: booleanTypeCaster,
     defaultValue: defaultOptions.withCredentials,
   },
+  uncaughtExceptionHandler: { typeCaster: nullableFunctionTypeCaster },
 }
 
 export default mappings


### PR DESCRIPTION
The goal of this change is to provide a plug point to allow
custom observability mechanisms to handle uncaught exceptions.