### PR TITLE
Fix(utils) disallow schema type array value string for oas3

### DIFF
--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -466,7 +466,6 @@ function validateValueBySchema(value, schema, requiredByParam, bypassRequiredChe
   let stringCheck = type === "string" && value
   let arrayCheck = type === "array" && Array.isArray(value) && value.length
   let arrayListCheck = type === "array" && Im.List.isList(value) && value.count()
-  let arrayStringCheck = type === "array" && typeof value === "string" && value
   let fileCheck = type === "file" && value instanceof win.File
   let booleanCheck = type === "boolean" && (value || value === false)
   let numberCheck = type === "number" && (value || value === 0)
@@ -475,7 +474,7 @@ function validateValueBySchema(value, schema, requiredByParam, bypassRequiredChe
   let objectStringCheck = type === "object" && typeof value === "string" && value
 
   const allChecks = [
-    stringCheck, arrayCheck, arrayListCheck, arrayStringCheck, fileCheck,
+    stringCheck, arrayCheck, arrayListCheck, fileCheck,
     booleanCheck, numberCheck, integerCheck, objectCheck, objectStringCheck,
   ]
 

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -410,7 +410,7 @@ export const validatePattern = (val, rxPattern) => {
   }
 }
 
-function validateValueBySchema(value, schema, requiredByParam, bypassRequiredCheck, parameterContentMediaType) {
+function validateValueBySchema(value, schema, requiredByParam, bypassRequiredCheck, parameterContentMediaType, isOAS3) {
   if(!schema) return []
   let errors = []
   let nullable = schema.get("nullable")
@@ -466,6 +466,7 @@ function validateValueBySchema(value, schema, requiredByParam, bypassRequiredChe
   let stringCheck = type === "string" && value
   let arrayCheck = type === "array" && Array.isArray(value) && value.length
   let arrayListCheck = type === "array" && Im.List.isList(value) && value.count()
+  let arrayStringCheck = type === "array" && typeof value === "string" && value
   let fileCheck = type === "file" && value instanceof win.File
   let booleanCheck = type === "boolean" && (value || value === false)
   let numberCheck = type === "number" && (value || value === 0)
@@ -473,11 +474,9 @@ function validateValueBySchema(value, schema, requiredByParam, bypassRequiredChe
   let objectCheck = type === "object" && typeof value === "object" && value !== null
   let objectStringCheck = type === "object" && typeof value === "string" && value
 
-  const allChecks = [
-    stringCheck, arrayCheck, arrayListCheck, fileCheck,
-    booleanCheck, numberCheck, integerCheck, objectCheck, objectStringCheck,
-  ]
-
+  const oas3Checks = [stringCheck, arrayCheck, arrayListCheck, fileCheck,
+    booleanCheck, numberCheck, integerCheck, objectCheck, objectStringCheck]
+  const allChecks = isOAS3 ? oas3Checks : [oas3Checks, arrayStringCheck]
   const passedAnyCheck = allChecks.some(v => !!v)
 
   if (schemaRequiresValue && !passedAnyCheck && !bypassRequiredCheck) {
@@ -507,7 +506,7 @@ function validateValueBySchema(value, schema, requiredByParam, bypassRequiredChe
     }
     if(schema && schema.has("properties")) {
       schema.get("properties").forEach((val, key) => {
-        const errs = validateValueBySchema(objectVal[key], val, false, bypassRequiredCheck, parameterContentMediaType)
+        const errs = validateValueBySchema(objectVal[key], val, false, bypassRequiredCheck, parameterContentMediaType, isOAS3)
         errors.push(...errs
           .map((error) => ({ propKey: key, error })))
       })
@@ -589,7 +588,7 @@ function validateValueBySchema(value, schema, requiredByParam, bypassRequiredChe
     }
     if(value) {
       value.forEach((item, i) => {
-        const errs = validateValueBySchema(item, schema.get("items"), false, bypassRequiredCheck, parameterContentMediaType)
+        const errs = validateValueBySchema(item, schema.get("items"), false, bypassRequiredCheck, parameterContentMediaType, isOAS3)
         errors.push(...errs
           .map((err) => ({ index: i, error: err })))
       })
@@ -613,7 +612,7 @@ export const validateParam = (param, value, { isOAS3 = false, bypassRequiredChec
     parameterContentMediaType
   } = getParameterSchema(param, { isOAS3 })
 
-  return validateValueBySchema(value, paramDetails, paramRequired, bypassRequiredCheck, parameterContentMediaType)
+  return validateValueBySchema(value, paramDetails, paramRequired, bypassRequiredCheck, parameterContentMediaType, isOAS3)
 }
 
 export const parseSearch = () => {

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -410,7 +410,7 @@ export const validatePattern = (val, rxPattern) => {
   }
 }
 
-function validateValueBySchema(value, schema, requiredByParam, bypassRequiredCheck, parameterContentMediaType, bypassArrayStringCheck) {
+function validateValueBySchema(value, schema, requiredByParam, bypassRequiredCheck, parameterContentMediaType, disallowArrayString) {
   if(!schema) return []
   let errors = []
   let nullable = schema.get("nullable")
@@ -476,7 +476,7 @@ function validateValueBySchema(value, schema, requiredByParam, bypassRequiredChe
 
   const checks = [stringCheck, arrayCheck, arrayListCheck, fileCheck,
     booleanCheck, numberCheck, integerCheck, objectCheck, objectStringCheck]
-  const allChecks = bypassArrayStringCheck ? checks : checks.concat(arrayStringCheck)
+  const allChecks = disallowArrayString ? checks : checks.concat(arrayStringCheck)
   const passedAnyCheck = allChecks.some(v => !!v)
 
   if (schemaRequiresValue && !passedAnyCheck && !bypassRequiredCheck) {
@@ -506,7 +506,7 @@ function validateValueBySchema(value, schema, requiredByParam, bypassRequiredChe
     }
     if(schema && schema.has("properties")) {
       schema.get("properties").forEach((val, key) => {
-        const errs = validateValueBySchema(objectVal[key], val, false, bypassRequiredCheck, parameterContentMediaType, bypassArrayStringCheck)
+        const errs = validateValueBySchema(objectVal[key], val, false, bypassRequiredCheck, parameterContentMediaType, disallowArrayString)
         errors.push(...errs
           .map((error) => ({ propKey: key, error })))
       })
@@ -588,7 +588,7 @@ function validateValueBySchema(value, schema, requiredByParam, bypassRequiredChe
     }
     if(value) {
       value.forEach((item, i) => {
-        const errs = validateValueBySchema(item, schema.get("items"), false, bypassRequiredCheck, parameterContentMediaType, bypassArrayStringCheck)
+        const errs = validateValueBySchema(item, schema.get("items"), false, bypassRequiredCheck, parameterContentMediaType, disallowArrayString)
         errors.push(...errs
           .map((err) => ({ index: i, error: err })))
       })

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -410,7 +410,7 @@ export const validatePattern = (val, rxPattern) => {
   }
 }
 
-function validateValueBySchema(value, schema, requiredByParam, bypassRequiredCheck, parameterContentMediaType, isOAS3) {
+function validateValueBySchema(value, schema, requiredByParam, bypassRequiredCheck, parameterContentMediaType, bypassArrayStringCheck) {
   if(!schema) return []
   let errors = []
   let nullable = schema.get("nullable")
@@ -474,9 +474,9 @@ function validateValueBySchema(value, schema, requiredByParam, bypassRequiredChe
   let objectCheck = type === "object" && typeof value === "object" && value !== null
   let objectStringCheck = type === "object" && typeof value === "string" && value
 
-  const oas3Checks = [stringCheck, arrayCheck, arrayListCheck, fileCheck,
+  const checks = [stringCheck, arrayCheck, arrayListCheck, fileCheck,
     booleanCheck, numberCheck, integerCheck, objectCheck, objectStringCheck]
-  const allChecks = isOAS3 ? oas3Checks : [oas3Checks, arrayStringCheck]
+  const allChecks = bypassArrayStringCheck ? checks : checks.concat(arrayStringCheck)
   const passedAnyCheck = allChecks.some(v => !!v)
 
   if (schemaRequiresValue && !passedAnyCheck && !bypassRequiredCheck) {
@@ -506,7 +506,7 @@ function validateValueBySchema(value, schema, requiredByParam, bypassRequiredChe
     }
     if(schema && schema.has("properties")) {
       schema.get("properties").forEach((val, key) => {
-        const errs = validateValueBySchema(objectVal[key], val, false, bypassRequiredCheck, parameterContentMediaType, isOAS3)
+        const errs = validateValueBySchema(objectVal[key], val, false, bypassRequiredCheck, parameterContentMediaType, bypassArrayStringCheck)
         errors.push(...errs
           .map((error) => ({ propKey: key, error })))
       })
@@ -588,7 +588,7 @@ function validateValueBySchema(value, schema, requiredByParam, bypassRequiredChe
     }
     if(value) {
       value.forEach((item, i) => {
-        const errs = validateValueBySchema(item, schema.get("items"), false, bypassRequiredCheck, parameterContentMediaType, isOAS3)
+        const errs = validateValueBySchema(item, schema.get("items"), false, bypassRequiredCheck, parameterContentMediaType, bypassArrayStringCheck)
         errors.push(...errs
           .map((err) => ({ index: i, error: err })))
       })

--- a/test/e2e-cypress/e2e/features/try-it-out-schema-type-array-example-type-string.cy.js
+++ b/test/e2e-cypress/e2e/features/try-it-out-schema-type-array-example-type-string.cy.js
@@ -1,0 +1,12 @@
+describe.only("Try it out with schema type array but example type string", () => {
+    it("shows a validation error message when Execute is clicked", () => {
+      cy
+        .visit("?tryItOutEnabled=true&url=/documents/features/try-it-out-schema-type-array-example-type-string.yaml")
+        .get("#operations-default-get_")
+        .click()
+        .get(".btn.execute")
+        .click()
+        .get(".validation-errors")
+        .should("exist")
+    })
+  })

--- a/test/e2e-cypress/e2e/features/try-it-out-schema-type-array-example-type-string.cy.js
+++ b/test/e2e-cypress/e2e/features/try-it-out-schema-type-array-example-type-string.cy.js
@@ -1,4 +1,4 @@
-describe.only("Try it out with schema type array but example type string", () => {
+describe("Try it out with schema type array but example type string", () => {
     it("shows a validation error message when Execute is clicked", () => {
       cy
         .visit("?tryItOutEnabled=true&url=/documents/features/try-it-out-schema-type-array-example-type-string.yaml")

--- a/test/e2e-cypress/static/documents/features/try-it-out-schema-type-array-example-type-string.yaml
+++ b/test/e2e-cypress/static/documents/features/try-it-out-schema-type-array-example-type-string.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.3
+info:
+  title: test
+  version: 1.0.0
+paths:
+  /:
+    get:
+      parameters:
+        - in: query
+          name: test
+          required: true
+          schema:
+            type: array
+            example: 'test1'
+            items:
+              type: string
+              enum:
+                - 'test1'
+                - 'test2'
+                - 'test3'
+      responses:
+        default:
+          description: ok

--- a/test/unit/core/utils.js
+++ b/test/unit/core/utils.js
@@ -749,7 +749,7 @@ describe("utils", () => {
         type: "array"
       }
       value = "[1]"
-      assertValidateParam(param, value, [])
+      assertValidateParam(param, value, ["Required field is not provided"])
 
       // valid array, items match type
       param = {

--- a/test/unit/core/utils.js
+++ b/test/unit/core/utils.js
@@ -350,13 +350,6 @@ describe("utils", () => {
     let value = null
     let result = null
 
-    const assertValidateParam = (param, value, expectedError) => {
-      // Swagger 2.0 version
-      assertValidateNotOas3Param(param, value, expectedError)
-      // OAS3 version, using `schema` sub-object
-      assertValidateOas3ParamWithSchema(param, value, expectedError)
-    }
-
     const assertValidateOas3Param = (param, value, expectedError) => {
       // for cases where you _only_ want to try OAS3
       result = validateParam(fromJS(param), value, {
@@ -381,6 +374,13 @@ describe("utils", () => {
         }
       }
       assertValidateOas3Param(oas3Param, value, expectedError)
+    }
+
+    const assertValidateParam = (param, value, expectedError) => {
+      // Swagger 2.0 version
+      assertValidateNotOas3Param(param, value, expectedError)
+      // OAS3 version, using `schema` sub-object
+      assertValidateOas3ParamWithSchema(param, value, expectedError)
     }
 
     it("should check the isOAS3 flag when validating parameters", () => {

--- a/test/unit/core/utils.js
+++ b/test/unit/core/utils.js
@@ -352,21 +352,9 @@ describe("utils", () => {
 
     const assertValidateParam = (param, value, expectedError) => {
       // Swagger 2.0 version
-      result = validateParam( fromJS(param), fromJS(value))
-      expect( result ).toEqual( expectedError )
-
+      assertValidateNotOas3Param(param, value, expectedError)
       // OAS3 version, using `schema` sub-object
-      let oas3Param = {
-        required: param.required,
-        schema: {
-          ...param,
-          required: undefined
-        }
-      }
-      result = validateParam( fromJS(oas3Param), fromJS(value), {
-        isOAS3: true
-      })
-      expect( result ).toEqual( expectedError )
+      assertValidateOas3ParamWithSchema(param, value, expectedError)
     }
 
     const assertValidateOas3Param = (param, value, expectedError) => {
@@ -375,6 +363,24 @@ describe("utils", () => {
         isOAS3: true
       })
       expect( result ).toEqual( expectedError )
+    }
+
+    const assertValidateNotOas3Param = (param, value, expectedError) => {
+      // Swagger 2.0 version
+      result = validateParam( fromJS(param), fromJS(value))
+      expect( result ).toEqual( expectedError )
+    }
+
+    const assertValidateOas3ParamWithSchema = (param, value, expectedError) => {
+      // OAS3 version, using `schema` sub-object
+      let oas3Param = {
+        required: param.required,
+        schema: {
+          ...param,
+          required: undefined
+        }
+      }
+      assertValidateOas3Param(oas3Param, value, expectedError)
     }
 
     it("should check the isOAS3 flag when validating parameters", () => {
@@ -749,7 +755,8 @@ describe("utils", () => {
         type: "array"
       }
       value = "[1]"
-      assertValidateParam(param, value, ["Required field is not provided"])
+      assertValidateOas3ParamWithSchema(param, value, ["Required field is not provided"])
+      assertValidateNotOas3Param(param, value, [])
 
       // valid array, items match type
       param = {

--- a/test/unit/core/utils.js
+++ b/test/unit/core/utils.js
@@ -358,7 +358,7 @@ describe("utils", () => {
       expect( result ).toEqual( expectedError )
     }
 
-    const assertValidateNotOas3Param = (param, value, expectedError) => {
+    const assertValidateOas2Param = (param, value, expectedError) => {
       // Swagger 2.0 version
       result = validateParam( fromJS(param), fromJS(value))
       expect( result ).toEqual( expectedError )
@@ -378,7 +378,7 @@ describe("utils", () => {
 
     const assertValidateParam = (param, value, expectedError) => {
       // Swagger 2.0 version
-      assertValidateNotOas3Param(param, value, expectedError)
+      assertValidateOas2Param(param, value, expectedError)
       // OAS3 version, using `schema` sub-object
       assertValidateOas3ParamWithSchema(param, value, expectedError)
     }
@@ -756,7 +756,7 @@ describe("utils", () => {
       }
       value = "[1]"
       assertValidateOas3ParamWithSchema(param, value, ["Required field is not provided"])
-      assertValidateNotOas3Param(param, value, [])
+      assertValidateOas2Param(param, value, [])
 
       // valid array, items match type
       param = {


### PR DESCRIPTION
Add validation and show error if the schema type is an array and value provided is string for OAS3

### Description
Before https://github.com/swagger-api/swagger-js/pull/3826, it was possible to send request without any issues. Now validation and error has been added

### Motivation and Context
After https://github.com/swagger-api/swagger-js/pull/3826 has been introduced, when user tries to Execute a request, the loader appears and stays

### How Has This Been Tested?
Manually and unit test

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (changes to documentation, CI, metadata, etc)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
