### PR TITLE
fix(auth): ensure schema is immutable when persisting authorization

### DIFF
--- a/src/core/plugins/auth/wrap-actions.js
+++ b/src/core/plugins/auth/wrap-actions.js
@@ -1,6 +1,7 @@
 /**
  * @prettier
  */
+import { fromJS } from "immutable"
 
 /**
  * `authorize` and `logout` wrapped actions provide capacity
@@ -18,7 +19,8 @@ export const authorize = (oriAction, system) => (payload) => {
 
   // create cookie
   try {
-    const [{ schema, value }] = Object.values(payload)
+    const [{ schema: payloadSchema, value }] = Object.values(payload)
+    const schema = fromJS(payloadSchema)
     const isApiKeyAuth = schema.get("type") === "apiKey"
     const isInCookie = schema.get("in") === "cookie"
     const isApiKeyInCookie = isApiKeyAuth && isInCookie

--- a/test/unit/core/plugins/auth/wrap-actions.js
+++ b/test/unit/core/plugins/auth/wrap-actions.js
@@ -42,6 +42,30 @@ describe("Cookie based apiKey persistence in document.cookie", () => {
       )
     })
 
+    it("should persist cookie in document.cookie if schema is a plain object", () => {
+      const system = {
+        getConfigs: () => ({
+          persistAuthorization: true,
+        }),
+      }
+      const payload = {
+        api_key: {
+          schema: {
+            type: "apiKey",
+            name: "apiKeyCookie",
+            in: "cookie",
+          },
+          value: "test",
+        },
+      }
+
+      authorize(jest.fn(), system)(payload)
+
+      expect(document.cookie).toEqual(
+        "apiKeyCookie=test; SameSite=None; Secure"
+      )
+    })
+
     it("should delete cookie from document.cookie", () => {
       const payload = fromJS({
         api_key: {


### PR DESCRIPTION
Refs #10569

This PR fixes an issue with persisting authorization by transforming schema in the payload to Immutable. The issue was that the payload had a plain object schema, while `authorize` function expected an Immutable Map. This was fixed by assuring that the schema is Immutable by using `fromJS`.