### PR TITLE
Remove @scarf/scarf analytics dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,23 +46,6 @@ The OpenAPI Specification has undergone 5 revisions since initial creation in 20
 | 1.0.13             | 2013-03-08   | 1.1, 1.2                                             | [tag v1.0.13](https://github.com/swagger-api/swagger-ui/tree/v1.0.13) |
 | 1.0.1              | 2011-10-11   | 1.0, 1.1                                             | [tag v1.0.1](https://github.com/swagger-api/swagger-ui/tree/v1.0.1)   |
 
-## Anonymized analytics
-
-SwaggerUI uses [Scarf](https://scarf.sh/) to collect [anonymized installation analytics](https://github.com/scarf-sh/scarf-js?tab=readme-ov-file#as-a-user-of-a-package-using-scarf-js-what-information-does-scarf-js-send-about-me). These analytics help support the maintainers of this library and ONLY run during installation. To [opt out](https://github.com/scarf-sh/scarf-js?tab=readme-ov-file#as-a-user-of-a-package-using-scarf-js-how-can-i-opt-out-of-analytics), you can set the `scarfSettings.enabled` field to `false` in your project's `package.json`:
-
-```
-// package.json
-{
-  // ...
-  "scarfSettings": {
-    "enabled": false
-  }
-  // ...
-}
-```
-
-Alternatively, you can set the environment variable `SCARF_ANALYTICS` to `false` as part of the environment that installs your npm packages, e.g., `SCARF_ANALYTICS=false npm install`.
-
 ## Documentation
 
 #### Usage

--- a/flavors/swagger-ui-react/README.md
+++ b/flavors/swagger-ui-react/README.md
@@ -10,24 +10,6 @@ It has a few differences from the main version of Swagger UI:
 
 Versions of this module mirror the version of Swagger UI included in the distribution.
 
-## Anonymized analytics
-
-`swagger-ui-react` uses [Scarf](https://scarf.sh/) to collect [anonymized installation analytics](https://github.com/scarf-sh/scarf-js?tab=readme-ov-file#as-a-user-of-a-package-using-scarf-js-what-information-does-scarf-js-send-about-me). These analytics help support the maintainers of this library and ONLY run during installation. To [opt out](https://github.com/scarf-sh/scarf-js?tab=readme-ov-file#as-a-user-of-a-package-using-scarf-js-how-can-i-opt-out-of-analytics), you can set the `scarfSettings.enabled` field to `false` in your project's `package.json`:
-
-```
-// package.json
-{
-  // ...
-  "scarfSettings": {
-    "enabled": false
-  }
-  // ...
-}
-```
-
-Alternatively, you can set the environment variable `SCARF_ANALYTICS` to `false` as part of the environment that installs your npm packages, e.g., `SCARF_ANALYTICS=false npm install`.
-
-
 ## Quick start
 
 Install `swagger-ui-react`:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.27.1",
-        "@scarf/scarf": "=1.4.0",
         "base64-js": "^1.5.1",
         "buffer": "^6.0.3",
         "classnames": "^2.5.1",
@@ -5549,11 +5548,6 @@
       "version": "1.1.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@scarf/scarf": {
-      "version": "1.4.0",
-      "hasInstallScript": true,
-      "license": "Apache-2.0"
     },
     "node_modules/@sideway/address": {
       "version": "4.1.5",
@@ -26458,7 +26452,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.22.15",
-        "@scarf/scarf": "=1.4.0",
         "@swagger-api/apidom-core": ">=1.0.0-beta.41 <1.0.0-rc.0",
         "@swagger-api/apidom-error": ">=1.0.0-beta.41 <1.0.0-rc.0",
         "@swagger-api/apidom-json-pointer": ">=1.0.0-beta.41 <1.0.0-rc.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
   },
   "dependencies": {
     "@babel/runtime-corejs3": "^7.27.1",
-    "@scarf/scarf": "=1.4.0",
     "base64-js": "^1.5.1",
     "buffer": "^6.0.3",
     "classnames": "^2.5.1",

--- a/swagger-ui-dist-package/README.md
+++ b/swagger-ui-dist-package/README.md
@@ -1,24 +1,6 @@
 # Swagger UI Dist
 [![NPM version](https://badge.fury.io/js/swagger-ui-dist.svg)](http://badge.fury.io/js/swagger-ui-dist)
 
-## Anonymized analytics
-
-SwaggerUI Dist uses [Scarf](https://scarf.sh/) to collect [anonymized installation analytics](https://github.com/scarf-sh/scarf-js?tab=readme-ov-file#as-a-user-of-a-package-using-scarf-js-what-information-does-scarf-js-send-about-me). These analytics help support the maintainers of this library and ONLY run during installation. To [opt out](https://github.com/scarf-sh/scarf-js?tab=readme-ov-file#as-a-user-of-a-package-using-scarf-js-how-can-i-opt-out-of-analytics), you can set the `scarfSettings.enabled` field to `false` in your project's `package.json`:
-
-```
-// package.json
-{
-  // ...
-  "scarfSettings": {
-    "enabled": false
-  }
-  // ...
-}
-```
-
-Alternatively, you can set the environment variable `SCARF_ANALYTICS` to `false` as part of the environment that installs your npm packages, e.g., `SCARF_ANALYTICS=false npm install`.
-
-
 # API
 
 This module, `swagger-ui-dist`, exposes Swagger-UI's entire dist folder as a dependency-free npm module.

--- a/swagger-ui-dist-package/package.json
+++ b/swagger-ui-dist-package/package.json
@@ -13,8 +13,6 @@
     "Sahar Jafari <shr.jafari@gmail.com>"
   ],
   "license": "Apache-2.0",
-  "dependencies": {
-    "@scarf/scarf": "=1.4.0"
-  },
+  "dependencies": {},
   "devDependencies": {}
 }


### PR DESCRIPTION
- Remove @scarf/scarf from package.json and swagger-ui-dist-package/package.json
- Remove scarf analytics documentation from all README files
- Update package-lock.json to reflect dependency removal

## Benefits

- Improved compatibility with pnpm and bun
- Better security posture for users using --ignore-scripts
- Cleaner dependency tree
- No functional impact on swagger-ui functionality

## Testing

- Verified no scarf references remain in the codebase
- Confirmed package.json files are properly updated
- Validated package-lock.json reflects changes
