### PR TITLE
fix(dark-mode): add color-scheme property for native dark UI controls

### DIFF
--- a/src/style/_dark-mode.scss
+++ b/src/style/_dark-mode.scss
@@ -39,6 +39,7 @@ $opblock_colors: (
 );
 
 html.dark-mode {
+  color-scheme: dark;
   background: $neutral-98;
 
   .swagger-ui {


### PR DESCRIPTION
Fixes #10718

Adds `color-scheme: dark` to the `html.dark-mode` selector so that browser-provided controls (scrollbars, form inputs, color pickers, etc.) render in dark mode, matching the rest of the Swagger UI dark theme.

Without this, native browser controls still render with light-mode styling even when dark mode is active.