### PR TITLE
fix: prevent webook from crashing in case of openapi 3.0

### DIFF
--- a/src/core/plugins/oas31/components/webhooks.jsx
+++ b/src/core/plugins/oas31/components/webhooks.jsx
@@ -7,6 +7,9 @@ import { List } from "immutable"
 
 const Webhooks = ({ specSelectors, getComponent }) => {
   const operationDTOs = specSelectors.selectWebhooksOperations()
+  if (!operationDTOs) {
+    return null
+  }
   const pathItemNames = Object.keys(operationDTOs)
 
   const OperationContainer = getComponent("OperationContainer", true)

--- a/test/e2e-cypress/e2e/features/webhooks.cy.js
+++ b/test/e2e-cypress/e2e/features/webhooks.cy.js
@@ -19,8 +19,8 @@ describe("Render Webhooks Component", () => {
     const baseUrl = "/?url=/documents/features/webhooks-openAPI30.yaml"
     it("should render nothing", () => {
       cy.visit(baseUrl)
-      cy.get('#swagger-ui .information-container')
-        .should('exist');
+      cy.get("#swagger-ui .information-container")
+        .should("exist")
       cy.get(".webhooks", {timeout: 0})
         .should("not.exist")
     })

--- a/test/e2e-cypress/e2e/features/webhooks.cy.js
+++ b/test/e2e-cypress/e2e/features/webhooks.cy.js
@@ -16,10 +16,12 @@ describe("Render Webhooks Component", () => {
     })
   })
   describe("OpenAPI 3.0.x", () => {
-    const baseUrl = "/?url=/documents/features/webhooks-openAPI31.yaml"
+    const baseUrl = "/?url=/documents/features/webhooks-openAPI30.yaml"
     it("should render nothing", () => {
       cy.visit(baseUrl)
-        .get(".webhooks")
+      cy.get('#swagger-ui .information-container')
+        .should('exist');
+      cy.get(".webhooks", {timeout: 0})
         .should("not.exist")
     })
   })


### PR DESCRIPTION
### Description
Prevent webhook component from crashing in case openapi 3.0