### PR TITLE
fix: display empty object instead of string for cyclic references in …

### DIFF
--- a/src/core/plugins/json-schema-5-samples/fn/index.js
+++ b/src/core/plugins/json-schema-5-samples/fn/index.js
@@ -38,7 +38,8 @@ const primitives = {
   "number": () => 0,
   "number_float": () => 0.0,
   "integer": () => 0,
-  "boolean": (schema) => typeof schema.default === "boolean" ? schema.default : true
+  "boolean": (schema) => typeof schema.default === "boolean" ? schema.default : true,
+  "any": ()=> ({})
 }
 
 const primitive = (schema) => {


### PR DESCRIPTION
Fixes #10524

**Problem:** 
Cyclic references in schema definitions were showing misleading example values as "string" instead of representing the actual object structure.

**Solution:**
Added handler for "any" type in primitives to return empty object `{}` for cyclic references detected by getType() function.

**Changes:**
- Added `"any": () => ({})` to primitives object in `src/core/plugins/json-schema-5-samples/fn/index.js`

**Result:**
Cyclic references now show as empty objects `{}` which better represents the actual data structure instead of the misleading "string" value.