### PR TITLE
fix: #6034 Authorization Code ( base and pkce flow ) -  get right authorization code on each attempt

### DIFF
--- a/src/core/oauth2-authorize.js
+++ b/src/core/oauth2-authorize.js
@@ -78,6 +78,9 @@ export default function authorize ( { auth, authActions, errActions, configs, au
   }
 
   if ((flow === "authorizationCode" || flow === "authorization_code" || flow === "accessCode") && authConfigs.usePkceWithAuthorizationCodeGrant) {
+      // deleting old authorization code before new attempt
+      delete auth.code
+      
       const codeVerifier = generateCodeVerifier()
       const codeChallenge = createCodeChallenge(codeVerifier)
 

--- a/src/core/oauth2-authorize.js
+++ b/src/core/oauth2-authorize.js
@@ -8,11 +8,6 @@ export default function authorize ( { auth, authActions, errActions, configs, au
   let flow = schema.get("flow")
   let query = []
 
-  // deleting old authorization code before new attempt if defined. 
-  // At this stage we don't care about flow type. 
-  // It fails silently if not defined yet
-  delete auth.code
-
   switch (flow) {
     case "password":
       authActions.authorizePassword(auth)
@@ -132,8 +127,12 @@ export default function authorize ( { auth, authActions, errActions, configs, au
     callback = authActions.authorizeAccessCodeWithFormParams
   }
 
+  // remove stale `code` without mutating original auth
+  let updatedAuth = { ...auth }
+  delete updatedAuth.code
+
   authActions.authPopup(url, {
-    auth: auth,
+    auth: updatedAuth,
     state: state,
     redirectUrl: redirectUrl,
     callback: callback,

--- a/src/core/oauth2-authorize.js
+++ b/src/core/oauth2-authorize.js
@@ -8,6 +8,11 @@ export default function authorize ( { auth, authActions, errActions, configs, au
   let flow = schema.get("flow")
   let query = []
 
+  // deleting old authorization code before new attempt if defined. 
+  // At this stage we don't care about flow type. 
+  // It fails silently if not defined yet
+  delete auth.code
+
   switch (flow) {
     case "password":
       authActions.authorizePassword(auth)
@@ -78,9 +83,6 @@ export default function authorize ( { auth, authActions, errActions, configs, au
   }
 
   if ((flow === "authorizationCode" || flow === "authorization_code" || flow === "accessCode") && authConfigs.usePkceWithAuthorizationCodeGrant) {
-      // deleting old authorization code before new attempt
-      delete auth.code
-      
       const codeVerifier = generateCodeVerifier()
       const codeChallenge = createCodeChallenge(codeVerifier)
 

--- a/test/unit/core/oauth2-authorize.js
+++ b/test/unit/core/oauth2-authorize.js
@@ -197,5 +197,22 @@ describe("oauth2", () => {
 
       authConfig3.authActions.authPopup.mockReset()
     })
+
+    it("should delete previous authorization code when using authorizationCode flow with usePkceWithAuthorizationCodeGrant enabled", () => {
+      mockSchema.flow = "authorizationCode"
+
+      authConfig.authConfigs.usePkceWithAuthorizationCodeGrant = true
+
+      // Simulate a stale authorization code from a previous attempt
+      authConfig.auth.code = "mock_authorization_code"
+
+      expect(authConfig.auth.code).toBe("mock_authorization_code")
+
+      oauth2Authorize(authConfig)
+      expect(authConfig.auth.code).toBeUndefined()
+
+      authConfig.authActions.authPopup.mockReset()
+    })
+
   })
 })

--- a/test/unit/core/oauth2-authorize.js
+++ b/test/unit/core/oauth2-authorize.js
@@ -198,7 +198,7 @@ describe("oauth2", () => {
       authConfig3.authActions.authPopup.mockReset()
     })
 
-    it("should delete previous authorization code when using authorizationCode flow with usePkceWithAuthorizationCodeGrant enabled", () => {
+    it("should delete previous authorization code when using authorizationCode flow on each attempt", () => {
       mockSchema.flow = "authorizationCode"
 
       authConfig.authConfigs.usePkceWithAuthorizationCodeGrant = true

--- a/test/unit/core/oauth2-authorize.js
+++ b/test/unit/core/oauth2-authorize.js
@@ -209,7 +209,7 @@ describe("oauth2", () => {
       expect(authConfig.auth.code).toBe("mock_authorization_code")
 
       oauth2Authorize(authConfig)
-      expect(authConfig.auth.code).toBeUndefined()
+      expect(authConfig.authActions.authPopup.mock.calls[0][1].auth.code).toBeUndefined()
 
       authConfig.authActions.authPopup.mockReset()
     })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
PKCE Flow Issue: ( authorization code not being properly refreshed )

In the OAuth2 PKCE low, a client application requests an authorization code from the authorization server, then exchanges it for an access token. Each authorization attempt must use a fresh code, because authorization codes are single-use and that's not happening because the authorization code is being renewed only when the client closes the authorization popup.


### Motivation and Context
This change ensures that on every PKCE authorization attempt, a fresh and correct authorization code is used. Any stale auth.code from previouss attempts is deleted before starting a new auth flow preventing reuse.
Fixes #6034 



### How Has This Been Tested?
I start by running swagger ui locally

1. git clone https://github.com/swagger-api/swagger-ui.git
2. cd swagger-ui
3. npm install
4. npm run dev

Then i set up a dummy server to simulate IdP for testing purposes.
```javascript
// Step 1: /authorize
app.get("/authorize", (req, res) => {
  const { client_id, code_challenge, code_challenge_method, redirect_uri } = req.query;
  if (!client_id || !code_challenge) return res.status(400).send("ERROR");

  const code = crypto.randomBytes(8).toString("hex");
  codes[code] = { code_challenge, code_challenge_method, createdAt: Date.now() };

  console.log("code:::", code);
  const uri = new URL(redirect_uri);
  uri.searchParams.set("code", code);
  res.redirect(uri.toString());
});

app.post("/token", (req, res) => {
  const { grant_type, code, code_verifier } = req.body;
  if (grant_type !== "authorization_code") return res.status(400).json({ error: "ERROR" });

  const stored = codes[code];
  if (!stored) return res.status(400).json({ error: "invalid_grant" });

  // Validate PKCE
  const hash = crypto.createHash("sha256").update(code_verifier).digest();
  const base64url = hash.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");

  if (stored.code_challenge !== base64url) return res.status(400).json({ error: "invalid_grant", detail: "PKCE mismatch" });
  console.log("returning success:::");
  res.json({
    access_token: "__FOO__BAR__",
    token_type: "Bearer",
    expires_in: 36000
  });
});
```
<img width="845" height="762" alt="Screenshot 2026-01-29 at 11 00 29" src="https://github.com/user-attachments/assets/2bf055ca-83e4-4c82-8ccb-e860f2d7d649" />

So, it is clear that if we don’t close the popup after the first attempt, the authorization code is never refreshed. After this change, auth.code is always set correctly, regardless of whether the authorization popup is closed.

With this change, the authorization can be performed multiple times without closing the popup.

All tests passed:
`npm run test:unit -- ./test/unit/core/oauth2-authorize.js  --silent=false`
`npm run test`

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
