### PR TITLE
fix(oas31): use transparent bg-color for accordion and expand buttons

### DIFF
--- a/src/core/plugins/json-schema-2020-12/components/Accordion/_accordion.scss
+++ b/src/core/plugins/json-schema-2020-12/components/Accordion/_accordion.scss
@@ -1,4 +1,5 @@
 .json-schema-2020-12-accordion {
+  background-color: transparent;
   outline: none;
   border: none;
   padding-left: 0;

--- a/src/core/plugins/json-schema-2020-12/components/ExpandDeepButton/_expand-deep-button.scss
+++ b/src/core/plugins/json-schema-2020-12/components/ExpandDeepButton/_expand-deep-button.scss
@@ -3,6 +3,7 @@
 
 .json-schema-2020-12-expand-deep-button {
   @include type.text_headline($section-models-model-title-font-color);
+  background-color: transparent;
   font-size: 12px;
   color: rgb(175, 174, 174);
   border: none;

--- a/src/core/plugins/oas31/components/model/_model.scss
+++ b/src/core/plugins/oas31/components/model/_model.scss
@@ -15,9 +15,4 @@
     padding: 0;
     background-color: transparent;
   }
-
-  .json-schema-2020-12-accordion,
-  .json-schema-2020-12-expand-deep-button {
-    background-color: transparent;
-  }
 }


### PR DESCRIPTION
### Description
Set `background-color` to `transparent` for accordion and expand buttons when loading an OAS 3.1 spec. 

### Motivation and Context
Currently, when loading an OAS 3.1 spec, the default button background color (`ButtonFace`) is used for accordion and expand buttons. 

In Chrome, `ButtonFace` happens to be very close to the container background color, so the difference is not noticeable. In Safari, however, the issue is quite apparent.

### How Has This Been Tested?
* Run `npm run lint`: No new problems.
* Run `npm run lint-styles`: No new problems.
* Run `npm run test`: All tests pass.
* Run `npm run dev`
  * Open in Safari & Chrome
  * Set spec URL to `https://raw.githubusercontent.com/readmeio/oas-examples/main/3.1/json/petstore.json`

### Screenshots

#### Before
<img width="1800" height="1169" alt="Before" src="https://github.com/user-attachments/assets/c7f80b3c-ec2a-4164-84c9-dc685f922271" />

#### After
<img width="1800" height="1169" alt="After" src="https://github.com/user-attachments/assets/6909d121-8956-4579-b471-a974c62a09f8" />

## Checklist

### My PR contains... 
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
