### PR TITLE
feat: add eslint-plugin-jsx-a11y and fix a11y violations

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,9 +19,10 @@ module.exports = {
   extends: [
     "eslint:recommended",
     "plugin:react/recommended",
+    "plugin:jsx-a11y/recommended",
     "plugin:prettier/recommended",
   ],
-  plugins: ["react", "import", "jest", "prettier"],
+  plugins: ["react", "import", "jest", "prettier", "jsx-a11y"],
   settings: {
     react: {
       pragma: "React",
@@ -74,5 +75,13 @@ module.exports = {
     "react/display-name": 0,
     "import/no-extraneous-dependencies": 2,
     "react/jsx-filename-extension": 2,
+    // autoFocus on the first field of a modal is an accepted a11y pattern
+    "jsx-a11y/no-autofocus": 0,
+    // Non-interactive elements with onClick need design-level refactoring; warn for now
+    "jsx-a11y/click-events-have-key-events": 1,
+    "jsx-a11y/no-static-element-interactions": 1,
+    "jsx-a11y/no-noninteractive-element-interactions": 1,
+    // Scope checkbox labels have accessible text nested at depth 3
+    "jsx-a11y/label-has-associated-control": ["error", { depth: 3 }],
   },
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,7 @@
         "eslint-config-prettier": "^10.1.1",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-jest": "^28.12.0",
+        "eslint-plugin-jsx-a11y": "=6.10.2",
         "eslint-plugin-prettier": "^5.2.3",
         "eslint-plugin-react": "^7.37.4",
         "esm": "=3.2.25",
@@ -7613,6 +7614,16 @@
         "node": ">=0.6.10"
       }
     },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/array-back": {
       "version": "6.2.2",
       "dev": true,
@@ -7843,6 +7854,13 @@
         "node": ">=4"
       }
     },
+    "node_modules/ast-types-flow": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
+      "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "dev": true,
@@ -7957,6 +7975,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/axe-core": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.2.tgz",
+      "integrity": "sha512-byD6KPdvo72y/wj2T/4zGEvvlis+PsZsn/yPS3pEO+sFpcrqRpX/TJCxvVaEsNeMrfQbCr7w163YqoD9IYwHXw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/axios": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
@@ -7975,6 +8003,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/babel-jest": {
@@ -10627,6 +10665,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/damerau-levenshtein": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/dargs": {
       "version": "8.1.0",
       "dev": true,
@@ -11872,6 +11917,43 @@
           "optional": true
         }
       }
