### PR TITLE
ft(oas3): show the schema tab in the Try it Out mode

### DIFF
--- a/src/core/plugins/oas3/components/request-body.jsx
+++ b/src/core/plugins/oas3/components/request-body.jsx
@@ -262,7 +262,7 @@ const RequestBody = ({
   if (testValueForJson) {
     language = "json"
   }
-  let example = isExecute ? <RequestBodyEditor
+  const example = isExecute ? <RequestBodyEditor
       value={requestBodyValue}
       errors={requestBodyErrors}
       defaultValue={sampleRequestBody}

--- a/src/core/plugins/oas3/components/request-body.jsx
+++ b/src/core/plugins/oas3/components/request-body.jsx
@@ -282,35 +282,25 @@ const RequestBody = ({
           />
       ) : null
     }
-    {
-      isExecute ? (
-        <div>
-          <RequestBodyEditor
-            value={requestBodyValue}
-            errors={requestBodyErrors}
-            defaultValue={sampleRequestBody}
-            onChange={onChange}
-            getComponent={getComponent}
-          />
-        </div>
-      ) : (
-        <ModelExample
-          getComponent={ getComponent }
-          getConfigs={ getConfigs }
-          specSelectors={ specSelectors }
-          expandDepth={1}
-          isExecute={isExecute}
-          schema={mediaTypeValue.get("schema")}
-          specPath={specPath.push("content", contentType)}
-          example={
-            <HighlightCode className="body-param__example" language={language}>
-              {stringify(requestBodyValue) || sampleRequestBody}
-            </HighlightCode>
-          }
-          includeWriteOnly={true}
-        />
-      )
-    }
+    <ModelExample
+      getComponent={ getComponent }
+      getConfigs={ getConfigs }
+      specSelectors={ specSelectors }
+      expandDepth={1}
+      isExecute={isExecute}
+      schema={mediaTypeValue.get("schema")}
+      specPath={specPath.push("content", contentType)}
+      example={isExecute ? <RequestBodyEditor
+        value={requestBodyValue}
+        errors={requestBodyErrors}
+        defaultValue={sampleRequestBody}
+        onChange={onChange}
+        getComponent={getComponent}
+      /> : <HighlightCode className="body-param__example" language={language}>
+        {stringify(requestBodyValue) || sampleRequestBody}
+      </HighlightCode>}
+      includeWriteOnly={true}
+    />
     {
       sampleForMediaType ? (
         <Example

--- a/src/core/plugins/oas3/components/request-body.jsx
+++ b/src/core/plugins/oas3/components/request-body.jsx
@@ -262,6 +262,15 @@ const RequestBody = ({
   if (testValueForJson) {
     language = "json"
   }
+  let example = isExecute ? <RequestBodyEditor
+      value={requestBodyValue}
+      errors={requestBodyErrors}
+      defaultValue={sampleRequestBody}
+      onChange={onChange}
+      getComponent={getComponent}
+    /> : <HighlightCode className="body-param__example" language={language}>
+      {stringify(requestBodyValue) || sampleRequestBody}
+    </HighlightCode>
 
   return <div>
     { requestBodyDescription &&
@@ -290,15 +299,7 @@ const RequestBody = ({
       isExecute={isExecute}
       schema={mediaTypeValue.get("schema")}
       specPath={specPath.push("content", contentType)}
-      example={isExecute ? <RequestBodyEditor
-        value={requestBodyValue}
-        errors={requestBodyErrors}
-        defaultValue={sampleRequestBody}
-        onChange={onChange}
-        getComponent={getComponent}
-      /> : <HighlightCode className="body-param__example" language={language}>
-        {stringify(requestBodyValue) || sampleRequestBody}
-      </HighlightCode>}
+      example={example}
       includeWriteOnly={true}
     />
     {

--- a/test/e2e-cypress/e2e/features/schema-rendering.cy.js
+++ b/test/e2e-cypress/e2e/features/schema-rendering.cy.js
@@ -6,20 +6,20 @@ describe("OpenAPI 3.0 Schema rendering", () => {
       .click()
       .get(".btn.try-out__btn")
       .click()
-      .get('.opblock-section-request-body')
+      .get(".opblock-section-request-body")
       .within(() => {
-        cy.contains('button', 'Schema')
-          .should('exist')
-          .and('be.visible')
+        cy.contains("button", "Schema")
+          .should("exist")
+          .and("be.visible")
           .click()
 
         cy
           .get('[data-name="modelPanel"]')
-          .should('be.visible')
+          .should("be.visible")
 
         cy
           .get('[data-name="examplePanel"]')
-          .should('not.exist')
+          .should("not.exist")
       })
   })
 })

--- a/test/e2e-cypress/e2e/features/schema-rendering.cy.js
+++ b/test/e2e-cypress/e2e/features/schema-rendering.cy.js
@@ -1,0 +1,25 @@
+describe("OpenAPI 3.0 Schema rendering", () => {
+  it("should render the Schema tab in Try it out mode for request body", () => {
+    cy
+      .visit("?url=/documents/features/oas3-xml.json")
+      .get("#operations-default-post_foo")
+      .click()
+      .get(".btn.try-out__btn")
+      .click()
+      .get('.opblock-section-request-body')
+      .within(() => {
+        cy.contains('button', 'Schema')
+          .should('exist')
+          .and('be.visible')
+          .click()
+
+        cy
+          .get('[data-name="modelPanel"]')
+          .should('be.visible')
+
+        cy
+          .get('[data-name="examplePanel"]')
+          .should('not.exist')
+      })
+  })
+})


### PR DESCRIPTION
Fixes #10440 

### Description
Render the 'RequestBodyEditor' component in case user is in 'Try it out' mode, otherwise keep previous logic.