### PR TITLE
feat(theme): configurable dark mode with system preference support

### DIFF
--- a/docker/configurator/variables.js
+++ b/docker/configurator/variables.js
@@ -106,6 +106,10 @@ const standardVariables = {
   WITH_CREDENTIALS: {
     type: "boolean",
     name: "withCredentials",
+  },
+  THEME_DEFAULT_MODE: {
+    type: "string",
+    name: "theme.defaultMode",
   }
 }
 

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -115,6 +115,24 @@ Parameter name | Docker variable | Description
         </td>
     </tr>
     <tr>
+        <td><a name="user-content-theme"></a><code>theme</code>
+        </td>
+        <td><em>Unavailable</em></td>
+        <td><code>Object={ defaultMode: "light" }</code>. Theme configuration object.
+        </td>
+    </tr>
+    <tr>
+        <td><a name="user-content-theme.defaultmode"></a><code>theme.defaultMode</code>
+        </td>
+        <td><code>THEME_DEFAULT_MODE</code></td>
+        <td><code>String=["light"*, "dark"]</code>. Sets the default color mode
+            when Swagger UI loads. Can be <code>"light"</code> or <code>"dark"</code>.
+            This works across all layouts and deployment scenarios, including
+            embedded usage and swagger-ui-react. The mode can still be toggled
+            via the UI if a dark mode toggle is available in your layout.
+        </td>
+    </tr>
+    <tr>
         <td><a name="user-content-filter"></a><code>filter</code></td>
         <td><code>FILTER</code></td>
         <td><code>Boolean=false OR String</code>. If set, enables filtering. The

