### PR TITLE
fix: use <h1> for main page heading to improve accessibility

### DIFF
--- a/src/core/components/info.jsx
+++ b/src/core/components/info.jsx
@@ -97,13 +97,13 @@ class Info extends React.Component {
     return (
       <div className="info">
         <hgroup className="main">
-          <h2 className="title">
+          <h1 className="title">
             {title}
             <span>
               {version && <VersionStamp version={version} />}
               <OpenAPIVersion oasVersion="2.0" />
             </span>
-          </h2>
+          </h1>
           {host || basePath ? (
             <InfoBasePath host={host} basePath={basePath} />
           ) : null}

--- a/src/core/plugins/oas31/components/info.jsx
+++ b/src/core/plugins/oas31/components/info.jsx
@@ -33,13 +33,13 @@ const Info = ({ getComponent, specSelectors }) => {
   return (
     <div className="info">
       <hgroup className="main">
-        <h2 className="title">
+        <h1 className="title">
           {title}
           <span>
             {version && <VersionStamp version={version} />}
             <OpenAPIVersion oasVersion="3.1" />
           </span>
-        </h2>
+        </h1>
 
         {(host || basePath) && <InfoBasePath host={host} basePath={basePath} />}
         {url && <InfoUrl getComponent={getComponent} url={url} />}

--- a/test/e2e-cypress/e2e/bugs/5138.cy.js
+++ b/test/e2e-cypress/e2e/bugs/5138.cy.js
@@ -2,7 +2,7 @@ describe("#5138: unwanted `url`/`urls` interactions", () => {
   it("should stably render the first `urls` entry", () => {
     cy
       .visit("/pages/5138/")
-      .get("h2.title")
+      .get("h1.title")
       .contains("USPTO Data Set API")
       .wait(3000)
       .contains("USPTO Data Set API")

--- a/test/e2e-cypress/e2e/features/urls.cy.js
+++ b/test/e2e-cypress/e2e/features/urls.cy.js
@@ -19,7 +19,7 @@ describe("configuration options: `urls` and `urls.primaryName`", () => {
 
     it("should render the first URL in the list", () => {
       cy.visit("/?configUrl=/configs/urls.yaml")
-        .get("h2.title")
+        .get("h1.title")
         .should("have.text", "OneOAS 2.0")
         .window()
         .then(win => win.ui.specSelectors.url())
@@ -31,7 +31,7 @@ describe("configuration options: `urls` and `urls.primaryName`", () => {
     cy.visit("/?configUrl=/configs/urls-primary-name.yaml")
       .get("select")
       .should("contain.value", "/documents/features/urls/2.yaml")
-      .get("h2.title")
+      .get("h1.title")
       .should("have.text", "TwoOAS 3.0")
       .window()
       .then(win => win.ui.specSelectors.url())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Updated the main heading of the page to use an <h1> element instead of a lower-level heading to meet accessibility standards.

### Description

The main heading was not using an <h1>, which is required for proper semantic structure and accessibility. This change ensures screen readers and assistive technologies can correctly interpret the page structure.

### Motivation and Context

This change is required to improve accessibility by ensuring the main page heading uses an <h1> element.  
Without this, screen readers and other assistive technologies may not correctly interpret the page structure.  

Fixes #10480 


### How Has This Been Tested?
Ran the code in development mode and verified that the main heading is now using an <h1> tag by inspecting it in the browser's developer tools under the <elements> panel. Checked that the page layout and styling remain intact.



### Screenshots (if appropriate):
<img width="1119" height="645" alt="image" src="https://github.com/user-attachments/assets/54005f49-fe45-4631-8c3e-16a556fc9eca" />



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
