### PR TITLE
feat(lint): integrate eslint-plugin-react-hooks with rules-of-hooks and exhaustive-deps as errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,7 +21,7 @@ module.exports = {
     "plugin:react/recommended",
     "plugin:prettier/recommended",
   ],
-  plugins: ["react", "import", "jest", "prettier"],
+  plugins: ["react", "react-hooks", "import", "jest", "prettier"],
   settings: {
     react: {
       pragma: "React",
@@ -74,5 +74,7 @@ module.exports = {
     "react/display-name": 0,
     "import/no-extraneous-dependencies": 2,
     "react/jsx-filename-extension": 2,
+    "react-hooks/rules-of-hooks": 2,
+    "react-hooks/exhaustive-deps": 2,
   },
 }

--- a/flavors/swagger-ui-react/index.jsx
+++ b/flavors/swagger-ui-react/index.jsx
@@ -93,6 +93,7 @@ const SwaggerUI = ({
     })
 
     setSystem(systemInstance)
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally mount-only: creates the initial SwaggerUI system instance once; prop changes after mount are handled by the dedicated effects below
   }, [])
 
   useEffect(() => {
@@ -106,6 +107,7 @@ const SwaggerUI = ({
         }
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- prevUrl is intentionally excluded: it is a usePrevious ref value and adding it would cause the effect to double-fire when the URL changes
   }, [system, url])
 
   useEffect(() => {
@@ -121,6 +123,7 @@ const SwaggerUI = ({
         system.specActions.updateSpec(updatedSpec)
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- prevSpec is intentionally excluded: it is a usePrevious ref value and adding it would cause the effect to double-fire when the spec changes
   }, [system, spec])
 
   return SwaggerUIComponent ? <SwaggerUIComponent /> : null

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,6 +83,7 @@
         "eslint-plugin-jest": "^28.12.0",
         "eslint-plugin-prettier": "^5.2.3",
         "eslint-plugin-react": "^7.37.4",
+        "eslint-plugin-react-hooks": "=7.0.1",
         "esm": "=3.2.25",
         "expect": "=29.7.0",
         "express": "^4.22.1",
@@ -11935,6 +11936,26 @@
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
       }
     },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
+      "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+      }
+    },
     "node_modules/eslint-plugin-react/node_modules/doctrine": {
       "version": "2.1.0",
       "dev": true,
@@ -13595,6 +13616,23 @@
       "license": "MIT",
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
       }
     },
     "node_modules/highlight.js": {
@@ -28370,6 +28408,29 @@
     "node_modules/zenscroll": {
       "version": "4.0.2",
       "license": "Unlicense"
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "eslint-plugin-jest": "^28.12.0",
     "eslint-plugin-prettier": "^5.2.3",
     "eslint-plugin-react": "^7.37.4",
+    "eslint-plugin-react-hooks": "=7.0.1",
     "esm": "=3.2.25",
     "expect": "=29.7.0",
     "express": "^4.22.1",

--- a/src/core/plugins/json-schema-2020-12/components/JSONSchema/JSONSchema.jsx
+++ b/src/core/plugins/json-schema-2020-12/components/JSONSchema/JSONSchema.jsx
@@ -45,15 +45,15 @@ const JSONSchema = forwardRef(
     const renderedSchemas = useRenderedSchemas(schema)
     const constraints = fn.stringifyConstraints(schema)
     const Accordion = useComponent("Accordion")
-    const Keyword$schema = useComponent("Keyword$schema")
-    const Keyword$vocabulary = useComponent("Keyword$vocabulary")
-    const Keyword$id = useComponent("Keyword$id")
-    const Keyword$anchor = useComponent("Keyword$anchor")
-    const Keyword$dynamicAnchor = useComponent("Keyword$dynamicAnchor")
-    const Keyword$ref = useComponent("Keyword$ref")
-    const Keyword$dynamicRef = useComponent("Keyword$dynamicRef")
-    const Keyword$defs = useComponent("Keyword$defs")
-    const Keyword$comment = useComponent("Keyword$comment")
+    const KeywordSchema = useComponent("Keyword$schema")
+    const KeywordVocabulary = useComponent("Keyword$vocabulary")
+    const KeywordId = useComponent("Keyword$id")
+    const KeywordAnchor = useComponent("Keyword$anchor")
+    const KeywordDynamicAnchor = useComponent("Keyword$dynamicAnchor")
+    const KeywordRef = useComponent("Keyword$ref")
+    const KeywordDynamicRef = useComponent("Keyword$dynamicRef")
+    const KeywordDefs = useComponent("Keyword$defs")
+    const KeywordComment = useComponent("Keyword$comment")
     const KeywordAllOf = useComponent("KeywordAllOf")
     const KeywordAnyOf = useComponent("KeywordAnyOf")
     const KeywordOneOf = useComponent("KeywordOneOf")
@@ -193,17 +193,17 @@ const JSONSchema = forwardRef(
                     />
                     <KeywordDefault schema={schema} />
                     <KeywordExamples schema={schema} />
-                    <Keyword$schema schema={schema} />
-                    <Keyword$vocabulary schema={schema} />
-                    <Keyword$id schema={schema} />
-                    <Keyword$anchor schema={schema} />
-                    <Keyword$dynamicAnchor schema={schema} />
-                    <Keyword$ref schema={schema} />
+                    <KeywordSchema schema={schema} />
+                    <KeywordVocabulary schema={schema} />
+                    <KeywordId schema={schema} />
+                    <KeywordAnchor schema={schema} />
+                    <KeywordDynamicAnchor schema={schema} />
+                    <KeywordRef schema={schema} />
                     {!isCircular && isExpandable && (
-                      <Keyword$defs schema={schema} />
+                      <KeywordDefs schema={schema} />
                     )}
-                    <Keyword$dynamicRef schema={schema} />
-                    <Keyword$comment schema={schema} />
+                    <KeywordDynamicRef schema={schema} />
+                    <KeywordComment schema={schema} />
                     <ExtensionKeywords schema={schema} />
                   </>
                 )}

--- a/src/core/plugins/json-schema-2020-12/components/keywords/$anchor.jsx
+++ b/src/core/plugins/json-schema-2020-12/components/keywords/$anchor.jsx
@@ -5,7 +5,7 @@ import React from "react"
 
 import { schema } from "../../prop-types"
 
-const $anchor = ({ schema }) => {
+const Anchor = ({ schema }) => {
   if (!schema?.$anchor) return null
 
   return (
@@ -20,8 +20,8 @@ const $anchor = ({ schema }) => {
   )
 }
 
-$anchor.propTypes = {
+Anchor.propTypes = {
   schema: schema.isRequired,
 }
 
-export default $anchor
+export default Anchor

--- a/src/core/plugins/json-schema-2020-12/components/keywords/$comment.jsx
+++ b/src/core/plugins/json-schema-2020-12/components/keywords/$comment.jsx
@@ -5,7 +5,7 @@ import React from "react"
 
 import { schema } from "../../prop-types"
 
-const $comment = ({ schema }) => {
+const Comment = ({ schema }) => {
   if (!schema?.$comment) return null
 
   return (
@@ -20,8 +20,8 @@ const $comment = ({ schema }) => {
   )
 }
 
-$comment.propTypes = {
+Comment.propTypes = {
   schema: schema.isRequired,
 }
 
-export default $comment
+export default Comment

--- a/src/core/plugins/json-schema-2020-12/components/keywords/$defs.jsx
+++ b/src/core/plugins/json-schema-2020-12/components/keywords/$defs.jsx
@@ -8,7 +8,7 @@ import { schema } from "../../prop-types"
 import { useComponent, useIsExpanded, usePath, useLevel } from "../../hooks"
 import { JSONSchemaLevelContext, JSONSchemaPathContext } from "../../context"
 
-const $defs = ({ schema }) => {
+const Defs = ({ schema }) => {
   const $defs = schema?.$defs || {}
   const pathToken = "$defs"
   const { path } = usePath(pathToken)
@@ -86,8 +86,8 @@ const $defs = ({ schema }) => {
   )
 }
 
-$defs.propTypes = {
+Defs.propTypes = {
   schema: schema.isRequired,
 }
 
-export default $defs
+export default Defs

--- a/src/core/plugins/json-schema-2020-12/components/keywords/$dynamicAnchor.jsx
+++ b/src/core/plugins/json-schema-2020-12/components/keywords/$dynamicAnchor.jsx
@@ -5,7 +5,7 @@ import React from "react"
 
 import { schema } from "../../prop-types"
 
-const $dynamicAnchor = ({ schema }) => {
+const DynamicAnchor = ({ schema }) => {
   if (!schema?.$dynamicAnchor) return null
 
   return (
@@ -20,8 +20,8 @@ const $dynamicAnchor = ({ schema }) => {
   )
 }
 
-$dynamicAnchor.propTypes = {
+DynamicAnchor.propTypes = {
   schema: schema.isRequired,
 }
 
-export default $dynamicAnchor
+export default DynamicAnchor

--- a/src/core/plugins/json-schema-2020-12/components/keywords/$dynamicRef.jsx
+++ b/src/core/plugins/json-schema-2020-12/components/keywords/$dynamicRef.jsx
@@ -5,7 +5,7 @@ import React from "react"
 
 import { schema } from "../../prop-types"
 
-const $dynamicRef = ({ schema }) => {
+const DynamicRef = ({ schema }) => {
   if (!schema?.$dynamicRef) return null
 
   return (
@@ -20,8 +20,8 @@ const $dynamicRef = ({ schema }) => {
   )
 }
 
-$dynamicRef.propTypes = {
+DynamicRef.propTypes = {
   schema: schema.isRequired,
 }
 
-export default $dynamicRef
+export default DynamicRef

--- a/src/core/plugins/json-schema-2020-12/components/keywords/$id.jsx
+++ b/src/core/plugins/json-schema-2020-12/components/keywords/$id.jsx
@@ -5,7 +5,7 @@ import React from "react"
 
 import { schema } from "../../prop-types"
 
-const $id = ({ schema }) => {
+const Id = ({ schema }) => {
   if (!schema?.$id) return null
 
   return (
@@ -20,8 +20,8 @@ const $id = ({ schema }) => {
   )
 }
 
-$id.propTypes = {
+Id.propTypes = {
   schema: schema.isRequired,
 }
 
-export default $id
+export default Id

--- a/src/core/plugins/json-schema-2020-12/components/keywords/$ref.jsx
+++ b/src/core/plugins/json-schema-2020-12/components/keywords/$ref.jsx
@@ -5,7 +5,7 @@ import React from "react"
 
 import { schema } from "../../prop-types"
 
-const $ref = ({ schema }) => {
+const Ref = ({ schema }) => {
   if (!schema?.$ref) return null
 
   return (
@@ -20,8 +20,8 @@ const $ref = ({ schema }) => {
   )
 }
 
-$ref.propTypes = {
+Ref.propTypes = {
   schema: schema.isRequired,
 }
 
-export default $ref
+export default Ref

--- a/src/core/plugins/json-schema-2020-12/components/keywords/$schema.jsx
+++ b/src/core/plugins/json-schema-2020-12/components/keywords/$schema.jsx
@@ -5,7 +5,7 @@ import React from "react"
 
 import { schema } from "../../prop-types"
 
-const $schema = ({ schema }) => {
+const Schema = ({ schema }) => {
   if (!schema?.$schema) return null
 
   return (
@@ -20,8 +20,8 @@ const $schema = ({ schema }) => {
   )
 }
 
-$schema.propTypes = {
+Schema.propTypes = {
   schema: schema.isRequired,
 }
 
-export default $schema
+export default Schema

--- a/src/core/plugins/json-schema-2020-12/components/keywords/$vocabulary/$vocabulary.jsx
+++ b/src/core/plugins/json-schema-2020-12/components/keywords/$vocabulary/$vocabulary.jsx
@@ -8,7 +8,7 @@ import { schema } from "../../../prop-types"
 import { useComponent, useIsExpanded, usePath } from "../../../hooks"
 import { JSONSchemaPathContext } from "../../../context"
 
-const $vocabulary = ({ schema }) => {
+const Vocabulary = ({ schema }) => {
   const pathToken = "$vocabulary"
   const { path } = usePath(pathToken)
   const { isExpanded, setExpanded, setCollapsed } = useIsExpanded(pathToken)
@@ -59,8 +59,8 @@ const $vocabulary = ({ schema }) => {
   )
 }
 
-$vocabulary.propTypes = {
+Vocabulary.propTypes = {
   schema: schema.isRequired,
 }
 
-export default $vocabulary
+export default Vocabulary

--- a/src/core/plugins/json-schema-2020-12/hoc.jsx
+++ b/src/core/plugins/json-schema-2020-12/hoc.jsx
@@ -4,15 +4,15 @@
 import React from "react"
 
 import JSONSchema from "./components/JSONSchema/JSONSchema"
-import Keyword$schema from "./components/keywords/$schema"
-import Keyword$vocabulary from "./components/keywords/$vocabulary/$vocabulary"
-import Keyword$id from "./components/keywords/$id"
-import Keyword$anchor from "./components/keywords/$anchor"
-import Keyword$dynamicAnchor from "./components/keywords/$dynamicAnchor"
-import Keyword$ref from "./components/keywords/$ref"
-import Keyword$dynamicRef from "./components/keywords/$dynamicRef"
-import Keyword$defs from "./components/keywords/$defs"
-import Keyword$comment from "./components/keywords/$comment"
+import KeywordSchema from "./components/keywords/$schema"
+import KeywordVocabulary from "./components/keywords/$vocabulary/$vocabulary"
+import KeywordId from "./components/keywords/$id"
+import KeywordAnchor from "./components/keywords/$anchor"
+import KeywordDynamicAnchor from "./components/keywords/$dynamicAnchor"
+import KeywordRef from "./components/keywords/$ref"
+import KeywordDynamicRef from "./components/keywords/$dynamicRef"
+import KeywordDefs from "./components/keywords/$defs"
+import KeywordComment from "./components/keywords/$comment"
 import KeywordAllOf from "./components/keywords/AllOf"
 import KeywordAnyOf from "./components/keywords/AnyOf"
 import KeywordOneOf from "./components/keywords/OneOf"
@@ -68,15 +68,15 @@ export const withJSONSchemaContext = (Component, overrides = {}) => {
   const value = {
     components: {
       JSONSchema,
-      Keyword$schema,
-      Keyword$vocabulary,
-      Keyword$id,
-      Keyword$anchor,
-      Keyword$dynamicAnchor,
-      Keyword$ref,
-      Keyword$dynamicRef,
-      Keyword$defs,
-      Keyword$comment,
+      Keyword$schema: KeywordSchema,
+      Keyword$vocabulary: KeywordVocabulary,
+      Keyword$id: KeywordId,
+      Keyword$anchor: KeywordAnchor,
+      Keyword$dynamicAnchor: KeywordDynamicAnchor,
+      Keyword$ref: KeywordRef,
+      Keyword$dynamicRef: KeywordDynamicRef,
+      Keyword$defs: KeywordDefs,
+      Keyword$comment: KeywordComment,
       KeywordAllOf,
       KeywordAnyOf,
       KeywordOneOf,
@@ -165,21 +165,17 @@ export const makeWithJSONSchemaSystemContext =
     const configs = getConfigs()
 
     const JSONSchema = getComponent("JSONSchema202012")
-    const Keyword$schema = getComponent("JSONSchema202012Keyword$schema")
-    const Keyword$vocabulary = getComponent(
-      "JSONSchema202012Keyword$vocabulary"
-    )
-    const Keyword$id = getComponent("JSONSchema202012Keyword$id")
-    const Keyword$anchor = getComponent("JSONSchema202012Keyword$anchor")
-    const Keyword$dynamicAnchor = getComponent(
+    const KeywordSchema = getComponent("JSONSchema202012Keyword$schema")
+    const KeywordVocabulary = getComponent("JSONSchema202012Keyword$vocabulary")
+    const KeywordId = getComponent("JSONSchema202012Keyword$id")
+    const KeywordAnchor = getComponent("JSONSchema202012Keyword$anchor")
+    const KeywordDynamicAnchor = getComponent(
       "JSONSchema202012Keyword$dynamicAnchor"
     )
-    const Keyword$ref = getComponent("JSONSchema202012Keyword$ref")
-    const Keyword$dynamicRef = getComponent(
-      "JSONSchema202012Keyword$dynamicRef"
-    )
-    const Keyword$defs = getComponent("JSONSchema202012Keyword$defs")
-    const Keyword$comment = getComponent("JSONSchema202012Keyword$comment")
+    const KeywordRef = getComponent("JSONSchema202012Keyword$ref")
+    const KeywordDynamicRef = getComponent("JSONSchema202012Keyword$dynamicRef")
+    const KeywordDefs = getComponent("JSONSchema202012Keyword$defs")
+    const KeywordComment = getComponent("JSONSchema202012Keyword$comment")
     const KeywordAllOf = getComponent("JSONSchema202012KeywordAllOf")
     const KeywordAnyOf = getComponent("JSONSchema202012KeywordAnyOf")
     const KeywordOneOf = getComponent("JSONSchema202012KeywordOneOf")
@@ -239,15 +235,15 @@ export const makeWithJSONSchemaSystemContext =
     return withJSONSchemaContext(Component, {
       components: {
         JSONSchema,
-        Keyword$schema,
-        Keyword$vocabulary,
-        Keyword$id,
-        Keyword$anchor,
-        Keyword$dynamicAnchor,
-        Keyword$ref,
-        Keyword$dynamicRef,
-        Keyword$defs,
-        Keyword$comment,
+        Keyword$schema: KeywordSchema,
+        Keyword$vocabulary: KeywordVocabulary,
+        Keyword$id: KeywordId,
+        Keyword$anchor: KeywordAnchor,
+        Keyword$dynamicAnchor: KeywordDynamicAnchor,
+        Keyword$ref: KeywordRef,
+        Keyword$dynamicRef: KeywordDynamicRef,
+        Keyword$defs: KeywordDefs,
+        Keyword$comment: KeywordComment,
         KeywordAllOf,
         KeywordAnyOf,
         KeywordOneOf,

--- a/src/core/plugins/json-schema-2020-12/hooks.js
+++ b/src/core/plugins/json-schema-2020-12/hooks.js
@@ -113,29 +113,34 @@ export const useIsExpanded = (name) => {
         ? JSONSchemaIsExpandedState.DeeplyExpanded
         : isExpandedState
     )
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally only re-runs when parentState changes; isExpandedState/pathMutator excluded to avoid infinite update loops
   }, [parentState])
 
+  // Note: pathMutator is excluded from both callbacks below because it is recreated on
+  // every render; including it would cause these callbacks to be recreated on every render,
+  // defeating the purpose of useCallback.
   const setExpanded = useCallback((options = { deep: false }) => {
     pathMutator(
       options.deep
         ? JSONSchemaIsExpandedState.DeeplyExpanded
         : JSONSchemaIsExpandedState.Expanded
     )
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- pathMutator excluded to prevent callback recreation on every render
   }, [])
 
   const setCollapsed = useCallback((options = { deep: false }) => {
     pathMutator(JSONSchemaIsExpandedState.Collapsed, options)
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- pathMutator excluded to prevent callback recreation on every render
   }, [])
 
   return { isExpanded, setExpanded, setCollapsed }
 }
 
 export const useRenderedSchemas = (schema = undefined) => {
-  if (typeof schema === "undefined") {
-    return useContext(JSONSchemaCyclesContext)
-  }
-
   const renderedSchemas = useContext(JSONSchemaCyclesContext)
+  if (typeof schema === "undefined") {
+    return renderedSchemas
+  }
   return new Set([...renderedSchemas, schema])
 }
 export const useIsCircular = (schema) => {

--- a/src/core/plugins/json-schema-2020-12/index.js
+++ b/src/core/plugins/json-schema-2020-12/index.js
@@ -2,15 +2,15 @@
  * @prettier
  */
 import JSONSchema from "./components/JSONSchema/JSONSchema"
-import Keyword$schema from "./components/keywords/$schema"
-import Keyword$vocabulary from "./components/keywords/$vocabulary/$vocabulary"
-import Keyword$id from "./components/keywords/$id"
-import Keyword$anchor from "./components/keywords/$anchor"
-import Keyword$dynamicAnchor from "./components/keywords/$dynamicAnchor"
-import Keyword$ref from "./components/keywords/$ref"
-import Keyword$dynamicRef from "./components/keywords/$dynamicRef"
-import Keyword$defs from "./components/keywords/$defs"
-import Keyword$comment from "./components/keywords/$comment"
+import KeywordSchema from "./components/keywords/$schema"
+import KeywordVocabulary from "./components/keywords/$vocabulary/$vocabulary"
+import KeywordId from "./components/keywords/$id"
+import KeywordAnchor from "./components/keywords/$anchor"
+import KeywordDynamicAnchor from "./components/keywords/$dynamicAnchor"
+import KeywordRef from "./components/keywords/$ref"
+import KeywordDynamicRef from "./components/keywords/$dynamicRef"
+import KeywordDefs from "./components/keywords/$defs"
+import KeywordComment from "./components/keywords/$comment"
 import KeywordAllOf from "./components/keywords/AllOf"
 import KeywordAnyOf from "./components/keywords/AnyOf"
 import KeywordOneOf from "./components/keywords/OneOf"
@@ -77,15 +77,15 @@ const JSONSchema202012Plugin = ({ getSystem, fn }) => {
   return {
     components: {
       JSONSchema202012: JSONSchema,
-      JSONSchema202012Keyword$schema: Keyword$schema,
-      JSONSchema202012Keyword$vocabulary: Keyword$vocabulary,
-      JSONSchema202012Keyword$id: Keyword$id,
-      JSONSchema202012Keyword$anchor: Keyword$anchor,
-      JSONSchema202012Keyword$dynamicAnchor: Keyword$dynamicAnchor,
-      JSONSchema202012Keyword$ref: Keyword$ref,
-      JSONSchema202012Keyword$dynamicRef: Keyword$dynamicRef,
-      JSONSchema202012Keyword$defs: Keyword$defs,
-      JSONSchema202012Keyword$comment: Keyword$comment,
+      JSONSchema202012Keyword$schema: KeywordSchema,
+      JSONSchema202012Keyword$vocabulary: KeywordVocabulary,
+      JSONSchema202012Keyword$id: KeywordId,
+      JSONSchema202012Keyword$anchor: KeywordAnchor,
+      JSONSchema202012Keyword$dynamicAnchor: KeywordDynamicAnchor,
+      JSONSchema202012Keyword$ref: KeywordRef,
+      JSONSchema202012Keyword$dynamicRef: KeywordDynamicRef,
+      JSONSchema202012Keyword$defs: KeywordDefs,
+      JSONSchema202012Keyword$comment: KeywordComment,
       JSONSchema202012KeywordAllOf: KeywordAllOf,
       JSONSchema202012KeywordAnyOf: KeywordAnyOf,
       JSONSchema202012KeywordOneOf: KeywordOneOf,

--- a/src/core/plugins/json-schema-5/components/model-example.jsx
+++ b/src/core/plugins/json-schema-5/components/model-example.jsx
@@ -32,7 +32,7 @@ const useTabs = ({ initialTab, isExecute, schema, example }) => {
     if (prevIsExecute && !isExecute && example) {
       setActiveTab(tabs.example)
     }
-  }, [prevIsExecute, isExecute, example])
+  }, [prevIsExecute, isExecute, example, tabs.example])
 
   return { activeTab, onTabChange: handleTabChange, tabs }
 }

--- a/src/core/plugins/oas3/components/servers.jsx
+++ b/src/core/plugins/oas3/components/servers.jsx
@@ -25,6 +25,7 @@ const Servers = ({
 
     // fire 'change' event to set default 'value' of select
     setSelectedServer(servers.first()?.get("url"))
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally mount-only: fires once to set the initial default server on first render
   }, [])
 
   useEffect(() => {
@@ -46,7 +47,7 @@ const Servers = ({
         val: val.get("default") || "",
       })
     })
-  }, [currentServer, servers])
+  }, [currentServer, servers, setSelectedServer, setServerVariableValue])
 
   const handleServerChange = useCallback(
     (e) => {

--- a/src/core/plugins/oas31/components/models/models.jsx
+++ b/src/core/plugins/oas31/components/models/models.jsx
@@ -5,6 +5,8 @@ import React, { useCallback, useEffect } from "react"
 import PropTypes from "prop-types"
 import classNames from "classnames"
 
+const SCHEMAS_PATH = Object.freeze(["components", "schemas"])
+
 const Models = ({
   specActions,
   specSelectors,
@@ -16,7 +18,7 @@ const Models = ({
 }) => {
   const schemas = specSelectors.selectSchemas()
   const hasSchemas = Object.keys(schemas).length > 0
-  const schemasPath = ["components", "schemas"]
+  const schemasPath = SCHEMAS_PATH
   const { docExpansion, defaultModelsExpandDepth } = getConfigs()
   const isOpenDefault = defaultModelsExpandDepth > 0 && docExpansion !== "none"
   const isOpen = layoutSelectors.isShown(schemasPath, isOpenDefault)
@@ -40,6 +42,7 @@ const Models = ({
     if (isOpenAndExpanded && !isResolved) {
       specActions.requestResolvedSubtree(schemasPath)
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally watches only isOpen/defaultModelsExpandDepth; plugin objects have unstable identity but stable behavior
   }, [isOpen, defaultModelsExpandDepth])
 
   /**
@@ -48,12 +51,15 @@ const Models = ({
 
   const handleModelsExpand = useCallback(() => {
     layoutActions.show(schemasPath, !isOpen)
-  }, [isOpen])
-  const handleModelsRef = useCallback((node) => {
-    if (node !== null) {
-      layoutActions.readyToScroll(schemasPath, node)
-    }
-  }, [])
+  }, [isOpen, layoutActions, schemasPath])
+  const handleModelsRef = useCallback(
+    (node) => {
+      if (node !== null) {
+        layoutActions.readyToScroll(schemasPath, node)
+      }
+    },
+    [layoutActions, schemasPath]
+  )
   const handleJSONSchema202012Ref = (schemaName) => (node) => {
     if (node !== null) {
       layoutActions.readyToScroll([...schemasPath, schemaName], node)


### PR DESCRIPTION
Adds `eslint-plugin-react-hooks@7.0.1` and enforces both `rules-of-hooks` and `exhaustive-deps` as errors across the entire codebase, eliminating pre-existing hook violations before activating the rules.

### ESLint configuration

- Added `react-hooks` plugin to `.eslintrc.js` with both rules at error level (`2`)
- Did **not** use `plugin:react-hooks/recommended` — v7 bundles additional rules (`refs`, `static-components`, `set-state-in-effect`) incompatible with the codebase's plugin-system patterns

### Phase 1 — `rules-of-hooks` fixes

Pre-existing violations corrected before enabling the rule:

| File | Issue | Fix |
|---|---|---|
| `hooks.js` (`useRenderedSchemas`) | `useContext` called inside an `if` branch — hook order not guaranteed | Unconditional call moved before the guard |
| All `$`-prefixed keyword components | Component function names not PascalCase — hooks inside not recognized by the rule | All nine functions renamed to PascalCase; all consuming usages updated |

The `useRenderedSchemas` fix is the most impactful: a conditional `useContext` can silently cause diverging hook call order between renders.

```js
// Before — conditional hook (violates rules-of-hooks)
export const useRenderedSchemas = (schema = undefined) => {
  if (typeof schema === "undefined") {
    return useContext(JSONSchemaCyclesContext) // ← hook behind if-guard
  }
  const renderedSchemas = useContext(JSONSchemaCyclesContext)
  return new Set([...renderedSchemas, schema])
}

// After — unconditional
export const useRenderedSchemas = (schema = undefined) => {
  const renderedSchemas = useContext(JSONSchemaCyclesContext)
  if (typeof schema === "undefined") return renderedSchemas
  return new Set([...renderedSchemas, schema])
}
```

All nine `$`-prefixed keyword component function names have been renamed to PascalCase for consistency and correct `rules-of-hooks` analysis:

| File | Old name | New name | Import alias |
|---|---|---|---|
| `$defs.jsx` | `$defs` | `Defs` | `KeywordDefs` |
| `$vocabulary.jsx` | `$vocabulary` | `Vocabulary` | `KeywordVocabulary` |
| `$ref.jsx` | `$ref` | `Ref` | `KeywordRef` |
| `$dynamicRef.jsx` | `$dynamicRef` | `DynamicRef` | `KeywordDynamicRef` |
| `$schema.jsx` | `$schema` | `Schema` | `KeywordSchema` |
| `$anchor.jsx` | `$anchor` | `Anchor` | `KeywordAnchor` |
| `$id.jsx` | `$id` | `Id` | `KeywordId` |
| `$dynamicAnchor.jsx` | `$dynamicAnchor` | `DynamicAnchor` | `KeywordDynamicAnchor` |
| `$comment.jsx` | `$comment` | `Comment` | `KeywordComment` |

All renames are fully propagated to consuming files (`hoc.jsx`, `index.js`, `JSONSchema.jsx`): import aliases, local variable names, and JSX element names. Component registration/lookup string keys (e.g. `"Keyword$ref"`, `"JSONSchema202012Keyword$ref"`) are preserved for backward compatibility.

### Phase 2+3 — `exhaustive-deps` fixes and suppressions

Each violation resolved either by correcting deps or suppressing with a documented comment:

- **`servers.jsx`** — second `useEffect` gets missing Redux action deps (`setSelectedServer`, `setServerVariableValue`); mount-only first effect suppressed
- **`models.jsx`** — `schemasPath` hoisted as `Object.freeze(["components", "schemas"])` module constant; missing `layoutActions`/`schemasPath` added to both `useCallback` deps; `useEffect` suppressed (intentionally watches only `isOpen`/`defaultModelsExpandDepth` to avoid over-firing)
- **`hooks.js`** (`useIsExpanded`) — `useEffect` and two `useCallback`s suppressed: `pathMutator` is recreated every render; including it would cause infinite update loops or defeat the purpose of `useCallback`
- **`model-example.jsx`** — `tabs.example` added to `useEffect` dep array (trivial: `tabs` is stable via `useMemo([], [])`)
- **`flavors/swagger-ui-react/index.jsx`** — three effects suppressed: mount-only SwaggerUI initializer, and two effects using `usePrevious` values where adding those deps would cause double-firing

### Motivation and Context

`eslint-plugin-react-hooks` catches two categories of bugs:
- **`rules-of-hooks`**: hooks called conditionally or outside components/hooks → unpredictable render behavior
- **`exhaustive-deps`**: stale closures in effects/callbacks → subtle data staleness bugs that are hard to reproduce

The `useRenderedSchemas` violation was a real latent bug. Renaming all `$`-prefixed component functions to PascalCase is required for the rule to correctly analyze hook calls inside those components, and ensures consistent naming across the entire keyword component set.

### How Has This Been Tested?

`npm run lint-errors` (used in CI) passes with zero errors. All 829 existing unit tests pass.

### Screenshots (if appropriate):

N/A

## Checklist

### My PR contains...
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [x] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.