### PR TITLE
Option to configure Plugins and Presets via Docker Env Variables

### DIFF
--- a/docker/configurator/variables.js
+++ b/docker/configurator/variables.js
@@ -83,6 +83,14 @@ const standardVariables = {
     type: "string",
     name: "oauth2RedirectUrl"
   },
+  PRESETS: {
+    type: "array",
+    name: "presets"
+  },
+  PLUGINS: {
+    type: "array",
+    name: "plugins"
+  },
   PERSIST_AUTHORIZATION: {
     type: "boolean",
     name: "persistAuthorization"

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -39,8 +39,8 @@ Read more about the plugin system in the [Customization documentation](/docs/cus
 Parameter name | Docker variable | Description
 --- | --- | -----
 <a name="layout"></a>`layout` | _Unavailable_ | `String="BaseLayout"`. The name of a component available via the plugin system to use as the top-level layout for Swagger UI.
-<a name="plugins"></a>`plugins` | _Unavailable_ | `Array=[]`. An array of plugin functions to use in Swagger UI.
-<a name="presets"></a>`presets` | _Unavailable_ | `Array=[SwaggerUI.presets.ApisPreset]`. An array of presets to use in Swagger UI. Usually, you'll want to include `ApisPreset` if you use this option.
+<a name="plugins"></a>`plugins` | `PLUGIN` | `Array=[]`. An array of plugin functions to use in Swagger UI.
+<a name="presets"></a>`presets` | `PRESETS` | `Array=[SwaggerUI.presets.ApisPreset]`. An array of presets to use in Swagger UI. Usually, you'll want to include `ApisPreset` if you use this option.
 
 ##### Display
 


### PR DESCRIPTION
Option to configure Plugins and Presets via Docker Env Variables

### Description
This change allows customization of the swagger-ui image without having to reimplement the templating logic for the swagger constructor.

This change just connects the already implemented functionality to docker environment variables.


### Motivation and Context
A good example why this is needed, is customizing the logo via plugin as described [here](https://github.com/swagger-api/swagger-ui/blob/7f75ee39dc6900e22703c788adb7c28577bd6895/docs/customization/plug-points.md#logo-component).
While the script defining the plugin can be loaded using a custom `index.html, a `custom swagger-initializer.js``would either be overwritten or not be templated at all.

The `LAYOUT` parameter is not included in this PR, as it is already implemented in the same way, but simply missing from the documentation (See #10029).

### How Has This Been Tested?

The change was tested by running the adjusted Dockerfile with different values for said environment variables (including omitting them).  
It was also tested with a custom image with a custom logo, as mentioned above.


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ x ] Improvements (misc. changes to existing features)
- [ x ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [ x ] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [ x ] My changes require a change to the project documentation.
- [ x ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ x ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ x ] All new and existing tests passed.
