### PR TITLE
Fixes (#10535) : Properly render example field in request schema as plain JSON 

### DIFF
--- a/src/core/components/example.jsx
+++ b/src/core/components/example.jsx
@@ -6,7 +6,7 @@ import React from "react"
 import PropTypes from "prop-types"
 import ImPropTypes from "react-immutable-proptypes"
 import { stringify } from "core/utils"
-import { Map } from "immutable"
+import { Map,List } from "immutable"
 
 export default function Example(props) {
   const { example, showValue, getComponent } = props
@@ -15,6 +15,13 @@ export default function Example(props) {
   const HighlightCode = getComponent("HighlightCode", true)
 
   if (!example || !Map.isMap(example)) return null
+
+  let value = example.get("value");
+  if (Map.isMap(value) || Array.isArray(value) || List.isList(value)) {
+    
+   value=value.toJS();
+  }
+value = stringify(value, null, 2);
 
   return (
     <div className="example">
@@ -29,7 +36,7 @@ export default function Example(props) {
       {showValue && example.has("value") ? (
         <section className="example__section">
           <div className="example__section-header">Example Value</div>
-          <HighlightCode>{stringify(example.get("value"))}</HighlightCode>
+          <HighlightCode>{value}</HighlightCode>
         </section>
       ) : null}
     </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

This change ensures that example objects in request schemas are displayed as standard JSON in Swagger UI, rather than with Immutable.js prefixes like OrderedMap.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change fix  Swagger UI would display Immutable.js type prefixes in example fields that would confuse the api users.

<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #10535
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->



### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
I did manually tested with arrays and objects in req schema in localhost server.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->



### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] All new and existing tests passed.


### Test cases that can prove the fix is not breakable

<img width="1917" height="833" alt="image" src="https://github.com/user-attachments/assets/962902e5-2b58-47cd-b64c-2965eac82967" />

<img width="1913" height="830" alt="image" src="https://github.com/user-attachments/assets/a5c41ca4-dcb7-4d46-9601-d8a834b2dc28" />

<img width="1918" height="835" alt="image" src="https://github.com/user-attachments/assets/e4ba0cd0-b495-4a45-826a-61a0b761f40c" />