--- a/docs/usage/dark-mode.md
+++ b/docs/usage/dark-mode.md
@@ -1,0 +1,161 @@
+# Dark Mode
+
+Swagger UI supports dark mode to provide a better viewing experience in low-light environments. Dark mode can be enabled in several ways depending on your deployment scenario.
+
+## Enabling Dark Mode via Configuration
+
+The easiest way to enable dark mode is through the `theme` configuration option:
+
+```javascript
+SwaggerUI({
+  dom_id: '#swagger-ui',
+  url: 'https://petstore.swagger.io/v2/swagger.json',
+  theme: {
+    defaultMode: 'dark'
+  }
+});
+```
+
+When `theme.defaultMode` is set to `'dark'`, Swagger UI will load in dark mode by default. This works across all layouts and deployment scenarios.
+
+## Using the Dark Mode Toggle
+
+If you're using the StandaloneLayoutPreset, a dark mode toggle button is available in the top bar. Users can click this button to switch between light and dark modes at any time.
+
+```javascript
+SwaggerUI({
+  dom_id: '#swagger-ui',
+  url: 'https://petstore.swagger.io/v2/swagger.json',
+  presets: [SwaggerUI.presets.apis, SwaggerUIStandalonePreset]
+});
+```
+
+## System Preference Detection
+
+When `theme.defaultMode` is not explicitly set to `'dark'`, Swagger UI will check the browser's system preference (`prefers-color-scheme: dark`) and automatically enable dark mode if the user's system is set to dark mode.
+
+## Embedded Usage
+
+Dark mode works seamlessly in embedded scenarios, including iframes and custom integrations:
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <link rel="stylesheet" type="text/css" href="./swagger-ui.css" />
+</head>
+<body>
+  <div id="swagger-ui"></div>
+  
+  <script src="./swagger-ui-bundle.js"></script>
+  <script>
+    SwaggerUI({
+      dom_id: '#swagger-ui',
+      url: 'https://petstore.swagger.io/v2/swagger.json',
+      theme: {
+        defaultMode: 'dark'  // Enable dark mode by default
+      }
+    });
+  </script>
+</body>
+</html>
+```
+
+The dark mode styles are scoped to the `.swagger-ui` container, ensuring they don't interfere with your host application's styles.
+
+## Using with swagger-ui-react
+
+If you're using the React component version, you can enable dark mode via the `theme` prop:
+
+```jsx
+import SwaggerUI from "swagger-ui-react"
+import "swagger-ui-react/swagger-ui.css"
+
+function MySwaggerUI() {
+  return (
+    <SwaggerUI
+      url="https://petstore.swagger.io/v2/swagger.json"
+      theme={{ defaultMode: 'dark' }}
+    />
+  )
+}
+```
+
+## Programmatic Control
+
+You can programmatically control dark mode using the dark mode plugin actions:
+
+```javascript
+const ui = SwaggerUI({
+  dom_id: '#swagger-ui',
+  url: 'https://petstore.swagger.io/v2/swagger.json'
+});
+
+// Enable dark mode
+ui.darkModeActions.setDarkMode(true);
+
+// Toggle dark mode
+ui.darkModeActions.toggleDarkMode();
+
+// Check if dark mode is enabled
+const isDarkMode = ui.darkModeSelectors.isDarkMode();
+```
+
+## Docker Environment Variable
+
+When using the Docker image, you can set the `THEME_DEFAULT_MODE` environment variable:
+
+```bash
+docker run -p 80:8080 -e THEME_DEFAULT_MODE="dark" swaggerapi/swagger-ui
+```
+
+## CSS Scoping and Customization
+
+All dark mode styles are scoped to the `.swagger-ui` container within the `html.dark-mode` selector. This ensures:
+
+- Dark mode styles only apply to Swagger UI elements
+- No CSS leakage into your host application
+- Easy customization through CSS overrides
+
+### Custom Dark Mode Colors
+
+You can customize dark mode colors by overriding the CSS variables or targeting specific selectors:
+
+```css
+/* Override dark mode background */
+html.dark-mode .swagger-ui {
+  background: #1a1a1a;
+}
+
+/* Override dark mode text color */
+html.dark-mode .swagger-ui {
+  color: #e0e0e0;
+}
+```
+
+## Migration from Manual Class Manipulation
+
+If you were previously adding the `dark-mode` class to the `<html>` element manually, you should migrate to using the `theme.defaultMode` configuration:
+
+**Before:**
+```javascript
+SwaggerUI({
+  dom_id: '#swagger-ui',
+  url: 'https://petstore.swagger.io/v2/swagger.json'
+});
+// Manually add dark mode
+document.documentElement.classList.add('dark-mode');
+```
+
+**After:**
+```javascript
+SwaggerUI({
+  dom_id: '#swagger-ui',
+  url: 'https://petstore.swagger.io/v2/swagger.json',
+  theme: {
+    defaultMode: 'dark'  // Use configuration instead
+  }
+});
+```
+
+The manual approach will continue to work for backwards compatibility, but using the configuration option is recommended as it integrates with the dark mode state management system.

--- a/src/core/config/defaults.js
+++ b/src/core/config/defaults.js
@@ -12,6 +12,9 @@ const defaultOptions = Object.freeze({
   configUrl: null,
   layout: "BaseLayout",
   docExpansion: "list",
+  theme: {
+    defaultMode: "system",
+  },
   maxDisplayedTags: -1,
   filter: false,
   validatorUrl: "https://validator.swagger.io/validator",

--- a/src/core/config/type-cast/mappings.js
+++ b/src/core/config/type-cast/mappings.js
@@ -34,6 +34,14 @@ const mappings = {
     typeCaster: numberTypeCaster,
     defaultValue: defaultOptions.defaultModelsExpandDepth,
   },
+  theme: {
+    typeCaster: objectTypeCaster,
+    defaultValue: defaultOptions.theme,
+  },
+  "theme.defaultMode": {
+    typeCaster: stringTypeCaster,
+    defaultValue: defaultOptions.theme.defaultMode,
+  },
   displayOperationId: {
     typeCaster: booleanTypeCaster,
     defaultValue: defaultOptions.displayOperationId,

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -31,6 +31,7 @@ import DownloadUrlPlugin from "./plugins/download-url"
 import SyntaxHighlightingPlugin from "core/plugins/syntax-highlighting"
 import VersionsPlugin from "core/plugins/versions"
 import SafeRenderPlugin from "./plugins/safe-render"
+import DarkModePlugin from "./plugins/dark-mode"
 
 import {
   defaultOptions,
@@ -169,6 +170,7 @@ SwaggerUI.plugins = {
   SyntaxHighlighting: SyntaxHighlightingPlugin,
   Versions: VersionsPlugin,
   SafeRender: SafeRenderPlugin,
+  DarkMode: DarkModePlugin,
 }
 
 export default SwaggerUI

--- a/src/core/plugins/dark-mode/actions.js
+++ b/src/core/plugins/dark-mode/actions.js
@@ -1,0 +1,64 @@
+/**
+ * @prettier
+ */
+
+export const DARK_MODE_SET = "dark_mode_set"
+export const DARK_MODE_TOGGLE = "dark_mode_toggle"
+
+/**
+ * Set dark mode state
+ * @param {boolean} isDarkMode - Whether dark mode should be enabled
+ */
+export function setDarkMode(isDarkMode) {
+  return {
+    type: DARK_MODE_SET,
+    payload: isDarkMode,
+  }
+}
+
+/**
+ * Toggle dark mode on/off
+ */
+export function toggleDarkMode() {
+  return {
+    type: DARK_MODE_TOGGLE,
+  }
+}
+
+/**
+ * Initialize dark mode based on configuration and system preferences
+ */
+export function initializeDarkMode() {
+  return (system) => {
+    const { getConfigs, darkModeActions } = system
+
+    // Get configs - this should be called after configs are loaded
+    const configs = getConfigs()
+
+    const theme = configs?.theme || {}
+    const defaultMode = theme.defaultMode || "system"
+
+    let shouldEnableDarkMode = false
+
+    if (defaultMode === "dark") {
+      // Explicitly set to dark mode
+      shouldEnableDarkMode = true
+    } else if (defaultMode === "light") {
+      // Explicitly set to light mode
+      shouldEnableDarkMode = false
+    } else if (defaultMode === "system") {
+      // Check system preference
+      if (typeof window !== "undefined") {
+        const prefersDarkMode =
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches
+        shouldEnableDarkMode = prefersDarkMode
+      }
+    }
+
+    // Apply dark mode if needed
+    if (shouldEnableDarkMode) {
+      darkModeActions.setDarkMode(true)
+    }
+  }
+}

--- a/src/core/plugins/dark-mode/index.js
+++ b/src/core/plugins/dark-mode/index.js
@@ -1,0 +1,47 @@
+/**
+ * @prettier
+ */
+import * as actions from "./actions"
+import * as selectors from "./selectors"
+import reducers, { initialState } from "./reducers"
+
+export default function darkModePlugin() {
+  return {
+    statePlugins: {
+      darkMode: {
+        initialState,
+        reducers,
+        actions,
+        selectors,
+      },
+      configs: {
+        // Hook into the configs loaded action to initialize dark mode
+      },
+    },
+    fn: {
+      // This hook is called after the system is fully initialized
+      // and configs are loaded, making it the perfect place to initialize dark mode
+      opsFilter: (taggedOps, fn) => fn(taggedOps),
+    },
+    afterLoad(system) {
+      // Use requestAnimationFrame to defer until next frame
+      // This ensures configs are loaded before initialization
+      if (typeof window !== "undefined" && window.requestAnimationFrame) {
+        window.requestAnimationFrame(() => {
+          const { darkModeActions } = system
+          if (darkModeActions && darkModeActions.initializeDarkMode) {
+            darkModeActions.initializeDarkMode()
+          }
+        })
+      } else {
+        // Fallback for non-browser environments
+        setTimeout(() => {
+          const { darkModeActions } = system
+          if (darkModeActions && darkModeActions.initializeDarkMode) {
+            darkModeActions.initializeDarkMode()
+          }
+        }, 0)
+      }
+    },
+  }
+}

--- a/src/core/plugins/dark-mode/reducers.js
+++ b/src/core/plugins/dark-mode/reducers.js
@@ -1,0 +1,44 @@
+/**
+ * @prettier
+ */
+import { Map } from "immutable"
+import { DARK_MODE_SET, DARK_MODE_TOGGLE } from "./actions"
+
+const initialState = Map({
+  isDarkMode: false,
+})
+
+export default {
+  [DARK_MODE_SET]: (state, action) => {
+    const isDarkMode = action.payload
+
+    // Apply or remove the dark-mode class on the HTML element
+    if (typeof document !== "undefined") {
+      if (isDarkMode) {
+        document.documentElement.classList.add("dark-mode")
+      } else {
+        document.documentElement.classList.remove("dark-mode")
+      }
+    }
+
+    return state.set("isDarkMode", isDarkMode)
+  },
+
+  [DARK_MODE_TOGGLE]: (state) => {
+    const currentMode = state.get("isDarkMode")
+    const newMode = !currentMode
+
+    // Apply or remove the dark-mode class on the HTML element
+    if (typeof document !== "undefined") {
+      if (newMode) {
+        document.documentElement.classList.add("dark-mode")
+      } else {
+        document.documentElement.classList.remove("dark-mode")
+      }
+    }
+
+    return state.set("isDarkMode", newMode)
+  },
+}
+
+export { initialState }

--- a/src/core/plugins/dark-mode/selectors.js
+++ b/src/core/plugins/dark-mode/selectors.js
@@ -1,0 +1,10 @@
+/**
+ * @prettier
+ */
+
+/**
+ * Get dark mode state
+ */
+export const isDarkMode = (state) => {
+  return state.get("isDarkMode", false)
+}

--- a/src/core/presets/base/index.js
+++ b/src/core/presets/base/index.js
@@ -22,6 +22,7 @@ import DownloadUrlPlugin from "core/plugins/download-url"
 import SyntaxHighlightingPlugin from "core/plugins/syntax-highlighting"
 import VersionsPlugin from "core/plugins/versions"
 import SafeRenderPlugin from "core/plugins/safe-render"
+import DarkModePlugin from "core/plugins/dark-mode"
 // ad-hoc plugins
 import CoreComponentsPlugin from "core/presets/base/plugins/core-components"
 import FormComponentsPlugin from "core/presets/base/plugins/form-components"
@@ -32,6 +33,7 @@ const BasePreset = () => [
   LogsPlugin,
   ViewPlugin,
   ViewLegacyPlugin,
+  DarkModePlugin,
   SpecPlugin,
   ErrPlugin,
   IconsPlugin,

--- a/src/standalone/plugins/top-bar/components/DarkModeToggle.jsx
+++ b/src/standalone/plugins/top-bar/components/DarkModeToggle.jsx
@@ -2,41 +2,52 @@
  * @prettier
  */
 import React, { Component } from "react"
+import PropTypes from "prop-types"
 
 import LightBulb from "../assets/lightbulb.svg"
 import LightBulbOff from "../assets/lightbulb-off.svg"
 
 class DarkModeToggle extends Component {
-  constructor(props) {
-    super(props)
-    this.state = {
-      isDarkMode: false,
-    }
-    this.toggleIsDarkMode = this.toggleIsDarkMode.bind(this)
+  static propTypes = {
+    darkModeSelectors: PropTypes.object,
+    darkModeActions: PropTypes.object,
   }
 
-  componentDidMount() {
-    if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
-      document.documentElement.classList.add("dark-mode")
-      this.setState({ isDarkMode: true })
+  toggleIsDarkMode = () => {
+    const { darkModeActions } = this.props
+
+    if (darkModeActions && darkModeActions.toggleDarkMode) {
+      // Use the core dark mode plugin if available
+      darkModeActions.toggleDarkMode()
+    } else {
+      // Fallback to manual DOM manipulation for backwards compatibility
+      document.documentElement.classList.toggle("dark-mode")
+      this.forceUpdate() // Force re-render to update icon
     }
   }
 
-  toggleIsDarkMode() {
-    document.documentElement.classList.toggle("dark-mode")
-    this.setState((prevState) => ({ isDarkMode: !prevState.isDarkMode }))
+  isDarkMode() {
+    const { darkModeSelectors } = this.props
+
+    if (darkModeSelectors && darkModeSelectors.isDarkMode) {
+      // Use the core dark mode plugin state if available
+      return darkModeSelectors.isDarkMode()
+    } else {
+      // Fallback to checking DOM class for backwards compatibility
+      return document.documentElement.classList.contains("dark-mode")
+    }
   }
 
   render() {
-    const { isDarkMode } = this.state
+    const isDarkMode = this.isDarkMode()
 
     return (
       <div className="dark-mode-toggle">
         <button onClick={this.toggleIsDarkMode}>
-          {!isDarkMode ? (
-            <LightBulbOff height="24" />
-          ) : (
+          {isDarkMode ? (
             <LightBulb height="24" />
+          ) : (
+            <LightBulbOff height="24" />
           )}
         </button>
       </div>

--- a/src/standalone/plugins/top-bar/components/TopBar.jsx
+++ b/src/standalone/plugins/top-bar/components/TopBar.jsx
@@ -109,7 +109,7 @@ class TopBar extends React.Component {
   }
 
   render() {
-    let { getComponent, specSelectors, getConfigs } = this.props
+    let { getComponent, specSelectors, getConfigs, darkModeSelectors, darkModeActions } = this.props
     const Button = getComponent("Button")
     const Link = getComponent("Link")
     const Logo = getComponent("Logo")
@@ -165,7 +165,10 @@ class TopBar extends React.Component {
             <form className="download-url-wrapper" onSubmit={formOnSubmit}>
               {control.map((el, i) => cloneElement(el, { key: i }))}
             </form>
-            <DarkModeToggle />
+            <DarkModeToggle 
+              darkModeSelectors={darkModeSelectors}
+              darkModeActions={darkModeActions}
+            />
           </div>
         </div>
       </div>
@@ -177,7 +180,9 @@ TopBar.propTypes = {
   specSelectors: PropTypes.object.isRequired,
   specActions: PropTypes.object.isRequired,
   getComponent: PropTypes.func.isRequired,
-  getConfigs: PropTypes.func.isRequired
+  getConfigs: PropTypes.func.isRequired,
+  darkModeSelectors: PropTypes.object,
+  darkModeActions: PropTypes.object
 }
 
 export default TopBar

--- a/test/unit/standalone/plugins/top-bar/DarkModeToggle.jsx
+++ b/test/unit/standalone/plugins/top-bar/DarkModeToggle.jsx
@@ -13,34 +13,54 @@ jest.mock("standalone/plugins/top-bar/assets/lightbulb-off.svg", () => () => (
 ))
 
 describe("DarkModeToggle Component", () => {
-  beforeAll(() => {
-    Object.defineProperty(window, "matchMedia", {
-      writable: true,
-      value: jest.fn().mockImplementation((query) => ({
-        matches: false,
-        media: query,
-        onchange: null,
-        addListener: jest.fn(),
-        removeListener: jest.fn(),
-        addEventListener: jest.fn(),
-        removeEventListener: jest.fn(),
-        dispatchEvent: jest.fn(),
-      })),
+  beforeEach(() => {
+    // Clear dark mode class before each test
+    document.documentElement.classList.remove("dark-mode")
+  })
+
+  describe("without dark mode plugin (backwards compatibility)", () => {
+    it("toggles the dark class on the html element on click", () => {
+      const wrapper = mount(<DarkModeToggle />)
+      const htmlElement = document.documentElement
+
+      expect(htmlElement.classList.contains("dark-mode")).toBe(false)
+
+      wrapper.find(".dark-mode-toggle button").simulate("click")
+      expect(htmlElement.classList.contains("dark-mode")).toBe(true)
+
+      wrapper.find(".dark-mode-toggle button").simulate("click")
+      expect(htmlElement.classList.contains("dark-mode")).toBe(false)
     })
   })
 
-  it("toggles the dark class on the html element and switches icons on click", () => {
-    const wrapper = mount(<DarkModeToggle />)
-    const htmlElement = document.documentElement
+  describe("with dark mode plugin", () => {
+    it("uses dark mode plugin actions when available", () => {
+      const mockToggleDarkMode = jest.fn()
+      const mockIsDarkMode = jest.fn().mockReturnValue(false)
 
-    expect(htmlElement.classList.contains("dark-mode")).toBe(false)
+      const wrapper = mount(
+        <DarkModeToggle
+          darkModeActions={{ toggleDarkMode: mockToggleDarkMode }}
+          darkModeSelectors={{ isDarkMode: mockIsDarkMode }}
+        />
+      )
 
-    wrapper.find(".dark-mode-toggle button").simulate("click")
+      wrapper.find(".dark-mode-toggle button").simulate("click")
 
-    expect(htmlElement.classList.contains("dark-mode")).toBe(true)
+      expect(mockToggleDarkMode).toHaveBeenCalledTimes(1)
+    })
 
-    wrapper.find(".dark-mode-toggle button").simulate("click")
+    it("uses dark mode selectors to determine state", () => {
+      const mockIsDarkMode = jest.fn().mockReturnValue(false)
 
-    expect(htmlElement.classList.contains("dark-mode")).toBe(false)
+      mount(
+        <DarkModeToggle
+          darkModeActions={{ toggleDarkMode: jest.fn() }}
+          darkModeSelectors={{ isDarkMode: mockIsDarkMode }}
+        />
+      )
+
+      expect(mockIsDarkMode).toHaveBeenCalled()
+    })
   })
 })


### PR DESCRIPTION
This PR implements a robust and configurable dark mode system with three options: `light`, `dark`, and `system` (auto-detect).

## Key Changes
1. **New `theme` Configuration:**
   - Added `theme: { defaultMode: '...' }` to Swagger UI config.
   - `'system'` (Default): Automatically respects the user's OS/browser preference.
   - `'dark'`: Forces dark mode.
   - `'light'`: Forces light mode.

2. **Core Plugin Implementation:**
   - Logic moved to a new core plugin (`src/core/plugins/dark-mode`) for better state management.
   - `src/standalone/plugins/top-bar/components/TopBar.jsx` - Pass dark mode props
   - `docker/configurator/variables.js` - Helper for Docker env vars
   - `test/unit/standalone/plugins/top-bar/DarkModeToggle.jsx` - Updated test
   - Ensures dark mode works uniformly across all layouts (Base, Standalone, etc.).

3. **Docker Support:**
   - Added `THEME_DEFAULT_MODE` environment variable support.
   - Allows configuring the default theme mode directly in Docker containers (e.g., `-e THEME_DEFAULT_MODE=dark`).

4. **CSS Isolation:**
   - Dark mode styles are properly scoped to `.swagger-ui` to prevent style leakage into host applications during embedded usage.

5. **Backward Compatibility:**
   - Existing manual methods (toggling `dark-mode` class) still work.
   - No breaking changes for existing users.

## Usage Example
```javascript
SwaggerUI({
  url: 'https://petstore.swagger.io/v2/swagger.json',
  theme: {
    defaultMode: 'dark' // or 'light' or 'system'
  }
});
```

## Documentation
- Added comprehensive guide: `docs/usage/dark-mode.md`
- Updated configuration docs: `docs/usage/configuration.md`

Closes #10663

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Implements configurable dark mode with `light`, `dark`, and `system` (auto-detect) options, including Docker support via `THEME_DEFAULT_MODE` env var.



### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->
As a user, I wanted native support for system-preferred dark mode and easier configuration options to improve the overall viewing experience.
Fixes #10663



### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually verified `theme.defaultMode` in browser (Chrome/Firefox), tested Docker environment variable injection, and verified CSS scoping prevents leakage.


### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [x] My changes require a change to the project documentation.
- [x] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
