### PR TITLE
fix(curl-cmd): escape pipe character in Windows CMD snippets

### DIFF
--- a/src/core/plugins/request-snippets/fn.js
+++ b/src/core/plugins/request-snippets/fn.js
@@ -31,6 +31,7 @@ const escapeShell = (str) => {
 const escapeCMD = (str) => {
   str = str
     .replace(/\^/g, "^^")
+    .replace(/\|/g, "^|")
     .replace(/\\"/g, "\\\\\"")
     .replace(/"/g, "\"\"")
     .replace(/\n/g, "^\n")

--- a/test/unit/core/cmd-escape-issue.test.js
+++ b/test/unit/core/cmd-escape-issue.test.js
@@ -1,0 +1,53 @@
+/**
+ * @prettier
+ */
+import Im from "immutable"
+import {
+  requestSnippetGenerator_curl_bash,
+  requestSnippetGenerator_curl_cmd,
+  requestSnippetGenerator_curl_powershell
+} from "core/plugins/request-snippets/fn.js"
+
+describe("curlify - CMD pipe escaping (issue #10540)", function () {
+  it("escapes pipe in CMD request body", function () {
+    const req = {
+      url: "http://example.com/api",
+      method: "POST",
+      body: "data|with|pipes",
+      headers: {}
+    }
+
+    const curlified = requestSnippetGenerator_curl_cmd(Im.fromJS(req))
+    expect(curlified).toContain("data^|with^|pipes")
+  })
+
+  it("escapes pipe in CMD URL and header", function () {
+    const req = {
+      url: "http://example.com/api?name=john|smith",
+      method: "GET",
+      headers: {
+        "X-Custom": "value|with|pipe"
+      }
+    }
+
+    const curlified = requestSnippetGenerator_curl_cmd(Im.fromJS(req))
+    expect(curlified).toContain("john^|smith")
+    expect(curlified).toContain("value^|with^|pipe")
+  })
+
+  it("keeps bash and powershell behavior unchanged", function () {
+    const req = {
+      url: "http://example.com/api?name=john|smith",
+      method: "GET",
+      headers: {}
+    }
+
+    const bashResult = requestSnippetGenerator_curl_bash(Im.fromJS(req))
+    const psResult = requestSnippetGenerator_curl_powershell(Im.fromJS(req))
+
+    expect(bashResult).toContain("john|smith")
+    expect(psResult).toContain("john|smith")
+    expect(bashResult).not.toContain("^|")
+    expect(psResult).not.toContain("^|")
+  })
+})


### PR DESCRIPTION
## Summary
Fixes #10540 by escaping the vertical bar (`|`) in Windows CMD request snippets.

## What changed
- Updated CMD escaping logic to convert `|` to `^|`.
- Added unit tests covering pipe escaping in:
  - request body
  - URL query string
  - header values
- Added compatibility assertion that bash/powershell snippets keep existing behavior.

## Why
In Windows CMD, `|` is a control operator and must be escaped as `^|`. Without escaping, generated snippets can execute incorrectly.

## Validation
- `npm run test:unit -- --testPathPattern="curlify|cmd-escape"` ✅
