### PR TITLE
fix(response): handle empty examples map in OAS3 responses

### DIFF
--- a/src/core/components/response.jsx
+++ b/src/core/components/response.jsx
@@ -68,7 +68,9 @@ export default class Response extends React.Component {
     const activeMediaType = response.getIn(["content", activeContentType], Map({}))
     const examplesForMediaType = activeMediaType.get("examples", null)
 
-    const firstExamplesKey = examplesForMediaType.keySeq().first()
+    const firstExamplesKey = Map.isMap(examplesForMediaType) && !examplesForMediaType.isEmpty()
+      ? examplesForMediaType.keySeq().first()
+      : undefined
     return activeExamplesKey || firstExamplesKey
   }
 
@@ -246,7 +248,7 @@ export default class Response extends React.Component {
               includeReadOnly={ true }/>
           ) : null }
 
-          { isOAS3 && examplesForMediaType ? (
+          { isOAS3 && Map.isMap(examplesForMediaType) && !examplesForMediaType.isEmpty() ? (
               <Example
                 example={examplesForMediaType.get(this.getTargetExamplesKey(), Map({}))}
                 getComponent={getComponent}

--- a/test/unit/core/plugins/json-schema-5/components/response.jsx
+++ b/test/unit/core/plugins/json-schema-5/components/response.jsx
@@ -83,4 +83,57 @@ describe("<Response />", function () {
       .schema.toJS().properties
     expect(Object.keys(modelExampleSchemaProperties)).toEqual(["c", "b", "a"])
   })
+
+  it("should render without error when OAS3 response has empty examples map", function () {
+    const oas3Components = {
+      ...components,
+      ExamplesSelect: dummyComponent,
+      Example: dummyComponent,
+    }
+    const getOAS3System = () => ({
+      getComponent: (c) => oas3Components[c],
+      getConfigs: () => {
+        return {}
+      },
+      specSelectors: {
+        isOAS3() {
+          return true
+        },
+      },
+      fn: {
+        inferSchema,
+        memoizedSampleFromSchema,
+        memoizedCreateXMLExample,
+        getJsonSampleSchema: makeGetJsonSampleSchema(getOAS3System),
+        getYamlSampleSchema: makeGetYamlSampleSchema(getOAS3System),
+        getXmlSampleSchema: makeGetXmlSampleSchema(getOAS3System),
+        getSampleSchema: makeGetSampleSchema(getOAS3System),
+      },
+    })
+    const oas3Props = {
+      ...getOAS3System(),
+      contentType: "application/json",
+      className: "for-test",
+      specPath: List(),
+      response: fromJS({
+        description: "ok",
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+            },
+            examples: {},
+          },
+        },
+      }),
+      code: "200",
+      path: "/foo",
+      method: "get",
+      oas3Actions: {},
+    }
+
+    expect(() => {
+      shallow(<Response {...oas3Props} />)
+    }).not.toThrow()
+  })
 })


### PR DESCRIPTION
### Description

Guard against empty `examples: {}` maps in OAS3 response content types that caused "could not render" errors. When a response's media type has an empty examples map, `examplesForMediaType.keySeq().first()` throws because the map has no keys. This fix checks that the examples map is a non-empty Immutable Map before accessing its keys.

### Motivation and Context

Fixes #7823

When an OAS3 spec includes an empty `examples: {}` in a response content type, Swagger UI crashes with a "could not render" error. This is because the code attempts to call `.keySeq().first()` on an empty (or null) Immutable Map without checking if it's valid first.

### How Has This Been Tested?

- Added a unit test that renders a `<Response>` component with an OAS3 response containing `examples: {}` and asserts no error is thrown
- Verified the existing unit tests still pass

### Screenshots (if appropriate):

N/A

## Checklist

### My PR contains...
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.