### PR TITLE
fix(docker): upgrade alpine packages to address HIGH severity CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # We don't declare them here — take a look at our docs.
 # https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md
 
-FROM nginx:1.29.8-alpine
+FROM nginx:1.30.0-alpine
 
 LABEL maintainer="vladimir.gorej@gmail.com" \
       org.opencontainers.image.authors="vladimir.gorej@gmail.com" \
@@ -11,7 +11,19 @@ LABEL maintainer="vladimir.gorej@gmail.com" \
       org.opencontainers.image.description="SwaggerUI Docker image" \
       org.opencontainers.image.licenses="Apache-2.0"
 
-RUN apk add --update-cache --no-cache "nodejs" "libxml2>=2.13.9-r0" "libexpat>=2.7.2-r0" "libxslt>=1.1.42-r2" "xz-libs>=5.6.3-r1" "c-ares>=1.34.5-r0" "libpng>=1.6.56-r0" "zlib>=1.3.2-r0"
+RUN apk add --update-cache --no-cache \
+    "nodejs" \
+    "libxml2>=2.13.9-r0" \
+    "libexpat>=2.7.2-r0" \
+    "libxslt>=1.1.42-r2" \
+    "xz-libs>=5.6.3-r1" \
+    "c-ares>=1.34.5-r0" \
+    "libpng>=1.6.56-r0" \
+    "zlib>=1.3.2-r0" \
+    "libcrypto3>=3.5.6-r0" \
+    "libssl3>=3.5.6-r0" \
+    "musl>=1.2.5-r23" \
+    "musl-utils>=1.2.5-r23"
 
 LABEL maintainer="char0n"
 


### PR DESCRIPTION
## Summary

- Pin `libcrypto3>=3.5.6-r0` and `libssl3>=3.5.6-r0` to fix **CVE-2026-28390** (OpenSSL NULL pointer dereference DoS, HIGH)
- Pin `musl>=1.2.5-r23` and `musl-utils>=1.2.5-r23` to fix **CVE-2026-40200** (musl libc arbitrary code execution/DoS, HIGH)
- Reformatted the `apk add` command into multi-line for readability (consistent with the existing version-constraint pattern)

## Motivation and Context

Trivy vulnerability scanner in CI flagged 4 HIGH severity vulnerabilities in the `docker.swagger.io/swaggerapi/swagger-ui:unstable` image:
https://github.com/swagger-api/swagger-ui/actions/runs/24437770187/job/71395735898

All four vulnerabilities have available fixes in Alpine 3.23 and are addressed by explicitly requiring the minimum fixed package versions during the Docker build.

## How Has This Been Tested?

- Verified fixed versions are available in Alpine 3.23 package repositories
- Trivy scan on the rebuilt image should show 0 HIGH/CRITICAL vulnerabilities for these packages

## Screenshots

N/A — Dockerfile-only change

## Checklist

- [x] Bug fix (no code change — Docker base image package upgrade)
- [x] No breaking changes
- [x] No documentation update required

🤖 Generated with [Claude Code](https://claude.com/claude-code)