### PR TITLE
fix(request-snippets): escape pipe character in cURL CMD snippets

### DIFF
--- a/src/core/plugins/request-snippets/fn.js
+++ b/src/core/plugins/request-snippets/fn.js
@@ -33,6 +33,7 @@ const escapeCMD = (str) => {
     .replace(/\^/g, "^^")
     .replace(/\\"/g, "\\\\\"")
     .replace(/"/g, "\"\"")
+    .replace(/\|/g, "^|")
     .replace(/\n/g, "^\n")
   if (str === "-d ") {
     return str


### PR DESCRIPTION
## Summary
Escape the vertical bar `|` character in cURL CMD request snippets to prevent CMD from interpreting it as a pipe operator.

## Problem
When a request body contains the `|` character, the generated CMD curl snippet does not escape it. CMD interprets `|` as a pipe operator, causing the command to fail with an error.

## Fix
Added `.replace(/\|/g, "^|")` to the `escapeCMD` function in `src/core/plugins/request-snippets/fn.js`. The caret `^` is the standard CMD escape character.

Fixes #10540