### PR TITLE
fix(request-snippets): escape pipe character in cURL CMD snippets

### DIFF
--- a/src/core/plugins/request-snippets/fn.js
+++ b/src/core/plugins/request-snippets/fn.js
@@ -33,6 +33,7 @@ const escapeCMD = (str) => {
     .replace(/\^/g, "^^")
     .replace(/\\"/g, "\\\\\"")
     .replace(/"/g, "\"\"")
+    .replace(/\|/g, "^|")
     .replace(/\n/g, "^\n")
   if (str === "-d ") {
     return str


### PR DESCRIPTION
## Summary

This PR fixes the issue where the vertical bar character (`|`) in the request body is not escaped in cURL (CMD) snippets.

## Problem

As described in #10540, when the request body contains a pipe character, the generated cURL command fails in Windows CMD because it is interpreted as a pipe operator.

## Solution

Added `.replace(/\|/g, "^|")` to the `escapeCMD` function to escape pipe characters with a caret (`^`).

## Related Issue

Fixes #10540