### PR TITLE
feat(docker): build and publish unprivileged Docker image

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -11,9 +11,16 @@ jobs:
 
   build-push:
     if: github.event.workflow_run.conclusion == 'success'
-    name: Build & Push SwaggerUI Docker image
+    name: Build & Push SwaggerUI Docker images (normal + unprivileged)
     runs-on: ubuntu-latest
-
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - file: Dockerfile
+            tags: swaggerapi/swagger-ui:latest,swaggerapi/swagger-ui:v
+          - file: Dockerfile.unprivileged
+            tags: swaggerapi/swagger-ui-unprivileged:latest,swaggerapi/swagger-ui-unprivileged:v
     steps:
       - uses: actions/checkout@v7
 
@@ -71,7 +78,8 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
+          file: ${{ matrix.file }}
+          tags: ${{ matrix.tags }}${{ env.RELEASED_VERSION }}
           push: true
           platforms: linux/amd64,linux/arm/v6,linux/arm64,linux/386,linux/ppc64le
           provenance: false
-          tags: swaggerapi/swagger-ui:latest,swaggerapi/swagger-ui:v${{ env.RELEASED_VERSION }}

--- a/Dockerfile.unprivileged
+++ b/Dockerfile.unprivileged
@@ -1,0 +1,42 @@
+# Looking for information on environment variables?
+# We don't declare them here — take a look at our docs.
+# https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md
+
+FROM nginxinc/nginx-unprivileged:1.27.5-alpine
+
+LABEL maintainer="vladimir.gorej@gmail.com" \
+      org.opencontainers.image.authors="vladimir.gorej@gmail.com" \
+      org.opencontainers.image.url="docker.swagger.io/swaggerapi/swagger-ui" \
+      org.opencontainers.image.source="https://github.com/swagger-api/swagger-ui" \
+      org.opencontainers.image.description="SwaggerUI Docker image" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
+USER root
+
+RUN apk add --update-cache --no-cache "nodejs" "libxml2>=2.13.4-r6" "libexpat>=2.7.0-r0" "libxslt>=1.1.42-r2" "xz-libs>=5.6.3-r1" "c-ares>=1.34.5-r0"
+RUN mkdir /etc/nginx/templates && \
+    mkdir /usr/share/nginx/configurator && \
+    # If user is set to a different ID at runtime, html must be writable by them too
+    chown -R nginx:nginx /usr/share/nginx/html && \
+    chmod a+rw /usr/share/nginx/html
+
+USER nginx
+
+LABEL maintainer="char0n"
+
+ENV API_KEY="**None**" \
+    SWAGGER_JSON="/app/swagger.json" \
+    PORT="8080" \
+    PORT_IPV6="" \
+    BASE_URL="/" \
+    SWAGGER_JSON_URL="" \
+    CORS="true" \
+    EMBEDDING="false"
+
+COPY --chmod=0666 ./docker/default.conf.template ./docker/cors.conf ./docker/embedding.conf /etc/nginx/templates/
+
+COPY --chown=nginx --chmod=0666 ./dist/* /usr/share/nginx/html/
+COPY --chmod=0555 ./docker/docker-entrypoint.d/ /docker-entrypoint.d/
+COPY --chown=nginx --chmod=0666 ./docker/configurator /usr/share/nginx/configurator
+
+EXPOSE 8080

--- a/docs/development/docker.md
+++ b/docs/development/docker.md
@@ -1,0 +1,21 @@
+# Docker images
+
+## Building locally
+
+**Privileged image**:
+
+```sh
+ $ docker build . -t swaggerapi/swagger-ui:next
+ $ docker run -d -p 8080:8080 swaggerapi/swagger-ui:next
+```
+
+Now open your browser at `http://localhost:8080/`.
+
+**Unprivileged image**:
+
+```sh
+ $ docker build . -f Dockerfile.unprivileged -t swaggerapi/swagger-ui:next-unprivileged
+ $ docker run -d -p 8080:8080 swaggerapi/swagger-ui:next-unprivileged
+```
+
+Now open your browser at `http://localhost:8080/`.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

This PR:
- adds a new Dockerfile that will build from the nginx unprivileged image
- modify the pipeline so that it builds images for both standard and unprivileged images

Similar to swagger-api/swagger-editor#3705

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->

This will allow to deploy Swagger-UI on clusters such as OpenShift without having to meddle with the security context and security context constraints.

Fixes #10254

### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Manual build of the Dockerfile.unprivileged image is successful
- Starting a container using this image is successful
- Starting a container using this image with a different user is successful
- No error logged during the startup

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [] Dependency changes (any modification to dependencies in `package.json`)
- [] Bug fixes (non-breaking change which fixes an issue)
- [] Improvements (misc. changes to existing features)
- [X] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [X] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [X] My changes require a change to the project documentation.
- [X] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [X] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [X] All new and existing tests passed.
