### PR TITLE
fix: escape vertical bar character in cURL (CMD) request snippets

### DIFF
--- a/src/core/plugins/request-snippets/fn.js
+++ b/src/core/plugins/request-snippets/fn.js
@@ -33,6 +33,7 @@ const escapeCMD = (str) => {
     .replace(/\^/g, "^^")
     .replace(/\\"/g, "\\\\\"")
     .replace(/"/g, "\"\"")
+    .replace(/\|/g, "^|")
     .replace(/\n/g, "^\n")
   if (str === "-d ") {
     return str


### PR DESCRIPTION
Fixes #10540

## Problem
The vertical bar character `|` in JSON request bodies was not being escaped in `cURL (CMD)` request snippets. When pasting the generated command into Windows `cmd.exe`, the pipe is interpreted as a command separator, causing errors like:

```
'some-string' is not recognized as an internal or external command
```

## Fix
Added `.replace(/\|/g, "^|")` to the `escapeCMD` function in `src/core/plugins/request-snippets/fn.js`. This escapes `|` with a caret (`^`), following the same CMD escaping convention already used for `^` and newlines in the function.

The replacement is placed after the caret escape (`^^`) to avoid double-escaping.