### PR TITLE
a11y: add aria-label to focusable cURL and response body elements

### DIFF
--- a/src/core/components/curl.jsx
+++ b/src/core/components/curl.jsx
@@ -24,8 +24,10 @@ export default class Curl extends React.Component {
           <SyntaxHighlighter
             language="bash"
             className="curl microlight"
+            aria-label="Curl command"
+            role="region"
             renderPlainText={({ children, PlainTextViewer }) => (
-              <PlainTextViewer className="curl">{children}</PlainTextViewer>
+              <PlainTextViewer className="curl" aria-label="Curl command" role="region">{children}</PlainTextViewer>
             )}
           >
             {curl}

--- a/src/core/components/response-body.jsx
+++ b/src/core/components/response-body.jsx
@@ -107,7 +107,7 @@ export default class ResponseBody extends React.PureComponent {
         body = "can't parse JSON.  Raw result:\n\n" + content
       }
 
-      bodyEl = <HighlightCode language={language} downloadable fileName={`${downloadName}.json`} canCopy>{body}</HighlightCode>
+      bodyEl = <HighlightCode language={language} downloadable fileName={`${downloadName}.json`} canCopy ariaLabel="Response body">{body}</HighlightCode>
 
       // XML
     } else if (/xml/i.test(contentType)) {
@@ -115,15 +115,15 @@ export default class ResponseBody extends React.PureComponent {
         textNodesOnSameLine: true,
         indentor: "  "
       })
-      bodyEl = <HighlightCode downloadable fileName={`${downloadName}.xml`} canCopy>{body}</HighlightCode>
+      bodyEl = <HighlightCode downloadable fileName={`${downloadName}.xml`} canCopy ariaLabel="Response body">{body}</HighlightCode>
 
       // HTML or Plain Text
     } else if (toLower(contentType) === "text/html" || /text\/plain/.test(contentType)) {
-      bodyEl = <HighlightCode downloadable fileName={`${downloadName}.html`} canCopy>{content}</HighlightCode>
+      bodyEl = <HighlightCode downloadable fileName={`${downloadName}.html`} canCopy ariaLabel="Response body">{content}</HighlightCode>
 
       // CSV
     } else if (toLower(contentType) === "text/csv" || /text\/csv/.test(contentType)) {
-      bodyEl = <HighlightCode downloadable fileName={`${downloadName}.csv`} canCopy>{content}</HighlightCode>
+      bodyEl = <HighlightCode downloadable fileName={`${downloadName}.csv`} canCopy ariaLabel="Response body">{content}</HighlightCode>
 
       // Image
     } else if (/^image\//i.test(contentType)) {
@@ -137,7 +137,7 @@ export default class ResponseBody extends React.PureComponent {
     } else if (/^audio\//i.test(contentType)) {
       bodyEl = <pre className="microlight"><audio controls key={ url }><source src={ url } type={ contentType } /></audio></pre>
     } else if (typeof content === "string") {
-      bodyEl = <HighlightCode downloadable fileName={`${downloadName}.txt`} canCopy>{content}</HighlightCode>
+      bodyEl = <HighlightCode downloadable fileName={`${downloadName}.txt`} canCopy ariaLabel="Response body">{content}</HighlightCode>
     } else if ( content.size > 0 ) {
       // We don't know the contentType, but there was some content returned
       if(parsedContent) {
@@ -147,7 +147,7 @@ export default class ResponseBody extends React.PureComponent {
           <p className="i">
             Unrecognized response type; displaying content as text.
           </p>
-          <HighlightCode downloadable fileName={`${downloadName}.txt`} canCopy>{parsedContent}</HighlightCode>
+          <HighlightCode downloadable fileName={`${downloadName}.txt`} canCopy ariaLabel="Response body">{parsedContent}</HighlightCode>
         </div>
 
       } else {

--- a/src/core/plugins/request-snippets/request-snippets.jsx
+++ b/src/core/plugins/request-snippets/request-snippets.jsx
@@ -140,8 +140,10 @@ const RequestSnippets = ({ request, requestSnippetsSelectors, getComponent }) =>
             <SyntaxHighlighter
               language={activeGenerator.get("syntax")}
               className="curl microlight"
+              aria-label={`${activeGenerator.get("title")} request snippet`}
+              role="region"
               renderPlainText={({ children, PlainTextViewer }) => (
-                <PlainTextViewer className="curl">{children}</PlainTextViewer>
+                <PlainTextViewer className="curl" aria-label={`${activeGenerator.get("title")} request snippet`} role="region">{children}</PlainTextViewer>
               )}
             >
               {snippet}

--- a/src/core/plugins/syntax-highlighting/components/HighlightCode.jsx
+++ b/src/core/plugins/syntax-highlighting/components/HighlightCode.jsx
@@ -15,6 +15,7 @@ const HighlightCode = ({
   canCopy,
   language,
   children,
+  ariaLabel,
 }) => {
   const rootRef = useRef(null)
   const SyntaxHighlighter = getComponent("SyntaxHighlighter", true)
@@ -84,8 +85,9 @@ const HighlightCode = ({
       <SyntaxHighlighter
         language={language}
         className={classNames(className, "microlight")}
+        {...(ariaLabel ? { "aria-label": ariaLabel, role: "region" } : {})}
         renderPlainText={({ children, PlainTextViewer }) => (
-          <PlainTextViewer className={className}>{children}</PlainTextViewer>
+          <PlainTextViewer className={className} {...(ariaLabel ? { "aria-label": ariaLabel, role: "region" } : {})}>{children}</PlainTextViewer>
         )}
       >
         {children}
@@ -102,6 +104,7 @@ HighlightCode.propTypes = {
   language: PropTypes.string,
   canCopy: PropTypes.bool,
   children: PropTypes.string.isRequired,
+  ariaLabel: PropTypes.string,
 }
 
 export default HighlightCode

--- a/src/core/plugins/syntax-highlighting/components/SyntaxHighlighter.jsx
+++ b/src/core/plugins/syntax-highlighting/components/SyntaxHighlighter.jsx
@@ -11,6 +11,8 @@ const SyntaxHighlighter = ({
   getConfigs,
   syntaxHighlighting = {},
   children = "",
+  renderPlainText,
+  ...rest
 }) => {
   const theme = getConfigs().syntaxHighlight.theme
   const { styles, defaultStyle } = syntaxHighlighting
@@ -21,6 +23,7 @@ const SyntaxHighlighter = ({
       language={language}
       className={className}
       style={style}
+      {...rest}
     >
       {children}
     </ReactSyntaxHighlighter>


### PR DESCRIPTION
Fixes #10709

Adds `aria-label` and `role="region"` to scrollable cURL command and response body code blocks so screen readers announce what the element is when focused via tab navigation.

**Changes:**
- `curl.jsx`: Added `aria-label="Curl command"` to the SyntaxHighlighter
- `request-snippets.jsx`: Added dynamic `aria-label` based on the active snippet generator title
- `HighlightCode.jsx`: Added `ariaLabel` prop that gets forwarded to SyntaxHighlighter
- `SyntaxHighlighter.jsx`: Pass through extra props (like `aria-label`, `role`) to the underlying `react-syntax-highlighter` `<pre>` element
- `response-body.jsx`: Pass `ariaLabel="Response body"` to all HighlightCode instances