### PR TITLE
a11y: add table captions and use th for column headers

### DIFF
--- a/src/core/components/live-response.jsx
+++ b/src/core/components/live-response.jsx
@@ -86,10 +86,11 @@ export default class LiveResponse extends React.Component {
         }
         <h4>Server response</h4>
         <table className="responses-table live-responses-table">
+          <caption className="sr-only">Live server response</caption>
           <thead>
           <tr className="responses-header">
-            <td className="col_header response-col_status">Code</td>
-            <td className="col_header response-col_description">Details</td>
+            <th className="col_header response-col_status" scope="col">Code</th>
+            <th className="col_header response-col_description" scope="col">Details</th>
           </tr>
           </thead>
           <tbody>

--- a/src/core/components/parameters/parameters.jsx
+++ b/src/core/components/parameters/parameters.jsx
@@ -175,10 +175,11 @@ export default class Parameters extends Component {
           {!groupedParametersArr.length ? <div className="opblock-description-wrapper"><p>No parameters</p></div> :
             <div className="table-container">
               <table className="parameters">
+                <caption className="sr-only">Parameters</caption>
                 <thead>
                 <tr>
-                  <th className="col_header parameters-col_name">Name</th>
-                  <th className="col_header parameters-col_description">Description</th>
+                  <th className="col_header parameters-col_name" scope="col">Name</th>
+                  <th className="col_header parameters-col_description" scope="col">Description</th>
                 </tr>
                 </thead>
                 <tbody>

--- a/src/core/components/responses.jsx
+++ b/src/core/components/responses.jsx
@@ -123,11 +123,12 @@ export default class Responses extends React.Component {
           }
 
           <table aria-live="polite" className="responses-table" id={regionId} role="region">
+            <caption className="sr-only">Server responses</caption>
             <thead>
               <tr className="responses-header">
-                <td className="col_header response-col_status">Code</td>
-                <td className="col_header response-col_description">Description</td>
-                { specSelectors.isOAS3() ? <td className="col col_header response-col_links">Links</td> : null }
+                <th className="col_header response-col_status" scope="col">Code</th>
+                <th className="col_header response-col_description" scope="col">Description</th>
+                { specSelectors.isOAS3() ? <th className="col col_header response-col_links" scope="col">Links</th> : null }
               </tr>
             </thead>
             <tbody>

--- a/src/style/_table.scss
+++ b/src/style/_table.scss
@@ -179,6 +179,18 @@ table {
   }
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .response-col_links {
   min-width: 6em;
 }


### PR DESCRIPTION
Fixes #10700

Adds visually hidden `<caption>` elements to tables (responses, live response, parameters) and replaces `<td>` column headers with proper `<th scope="col">` elements so screen readers can announce table context and column titles when navigating rows.

**Changes:**
- `responses.jsx`: Added caption "Server responses", changed `<td>` headers to `<th scope="col">`
- `live-response.jsx`: Added caption "Live server response", changed `<td>` headers to `<th scope="col">`
- `parameters.jsx`: Added caption "Parameters", added `scope="col"` to existing `<th>` elements
- `_table.scss`: Added `.sr-only` utility class for visually hidden captions