### PR TITLE
fix: ignore rendering responses with extensions in the schema

### DIFF
--- a/src/core/components/responses.jsx
+++ b/src/core/components/responses.jsx
@@ -2,7 +2,7 @@ import React from "react"
 import { fromJS, Iterable } from "immutable"
 import PropTypes from "prop-types"
 import ImPropTypes from "react-immutable-proptypes"
-import { defaultStatusCode, getAcceptControllingResponse } from "core/utils"
+import { defaultStatusCode, getAcceptControllingResponse, isExtension } from "core/utils"
 import createHtmlReadyId from "core/utils/create-html-ready-id"
 
 export default class Responses extends React.Component {
@@ -131,7 +131,7 @@ export default class Responses extends React.Component {
             </thead>
             <tbody>
               {
-                responses.filter((_, key) => !key.startsWith("x-")).entrySeq().map( ([code, response]) => {
+                responses.filter((_, key) => !isExtension(key)).entrySeq().map( ([code, response]) => {
 
                   let className = tryItOutResponse && tryItOutResponse.get("status") == code ? "response_current" : ""
                   return (

--- a/src/core/components/responses.jsx
+++ b/src/core/components/responses.jsx
@@ -87,10 +87,11 @@ export default class Responses extends React.Component {
     const acceptControllingResponse = isSpecOAS3 ?
       getAcceptControllingResponse(responses) : null
 
+    const nonExtensionResponses = responses.filter((_, key) => !isExtension(key))
     const regionId = createHtmlReadyId(`${method}${path}_responses`)
     const controlId = `${regionId}_select`
 
-    return (
+    return (!nonExtensionResponses || !nonExtensionResponses.size) ? null : (
       <div className="responses-wrapper">
         <div className="opblock-section-header">
           <h4>Responses</h4>
@@ -131,7 +132,7 @@ export default class Responses extends React.Component {
             </thead>
             <tbody>
               {
-                responses.filter((_, key) => !isExtension(key)).entrySeq().map( ([code, response]) => {
+                nonExtensionResponses.entrySeq().map( ([code, response]) => {
 
                   let className = tryItOutResponse && tryItOutResponse.get("status") == code ? "response_current" : ""
                   return (

--- a/src/core/components/responses.jsx
+++ b/src/core/components/responses.jsx
@@ -131,7 +131,7 @@ export default class Responses extends React.Component {
             </thead>
             <tbody>
               {
-                responses.entrySeq().map( ([code, response]) => {
+                responses.filter((_, key) => !key.startsWith("x-")).entrySeq().map( ([code, response]) => {
 
                   let className = tryItOutResponse && tryItOutResponse.get("status") == code ? "response_current" : ""
                   return (

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -704,14 +704,16 @@ export const createDeepLinkPath = (str) => typeof str == "string" || str instanc
 // suitable for use in CSS classes and ids
 export const escapeDeepLinkPath = (str) => cssEscape( createDeepLinkPath(str).replace(/%20/g, "_") )
 
-const extensionRegExp = /^x-/
-export const isExtension = (key) => extensionRegExp.test(key)
+export const isExtension = (key) => {
+  const extensionRegExp = /^x-/
+  return extensionRegExp.test(key)
+}
 
 export const getExtensions = (defObj) => {
   if(Map.isMap(defObj)) {
-    return defObj.filter((v, k) => extensionRegExp.test(k))
+    return defObj.filter((v, k) => isExtension(k))
   }
-  return Object.keys(defObj).filter((key) => extensionRegExp.test(key))
+  return Object.keys(defObj).filter((key) => isExtension(key))
 }
 export const getCommonExtensions = (defObj) => defObj.filter((v, k) => /^pattern|maxLength|minLength|maximum|minimum/.test(k))
 

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -704,8 +704,10 @@ export const createDeepLinkPath = (str) => typeof str == "string" || str instanc
 // suitable for use in CSS classes and ids
 export const escapeDeepLinkPath = (str) => cssEscape( createDeepLinkPath(str).replace(/%20/g, "_") )
 
+const extensionRegExp = /^x-/
+export const isExtension = (key) => extensionRegExp.test(key)
+
 export const getExtensions = (defObj) => {
-  const extensionRegExp = /^x-/
   if(Map.isMap(defObj)) {
     return defObj.filter((v, k) => extensionRegExp.test(k))
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
This PR fixes a rendering bug in the Responses when using custom OpenAPI extensions (`x-*`) inside the responses object.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->
fixes #10561 
Swagger UI previously attempted to render all entries in the responses object, including custom extensions like `x-tenant` as actual HTTP responses.



### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually tested with an OpenAPI 3.1.0 spec containing `x-tenant` under responses
Verified that the Responses section renders correctly and without errors
Confirmed that valid responses (200, 500, etc.) still display as expected
Ran relevant tests, no regressions observed.

Environment:
OS: Linux
Browser: Chromium 139
Swagger UI: `master` Branch

Schema used for testing: 
```json
{
  "openapi" : "3.1.0",
  "paths" : {
    "/hello" : {
      "get" : {
        "responses" : {
          "200" : {
            "description" : "The hello message",
            "content" : {
              "text/plain" : {
                "schema" : {
                  "type" : "string"
                }
              }
            },
            "x-tenant" : "acme"
          },
          "500" : {
            "description" : "Internal server error",
            "x-tenant" : "acme"
          },
          "x-tenant" : "acme"
        },
        "x-tenant" : "acme",
        "summary" : "Hello",
        "tags" : [ "Example Resource" ]
      }
    }
  },
  "info" : {
    "title" : "prout-quarkus API",
    "version" : "1.0-SNAPSHOT"
  }
}
```

### Screenshots (if appropriate):
#### Before:
<img width="1882" height="1035" alt="image" src="https://github.com/user-attachments/assets/ad425f77-282a-40a3-9927-029f4ea152f6" />

#### After:
<img width="1357" height="1039" alt="image" src="https://github.com/user-attachments/assets/f07c29f0-cd61-4f42-bb6f-81dc3622a815" />

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fixes (non-breaking change which fixes an issue)

### My changes...
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.

### Automated tests
- [x] All new and existing tests passed.
