### PR TITLE
fix permissions of files to allow running as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ ENV API_KEY="**None**" \
 
 COPY --chmod=0644 ./docker/default.conf.template ./docker/cors.conf ./docker/embedding.conf /etc/nginx/templates/
 
-COPY --chmod=0666 ./dist/* /usr/share/nginx/html/
+COPY --chmod=0644 ./dist/* /usr/share/nginx/html/
 COPY --chmod=0755 ./docker/docker-entrypoint.d/ /docker-entrypoint.d/
 COPY --chmod=0644 ./docker/configurator /usr/share/nginx/configurator
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,14 +24,16 @@ ENV API_KEY="**None**" \
     CORS="true" \
     EMBEDDING="false"
 
-COPY --chown=nginx:nginx --chmod=0666 ./docker/default.conf.template ./docker/cors.conf ./docker/embedding.conf /etc/nginx/templates/
+COPY --chmod=0644 ./docker/default.conf.template ./docker/cors.conf ./docker/embedding.conf /etc/nginx/templates/
 
 COPY --chmod=0666 ./dist/* /usr/share/nginx/html/
-COPY --chmod=0555 ./docker/docker-entrypoint.d/ /docker-entrypoint.d/
-COPY --chmod=0666 ./docker/configurator /usr/share/nginx/configurator
+COPY --chmod=0755 ./docker/docker-entrypoint.d/ /docker-entrypoint.d/
+COPY --chmod=0644 ./docker/configurator /usr/share/nginx/configurator
 
 # Simulates running NGINX as a non root; in future we want to use nginxinc/nginx-unprivileged.
 # In future we will have separate unpriviledged images tagged as v5.1.2-unprivileged.
-RUN chmod 777 /usr/share/nginx/html/ /etc/nginx/conf.d/ /etc/nginx/conf.d/default.conf /var/cache/nginx/ /var/run/
+RUN chmod 777 /etc/nginx/conf.d/ /usr/share/nginx/html/ /var/cache/nginx/ /var/run/ && \
+    chmod 666 /etc/nginx/conf.d/default.conf /usr/share/nginx/html/swagger-initializer.js && \
+    chmod 755 /etc/nginx/templates /usr/share/nginx/configurator
 
 EXPOSE 8080


### PR DESCRIPTION
### Description

Fix file and directory permissions of the docker image. Some were to broad, some were not adequate.

This is a fix for issue #10505 


### Motivation and Context

With this fix, I'm able to run the image in the OpenShift where the UID of the process is chosen by the OpenShift. It should work with any UID.

### How Has This Been Tested?

I deployed the image into the OpenShift environment.

### My PR contains... 

A change to the Dockerfile which consists of:

Files copied into the /etc/nginx/templates/ directory need not have permission 0666 (writable for all) since they are never (over)written, just read. They now have permission 0644 (standard writable for root only).

Executable scripts copied into the /docker-entrypoint.d/ directory had permission 0555 (read execute for all), but it is more standard to have permission 0755 (also write for root). Root can write to any file regardless of permission, so this is just making the permission reflect the ability.

Files copied into the /usr/share/nginx/html/ directory need not have  permission 0666 (writable for all) since they are never (over)written, just read. They now have permission 0644 (standard writable for root only). Except one: swagger-initializer.js, which is chmod-ed later.

Files copied into the /usr/share/nginx/configurator directory need not have  permission 0666 (writable for all) since they are never (over)written, just read. They now have permission 0644 (standard writable for root only).

Permission 0777 (read write execute for all) is needed just for directories that will be written to (files created into):
/etc/nginx/conf.d/ /usr/share/nginx/html/ /var/cache/nginx/ /var/run/

Non-executable files that will be overwritten need only 0666 (read write for all):
/etc/nginx/conf.d/default.conf /usr/share/nginx/html/swagger-initializer.js

The directories that are auto-created while copying files need to have the executable permission (standard for reading only is 0755) so files can be searched in them:
/etc/nginx/templates /usr/share/nginx/configurator