+    },
+    "node_modules/eslint-plugin-jsx-a11y": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
+      "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.3.2",
+        "array-includes": "^3.1.8",
+        "array.prototype.flatmap": "^1.3.2",
+        "ast-types-flow": "^0.0.8",
+        "axe-core": "^4.10.0",
+        "axobject-query": "^4.1.0",
+        "damerau-levenshtein": "^1.0.8",
+        "emoji-regex": "^9.2.2",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^3.3.5",
+        "language-tags": "^1.0.9",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.includes": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eslint-plugin-prettier": {
       "version": "5.2.3",
@@ -17566,6 +17648,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/language-subtag-registry": {
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
+      "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/language-tags": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
+      "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "language-subtag-registry": "^0.3.20"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/launch-editor": {
@@ -25697,6 +25799,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/string.prototype.includes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
+      "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/string.prototype.matchall": {

--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "eslint-config-prettier": "^10.1.1",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-jest": "^28.12.0",
+    "eslint-plugin-jsx-a11y": "=6.10.2",
     "eslint-plugin-prettier": "^5.2.3",
     "eslint-plugin-react": "^7.37.4",
     "esm": "=3.2.25",

--- a/src/core/components/auth/oauth2.jsx
+++ b/src/core/components/auth/oauth2.jsx
@@ -234,8 +234,8 @@ export default class Oauth2 extends React.Component {
           !isAuthorized && scopes && scopes.size ? <div className="scopes">
             <h2>
               Scopes:
-              <a onClick={this.selectScopes} data-all={true}>select all</a>
-              <a onClick={this.selectScopes}>select none</a>
+              <button type="button" className="link" onClick={this.selectScopes} data-all={true}>select all</button>
+              <button type="button" className="link" onClick={this.selectScopes}>select none</button>
             </h2>
             { scopes.map((description, name) => {
               return (

--- a/src/core/components/debug.jsx
+++ b/src/core/components/debug.jsx
@@ -29,7 +29,7 @@ export default class Debug extends React.Component {
 
     return (
       <div className="info">
-        <h3><a onClick={this.toggleJsonDump}> {this.plusOrMinus(this.state.jsonDumpOpen)} App </a></h3>
+        <h3><button type="button" className="link" onClick={this.toggleJsonDump}> {this.plusOrMinus(this.state.jsonDumpOpen)} App </button></h3>
 
         <Collapse isOpened={this.state.jsonDumpOpen} springConfig={{ stiffness: 170, damping: 26 }}>
 

--- a/src/core/components/errors.jsx
+++ b/src/core/components/errors.jsx
@@ -76,7 +76,7 @@ const ThrownErrorItem = ( { error, jumpToLine } ) => {
             { error.get("message") }
           </span>
           <div className="error-line">
-            { errorLine && jumpToLine ? <a onClick={jumpToLine.bind(null, errorLine)}>Jump to line { errorLine }</a> : null }
+            { errorLine && jumpToLine ? <button type="button" className="link" onClick={jumpToLine.bind(null, errorLine)}>Jump to line { errorLine }</button> : null }
           </div>
         </div>
       }
@@ -105,7 +105,7 @@ const SpecErrorItem = ( { error, jumpToLine = null } ) => {
           <span className="message">{ error.get("message") }</span>
           <div className="error-line">
             { jumpToLine ? (
-              <a onClick={jumpToLine.bind(null, error.get("line"))}>Jump to line { error.get("line") }</a>
+              <button type="button" className="link" onClick={jumpToLine.bind(null, error.get("line"))}>Jump to line { error.get("line") }</button>
             ) : null }
           </div>
         </div>

--- a/src/core/components/headers.jsx
+++ b/src/core/components/headers.jsx
@@ -25,9 +25,9 @@ export default class Headers extends React.Component {
         <table className="headers">
           <thead>
             <tr className="header-row">
-              <th className="header-col">Name</th>
-              <th className="header-col">Description</th>
-              <th className="header-col">Type</th>
+              <th className="header-col" scope="col">Name</th>
+              <th className="header-col" scope="col">Description</th>
+              <th className="header-col" scope="col">Type</th>
             </tr>
           </thead>
           <tbody>

--- a/src/core/components/layout-utils.jsx
+++ b/src/core/components/layout-utils.jsx
@@ -210,12 +210,13 @@ export class Select extends React.Component {
 export class Link extends React.Component {
 
   render() {
-    return <a {...this.props} rel="noopener noreferrer" className={xclass(this.props.className, "link")}/>
+    return <a {...this.props} rel="noopener noreferrer" className={xclass(this.props.className, "link")}>{this.props.children}</a>
   }
 
 }
 
 Link.propTypes = {
+  children: PropTypes.node,
   className: PropTypes.string
 }
 

--- a/src/core/components/parameters/parameters.jsx
+++ b/src/core/components/parameters/parameters.jsx
@@ -177,8 +177,8 @@ export default class Parameters extends Component {
               <table className="parameters">
                 <thead>
                 <tr>
-                  <th className="col_header parameters-col_name">Name</th>
-                  <th className="col_header parameters-col_description">Description</th>
+                  <th className="col_header parameters-col_name" scope="col">Name</th>
+                  <th className="col_header parameters-col_description" scope="col">Description</th>
                 </tr>
                 </thead>
                 <tbody>
@@ -220,7 +220,7 @@ export default class Parameters extends Component {
             <div className="opblock-section-header">
               <h4 className={`opblock-title parameter__name ${requestBody.get("required") && "required"}`}>Request
                 body</h4>
-              <label id={controlId}>
+              <div id={controlId}>
                 <ContentType
                   value={oas3Selectors.requestContentType(...pathMethod)}
                   contentTypes={requestBody.get("content", List()).keySeq()}
@@ -231,7 +231,7 @@ export default class Parameters extends Component {
                   ariaLabel="Request content type" 
                   controlId={controlId}
                 />
-              </label>
+              </div>
             </div>
             <div className="opblock-description-wrapper">
               <RequestBody

--- a/src/core/components/response-body.jsx
+++ b/src/core/components/response-body.jsx
@@ -130,11 +130,12 @@ export default class ResponseBody extends React.PureComponent {
       if(contentType.includes("svg")) {
         bodyEl = <div> { content } </div>
       } else {
-        bodyEl = <img src={ window.URL.createObjectURL(content) } />
+        bodyEl = <img alt="" src={ window.URL.createObjectURL(content) } />
       }
 
       // Audio
     } else if (/^audio\//i.test(contentType)) {
+      // eslint-disable-next-line jsx-a11y/media-has-caption
       bodyEl = <pre className="microlight"><audio controls key={ url }><source src={ url } type={ contentType } /></audio></pre>
     } else if (typeof content === "string") {
       bodyEl = <HighlightCode downloadable fileName={`${downloadName}.txt`} canCopy>{content}</HighlightCode>


### PR DESCRIPTION
Introduces `eslint-plugin-jsx-a11y@6.10.2` as a dev dependency with `plugin:jsx-a11y/recommended` to statically enforce accessibility rules across all JSX. Fixes every error-level violation surfaced by the plugin.

### ESLint configuration (`eslintrc.js`)
- Extends `plugin:jsx-a11y/recommended`
- `no-autofocus: 0` — autoFocus on first modal field is intentional UX
- `click-events-have-key-events`, `no-static-element-interactions`, `no-noninteractive-element-interactions` → `warn` — patterns like `<h4 onClick>` / `<div onClick>` require design-level refactoring, flagged for future work
- `label-has-associated-control: ["error", { depth: 3 }]` — OAuth2 scope checkbox labels have accessible text 3 levels deep

### Code fixes

| File | Change |
|------|--------|
| `errors.jsx` | 2× `<a onClick>` (no href) → `<button type="button" className="link">` |
| `debug.jsx` | `<a onClick>` → `<button type="button" className="link">` |
| `oauth2.jsx` | "select all"/"select none" `<a onClick>` → `<button type="button" className="link">` |
| `response-body.jsx` | Add `alt=""` to blob-rendered `<img>`; suppress `media-has-caption` for dynamic API audio (no caption source available) |
| `headers.jsx` | Add `scope="col"` to all `<th>` elements |
| `parameters.jsx` | Add `scope="col"` to `<th>` elements; replace `<label id={controlId}>` (no `htmlFor`, no text) with `<div>` — the wrapped `<select>` already carries `aria-label` |
| `layout-utils.jsx` | Make `Link` children explicit (`{this.props.children}`) to satisfy `anchor-has-content`; add `children` to propTypes |

### How Has This Been Tested?
- `npm run lint` — 0 errors (pre-existing `react/jsx-no-bind` warnings unchanged; 10 new a11y warnings on non-interactive `onClick` patterns intentionally left as warnings)
- `npm run test:unit` — 829/829 tests pass

### Screenshots (if appropriate):

## Checklist

### My PR contains... 
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [x] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.