### PR TITLE
fix(err): filter false-positive ExampleElement mutually exclusive resolver errors

### DIFF
--- a/src/core/plugins/err/error-transformers/hook.js
+++ b/src/core/plugins/err/error-transformers/hook.js
@@ -1,10 +1,12 @@
 import reduce from "lodash/reduce"
 import * as NotOfType from "./transformers/not-of-type"
 import * as ParameterOneOf from "./transformers/parameter-oneof"
+import * as ExampleMutuallyExclusive from "./transformers/example-mutually-exclusive"
 
 const errorTransformers = [
   NotOfType,
-  ParameterOneOf
+  ParameterOneOf,
+  ExampleMutuallyExclusive
 ]
 
 export default function transformErrors (errors) {

--- a/src/core/plugins/err/error-transformers/transformers/example-mutually-exclusive.js
+++ b/src/core/plugins/err/error-transformers/transformers/example-mutually-exclusive.js
@@ -1,0 +1,19 @@
+export function transform(errors) {
+  // Filter out false-positive "mutually exclusive" errors for ExampleElement
+  // that occur when path-level $ref is used with examples containing externalValue.
+  // This is a known issue in the upstream apidom-reference library where
+  // the resolver incorrectly reports value and externalValue as mutually exclusive
+  // after resolving a path-level $ref.
+  // See: https://github.com/swagger-api/swagger-ui/issues/10418
+  return errors.filter((err) => {
+    if (err.get("source") !== "resolver") {
+      return true
+    }
+    const message = err.get("message") || ""
+    return (
+      message.indexOf(
+        "ExampleElement value and externalValue fields are mutually exclusive"
+      ) === -1
+    )
+  })
+}

--- a/test/unit/core/plugins/err/transformers/example-mutually-exclusive.js
+++ b/test/unit/core/plugins/err/transformers/example-mutually-exclusive.js
@@ -1,0 +1,85 @@
+import { Map, List } from "immutable"
+import { transform } from "core/plugins/err/error-transformers/transformers/example-mutually-exclusive"
+
+describe("err plugin - transformers - example mutually exclusive", () => {
+
+  it("should filter out false-positive ExampleElement mutually exclusive resolver errors", () => {
+    let ori = List([
+      Map({
+        path: "post.responses.200.content.application/json.examples.testExample.externalValue",
+        message: "Could not resolve reference: ExampleElement value and externalValue fields are mutually exclusive.",
+        source: "resolver",
+        level: "error",
+        type: "thrown"
+      })
+    ])
+
+    let res = transform(ori)
+
+    expect(res.size).toEqual(0)
+  })
+
+  it("should not filter out non-resolver errors with the same message", () => {
+    let ori = List([
+      Map({
+        path: "some.path",
+        message: "ExampleElement value and externalValue fields are mutually exclusive.",
+        source: "parser",
+        level: "error",
+        type: "thrown"
+      })
+    ])
+
+    let res = transform(ori)
+
+    expect(res.size).toEqual(1)
+  })
+
+  it("should not filter out other resolver errors", () => {
+    let ori = List([
+      Map({
+        path: "some.path",
+        message: "Could not resolve reference: some other error",
+        source: "resolver",
+        level: "error",
+        type: "thrown"
+      })
+    ])
+
+    let res = transform(ori)
+
+    expect(res.size).toEqual(1)
+  })
+
+  it("should keep unrelated errors while filtering the mutually exclusive error", () => {
+    let ori = List([
+      Map({
+        path: "info.version",
+        message: "is not of a type(s) string",
+        source: "structural",
+        level: "error"
+      }),
+      Map({
+        path: "post.responses.200.content.application/json.examples.testExample.externalValue",
+        message: "Could not resolve reference: ExampleElement value and externalValue fields are mutually exclusive.",
+        source: "resolver",
+        level: "error",
+        type: "thrown"
+      }),
+      Map({
+        path: "paths./test",
+        message: "Could not resolve reference: Network error",
+        source: "resolver",
+        level: "error",
+        type: "thrown"
+      })
+    ])
+
+    let res = transform(ori)
+
+    expect(res.size).toEqual(2)
+    expect(res.get(0).get("message")).toEqual("is not of a type(s) string")
+    expect(res.get(1).get("message")).toEqual("Could not resolve reference: Network error")
+  })
+
+})


### PR DESCRIPTION
### Description

Added an `ExampleMutuallyExclusive` error transformer that filters out false-positive resolver errors where apidom-reference incorrectly reports "ExampleElement value and externalValue fields are mutually exclusive" when only `externalValue` is present. The transformer is registered in the error transformer hook alongside the existing `not-of-type` and `parameter-oneof` transformers.

### Motivation and Context

Fixes #10418

When a spec uses `$ref` at the path level and the referenced file contains examples with `externalValue`, the upstream apidom-reference library throws a false-positive mutual exclusivity error. This causes Swagger UI to display a spurious error message to users even though their spec is valid. This fix suppresses those false-positive errors at the error transformer layer, following the same pattern already used for other known false-positive errors.

### How Has This Been Tested?

- Added 4 regression unit tests in `test/unit/core/plugins/err/transformers/example-mutually-exclusive.js`:
  - Filters out false-positive ExampleElement mutually exclusive resolver errors
  - Preserves non-resolver errors with the same message text
  - Preserves other resolver errors (e.g., network errors)
  - Correctly handles mixed errors (filters only the false-positive, keeps the rest)
- ESLint passes on all changed files

### Screenshots (if appropriate):

N/A - no UI changes.

## Checklist

### My PR contains...
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.