### PR TITLE
fix(oas31): resolve schema refs regardless of expand depth

### DIFF
--- a/src/core/plugins/oas31/components/models/models.jsx
+++ b/src/core/plugins/oas31/components/models/models.jsx
@@ -30,14 +30,8 @@ const Models = ({
    * Effects.
    */
   useEffect(() => {
-    const includesExpandedSchema = Object.entries(schemas).some(
-      ([schemaName]) =>
-        layoutSelectors.isShown([...schemasPath, schemaName], false)
-    )
-    const isOpenAndExpanded =
-      isOpen && (defaultModelsExpandDepth > 1 || includesExpandedSchema)
     const isResolved = specSelectors.specResolvedSubtree(schemasPath) != null
-    if (isOpenAndExpanded && !isResolved) {
+    if (isOpen && !isResolved) {
       specActions.requestResolvedSubtree(schemasPath)
     }
   }, [isOpen, defaultModelsExpandDepth])

--- a/test/unit/core/plugins/oas31/components/models.jsx
+++ b/test/unit/core/plugins/oas31/components/models.jsx
@@ -1,0 +1,290 @@
+/**
+ * @prettier
+ */
+/* eslint-disable react/jsx-no-bind, react/prop-types */
+import React from "react"
+import { mount } from "enzyme"
+
+import Models from "core/plugins/oas31/components/models/models"
+
+const fakeComponent =
+  (name) =>
+  ({ children, ...props }) => {
+    return (
+      <div data-component-name={name} {...props}>
+        {children}
+      </div>
+    )
+  }
+
+describe("<OAS31Models />", function () {
+  it("should request resolved subtree when schemas section is open with defaultModelsExpandDepth=1", function () {
+    const requestResolvedSubtree = jest.fn()
+    const schemas = {
+      Pet: {
+        type: "object",
+        properties: { petType: { type: "string" } },
+        discriminator: {
+          propertyName: "petType",
+          mapping: {
+            dog: "#/components/schemas/Dog",
+            cat: "#/components/schemas/Cat",
+          },
+        },
+      },
+      Dog: {
+        allOf: [
+          { $ref: "#/components/schemas/Pet" },
+          {
+            type: "object",
+            properties: { breed: { type: "string" } },
+          },
+        ],
+      },
+    }
+
+    mount(
+      <Models
+        specSelectors={{
+          selectSchemas: () => schemas,
+          specResolvedSubtree: () => null,
+        }}
+        specActions={{
+          requestResolvedSubtree: requestResolvedSubtree,
+        }}
+        layoutSelectors={{
+          isShown: () => true,
+        }}
+        layoutActions={{
+          show: jest.fn(),
+          readyToScroll: jest.fn(),
+        }}
+        getConfigs={() => ({
+          docExpansion: "list",
+          defaultModelsExpandDepth: 1,
+        })}
+        getComponent={(name) => fakeComponent(name)}
+        fn={{
+          jsonSchema202012: {
+            useFn: () => ({
+              getTitle: () => "",
+            }),
+          },
+        }}
+      />
+    )
+
+    expect(requestResolvedSubtree).toHaveBeenCalledWith([
+      "components",
+      "schemas",
+    ])
+  })
+
+  it("should not request resolved subtree when schemas are already resolved", function () {
+    const requestResolvedSubtree = jest.fn()
+    const schemas = {
+      Pet: { type: "object", properties: { petType: { type: "string" } } },
+    }
+
+    mount(
+      <Models
+        specSelectors={{
+          selectSchemas: () => schemas,
+          specResolvedSubtree: () => ({}),
+        }}
+        specActions={{
+          requestResolvedSubtree: requestResolvedSubtree,
+        }}
+        layoutSelectors={{
+          isShown: () => true,
+        }}
+        layoutActions={{
+          show: jest.fn(),
+          readyToScroll: jest.fn(),
+        }}
+        getConfigs={() => ({
+          docExpansion: "list",
+          defaultModelsExpandDepth: 1,
+        })}
+        getComponent={(name) => fakeComponent(name)}
+        fn={{
+          jsonSchema202012: {
+            useFn: () => ({
+              getTitle: () => "",
+            }),
+          },
+        }}
+      />
+    )
+
+    expect(requestResolvedSubtree).not.toHaveBeenCalled()
+  })
+
+  it("should not request resolved subtree when schemas section is closed", function () {
+    const requestResolvedSubtree = jest.fn()
+    const schemas = {
+      Pet: { type: "object", properties: { petType: { type: "string" } } },
+    }
+
+    mount(
+      <Models
+        specSelectors={{
+          selectSchemas: () => schemas,
+          specResolvedSubtree: () => null,
+        }}
+        specActions={{
+          requestResolvedSubtree: requestResolvedSubtree,
+        }}
+        layoutSelectors={{
+          isShown: () => false,
+        }}
+        layoutActions={{
+          show: jest.fn(),
+          readyToScroll: jest.fn(),
+        }}
+        getConfigs={() => ({
+          docExpansion: "none",
+          defaultModelsExpandDepth: 1,
+        })}
+        getComponent={(name) => fakeComponent(name)}
+        fn={{
+          jsonSchema202012: {
+            useFn: () => ({
+              getTitle: () => "",
+            }),
+          },
+        }}
+      />
+    )
+
+    expect(requestResolvedSubtree).not.toHaveBeenCalled()
+  })
+
+  it("should request resolved subtree for discriminator+allOf schemas with defaultModelsExpandDepth=1", function () {
+    const requestResolvedSubtree = jest.fn()
+    const schemas = {
+      Pet: {
+        type: "object",
+        required: ["petType"],
+        properties: { petType: { type: "string" } },
+        discriminator: {
+          propertyName: "petType",
+          mapping: {
+            dog: "#/components/schemas/Dog",
+            cat: "#/components/schemas/Cat",
+          },
+        },
+      },
+      Dog: {
+        allOf: [
+          { $ref: "#/components/schemas/Pet" },
+          {
+            type: "object",
+            properties: {
+              breed: { type: "string" },
+              barkVolume: {
+                type: "integer",
+                description: "Volume of the bark",
+              },
+            },
+          },
+        ],
+      },
+      Cat: {
+        allOf: [
+          { $ref: "#/components/schemas/Pet" },
+          {
+            type: "object",
+            properties: {
+              color: { type: "string" },
+              purrLoudness: {
+                type: "integer",
+                description: "Loudness of the purr",
+              },
+            },
+          },
+        ],
+      },
+    }
+
+    mount(
+      <Models
+        specSelectors={{
+          selectSchemas: () => schemas,
+          specResolvedSubtree: () => null,
+        }}
+        specActions={{
+          requestResolvedSubtree: requestResolvedSubtree,
+        }}
+        layoutSelectors={{
+          isShown: () => true,
+        }}
+        layoutActions={{
+          show: jest.fn(),
+          readyToScroll: jest.fn(),
+        }}
+        getConfigs={() => ({
+          docExpansion: "list",
+          defaultModelsExpandDepth: 1,
+        })}
+        getComponent={(name) => fakeComponent(name)}
+        fn={{
+          jsonSchema202012: {
+            useFn: () => ({
+              getTitle: () => "",
+            }),
+          },
+        }}
+      />
+    )
+
+    expect(requestResolvedSubtree).toHaveBeenCalledWith([
+      "components",
+      "schemas",
+    ])
+  })
+
+  it("should render all schema entries from selectSchemas", function () {
+    const schemas = {
+      Pet: { type: "object" },
+      Dog: { type: "object" },
+      Cat: { type: "object" },
+    }
+
+    const wrapper = mount(
+      <Models
+        specSelectors={{
+          selectSchemas: () => schemas,
+          specResolvedSubtree: () => ({}),
+        }}
+        specActions={{
+          requestResolvedSubtree: jest.fn(),
+        }}
+        layoutSelectors={{
+          isShown: () => true,
+        }}
+        layoutActions={{
+          show: jest.fn(),
+          readyToScroll: jest.fn(),
+        }}
+        getConfigs={() => ({
+          docExpansion: "list",
+          defaultModelsExpandDepth: 1,
+        })}
+        getComponent={(name) => fakeComponent(name)}
+        fn={{
+          jsonSchema202012: {
+            useFn: () => ({
+              getTitle: () => "",
+            }),
+          },
+        }}
+      />
+    )
+
+    const jsonSchemaComponents = wrapper.find(
+      '[data-component-name="JSONSchema202012"]'
+    )
+    expect(jsonSchemaComponents).toHaveLength(3)
+  })
+})


### PR DESCRIPTION
### Description

Simplify the schema resolution condition in the OAS 3.1 Models component to trigger resolution whenever the Models section is open and schemas haven't been resolved yet, regardless of `defaultModelsExpandDepth`.

Previously, the `useEffect` only requested resolution of `["components", "schemas"]` when `defaultModelsExpandDepth > 1` OR when at least one schema was individually expanded in the layout state. With the default depth of 1, `$ref` values in `allOf` (used with discriminator patterns) were never resolved, causing "could not resolve reference" errors.

### Motivation and Context

Fixes #10336

The `defaultModelsExpandDepth` config should control UI expansion depth, not whether schema references get resolved. Schemas need to be resolved to render correctly regardless of expansion depth.

### How Has This Been Tested?

- Added 5 regression tests covering:
  - Resolution requested with `defaultModelsExpandDepth=1` (the bug scenario)
  - Resolution NOT requested when already resolved
  - Resolution NOT requested when the section is closed
  - Resolution for the exact discriminator+allOf pattern from the issue
  - All schema entries are rendered
- All 834 unit tests pass

### Screenshots (if appropriate):

N/A

## Checklist

### My PR contains...
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.