### PR TITLE
fix: validated support for OpenAPI 3.1.2 and updated docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ This repository publishes **three different npm packages**:
 ### OpenAPI Specification Compatibility
 
 - **Current Support:** OpenAPI 2.0, 3.0.x, 3.1.x
-- **Latest Version:** v5.31.0 (supports up to OpenAPI 3.1.1)
+- **Latest Version:** v5.31.0 (supports up to OpenAPI 3.1.2)
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ If you are looking for plain ol' HTML/JS/CSS, [download the latest release](http
 ## Compatibility
 The OpenAPI Specification has undergone 5 revisions since initial creation in 2010.  Compatibility between Swagger UI and the OpenAPI Specification is as follows:
 
-| Swagger UI Version | Release Date | OpenAPI Spec compatibility                           | Notes                                                                 |
-|--------------------|--------------|------------------------------------------------------|-----------------------------------------------------------------------|
-| 5.19.0             | 2025-02-17   | 2.0, 3.0.0, 3.0.1, 3.0.2, 3.0.3, 3.0.4, 3.1.0, 3.1.1 | [tag v5.19.0](https://github.com/swagger-api/swagger-ui/tree/v5.19.0) |
+| Swagger UI Version | Release Date | OpenAPI Spec compatibility                                  | Notes                                                                 |
+|--------------------|--------------|-------------------------------------------------------------|-----------------------------------------------------------------------|
+| 5.19.0             | 2025-02-17   | 2.0, 3.0.0, 3.0.1, 3.0.2, 3.0.3, 3.0.4, 3.1.0, 3.1.1, 3.1.2 | [tag v5.19.0](https://github.com/swagger-api/swagger-ui/tree/v5.19.0) |
 | 5.0.0              | 2023-06-12   | 2.0, 3.0.0, 3.0.1, 3.0.2, 3.0.3, 3.1.0               | [tag v5.0.0](https://github.com/swagger-api/swagger-ui/tree/v5.0.0)   |
 | 4.0.0              | 2021-11-03   | 2.0, 3.0.0, 3.0.1, 3.0.2, 3.0.3                      | [tag v4.0.0](https://github.com/swagger-api/swagger-ui/tree/v4.0.0)   |
 | 3.18.3             | 2018-08-03   | 2.0, 3.0.0, 3.0.1, 3.0.2, 3.0.3                      | [tag v3.18.3](https://github.com/swagger-api/swagger-ui/tree/v3.18.3) |

--- a/test/unit/core/plugins/oas31/fn.js
+++ b/test/unit/core/plugins/oas31/fn.js
@@ -10,6 +10,7 @@ describe("isOAS30", function () {
   it("should recognize valid OAS3 version values", function () {
     expect(isOAS31Shorthand("3.1.0")).toEqual(true)
     expect(isOAS31Shorthand("3.1.1")).toEqual(true)
+    expect(isOAS31Shorthand("3.1.2")).toEqual(true)
     expect(isOAS31Shorthand("3.1.25")).toEqual(true)
   })
 


### PR DESCRIPTION
spec is here https://spec.openapis.org/oas/v3.1.2.html
this version of the spec is only a set of *fixes*, not changes in behaviour
because of how the regex was structured, it already technically worked, but not we have a test to prevent regressions and the docs are updated