### PR TITLE
chore: edit docs to replace highlightjs doc url

### DIFF
--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -222,7 +222,7 @@ Parameter name | Docker variable | Description
         <td><em>Unavailable</em></td>
         <td><code>String=["agate"*, "arta", "monokai", "nord", "obsidian",
             "tomorrow-night", "idea"]</code>. <a
-                href="https://highlightjs.org/static/demo/" rel="nofollow">Highlight.js</a>
+                href="https://highlightjs.org/demo/" rel="nofollow">Highlight.js</a>
             syntax coloring theme to use. (Only these 7 styles are available.)
         </td>
     </tr>


### PR DESCRIPTION
### Description
The highlightjs doc has been updated

before : 
https://highlightjs.org/static/demo/
after : 
https://highlightjs.org/demo/


