### PR TITLE
fix(topbar): handle empty urls array without crashing

### DIFF
--- a/src/standalone/plugins/top-bar/components/TopBar.jsx
+++ b/src/standalone/plugins/top-bar/components/TopBar.jsx
@@ -126,7 +126,7 @@ class TopBar extends React.Component {
     let control = []
     let formOnSubmit = null
 
-    if(urls) {
+    if(urls && urls.length) {
       let rows = []
       urls.forEach((link, i) => {
         rows.push(<option key={i} value={link.url}>{link.name}</option>)


### PR DESCRIPTION
### Description

When the `urls` configuration option is set to an empty array (`[]`), the TopBar component crashes because in the `render()` method it only checks `if(urls)` before trying to access `urls[this.state.selectedIndex].url`. Since an empty array is truthy in JavaScript, this check passes, but then accessing index `0` of an empty array returns `undefined`, and accessing `.url` on `undefined` throws a TypeError.

The fix adds a `.length` check: `if(urls && urls.length)`, which is consistent with the pattern already used in `componentDidMount()` and `setSelectedUrl()` within the same file.

### Motivation and Context

Fixes #5663

Users may configure `urls: []` or pass `?urls=[]` as a query parameter. Instead of crashing, the UI should gracefully fall back to showing the URL text input.

### How Has This Been Tested?

- Verified the fix matches the existing pattern used elsewhere in the same file
- When `urls` is `[]`, the component now falls through to the `else` branch and renders the URL text input instead of crashing
- When `urls` has entries, behavior is unchanged

### Screenshots (if appropriate):

N/A

## Checklist

### My PR contains...
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.