### PR TITLE
a11y: make operation expand/collapse button focusable

### DIFF
--- a/src/core/components/operation-summary.jsx
+++ b/src/core/components/operation-summary.jsx
@@ -98,10 +98,9 @@ export default class OperationSummary extends PureComponent {
         }
         <JumpToPath path={specPath} />{/* TODO: use wrapComponents here, swagger-ui doesn't care about jumpToPath */}
         <button
-          aria-label={`${method} ${path.replace(/\//g, "\u200b/")}`}
+          aria-label={`${isShown ? "Collapse" : "Expand"} ${method.toUpperCase()} ${path.replace(/\//g, "\u200b/")}`}
           className="opblock-control-arrow"
           aria-expanded={isShown}
-          tabIndex="-1"
           onClick={toggleShown}>
           {isShown ? <ArrowUpIcon className="arrow" /> : <ArrowDownIcon className="arrow" />}
         </button>


### PR DESCRIPTION
Fixes #10708

The expand/collapse arrow button on each operation had `tabIndex="-1"`, making it unreachable via keyboard navigation. This removes the negative tabIndex so the button is naturally focusable.

Also improves the `aria-label` to include the current state ("Collapse" or "Expand") and uppercases the HTTP method for better screen reader clarity.

Addresses the original issue reported in #7350.