### PR TITLE
fix(oas3): show request body description for file upload content types

### DIFF
--- a/src/core/plugins/oas3/components/request-body.jsx
+++ b/src/core/plugins/oas3/components/request-body.jsx
@@ -114,12 +114,22 @@ const RequestBody = ({
     const Input = getComponent("Input")
 
     if(!isExecute) {
-      return <i>
-        Example values are not available for <code>{contentType}</code> media types.
-      </i>
+      return <div>
+        { requestBodyDescription &&
+          <Markdown source={requestBodyDescription} />
+        }
+        <i>
+          Example values are not available for <code>{contentType}</code> media types.
+        </i>
+      </div>
     }
 
-    return <Input type={"file"} onChange={handleFile} />
+    return <div>
+      { requestBodyDescription &&
+        <Markdown source={requestBodyDescription} />
+      }
+      <Input type={"file"} onChange={handleFile} />
+    </div>
   }
 
 

--- a/test/e2e-cypress/e2e/features/plugins/oas3/request-body-file-upload-description.cy.js
+++ b/test/e2e-cypress/e2e/features/plugins/oas3/request-body-file-upload-description.cy.js
@@ -1,0 +1,155 @@
+/**
+ * @prettier
+ */
+
+describe("OpenAPI 3.0 Request Body description on file upload content types", () => {
+  beforeEach(() => {
+    cy.visit(
+      "/?url=/documents/features/oas3-request-body-file-upload-description.yaml"
+    )
+  })
+
+  describe("application/octet-stream (with schema)", () => {
+    beforeEach(() => {
+      cy.get("#operations-default-uploadApplicationOctetStream").click()
+    })
+
+    it("renders the Markdown description before Try it out is enabled", () => {
+      cy.get(
+        ".opblock-section-request-body .opblock-description-wrapper .markdown"
+      )
+        .should("exist")
+        .and("contain.text", "Upload a binary blob")
+      cy.get(
+        ".opblock-section-request-body .opblock-description-wrapper .markdown strong"
+      ).should("have.text", "Upload a binary blob")
+      cy.get(
+        ".opblock-section-request-body .opblock-description-wrapper i"
+      ).should(
+        "have.text",
+        "Example values are not available for application/octet-stream media types."
+      )
+    })
+
+    it("renders the Markdown description after Try it out is enabled", () => {
+      cy.get(".try-out__btn").click()
+      cy.get(
+        ".opblock-section-request-body .opblock-description-wrapper .markdown"
+      )
+        .should("exist")
+        .and("contain.text", "Upload a binary blob")
+      cy.get(
+        ".opblock-section-request-body .opblock-description-wrapper input"
+      ).should("have.prop", "type", "file")
+    })
+  })
+
+  describe("image/png", () => {
+    beforeEach(() => {
+      cy.get("#operations-default-uploadImagePng").click()
+    })
+
+    it("renders the Markdown description before Try it out is enabled", () => {
+      cy.get(
+        ".opblock-section-request-body .opblock-description-wrapper .markdown"
+      )
+        .should("exist")
+        .and("contain.text", "Upload a PNG image")
+      cy.get(
+        ".opblock-section-request-body .opblock-description-wrapper .markdown em"
+      ).should("have.text", "Upload a PNG image")
+    })
+
+    it("renders the Markdown description after Try it out is enabled", () => {
+      cy.get(".try-out__btn").click()
+      cy.get(
+        ".opblock-section-request-body .opblock-description-wrapper .markdown"
+      )
+        .should("exist")
+        .and("contain.text", "Upload a PNG image")
+      cy.get(
+        ".opblock-section-request-body .opblock-description-wrapper input"
+      ).should("have.prop", "type", "file")
+    })
+  })
+
+  describe("application/octet-stream with empty Media Type Object", () => {
+    beforeEach(() => {
+      cy.get("#operations-default-uploadApplicationOctetStreamEmpty").click()
+    })
+
+    it("renders the Markdown description before Try it out is enabled", () => {
+      cy.get(
+        ".opblock-section-request-body .opblock-description-wrapper .markdown"
+      )
+        .should("exist")
+        .and("contain.text", "Empty media type object")
+    })
+
+    it("renders the Markdown description after Try it out is enabled", () => {
+      cy.get(".try-out__btn").click()
+      cy.get(
+        ".opblock-section-request-body .opblock-description-wrapper .markdown"
+      )
+        .should("exist")
+        .and("contain.text", "Empty media type object")
+      cy.get(
+        ".opblock-section-request-body .opblock-description-wrapper input"
+      ).should("have.prop", "type", "file")
+    })
+  })
+
+  describe("schema type string and format binary", () => {
+    beforeEach(() => {
+      cy.get("#operations-default-uploadSchemaFormatBinary").click()
+    })
+
+    it("renders the Markdown description before Try it out is enabled", () => {
+      cy.get(
+        ".opblock-section-request-body .opblock-description-wrapper .markdown"
+      )
+        .should("exist")
+        .and("contain.text", "application/x-custom")
+    })
+
+    it("renders the Markdown description after Try it out is enabled", () => {
+      cy.get(".try-out__btn").click()
+      cy.get(
+        ".opblock-section-request-body .opblock-description-wrapper .markdown"
+      )
+        .should("exist")
+        .and("contain.text", "application/x-custom")
+      cy.get(
+        ".opblock-section-request-body .opblock-description-wrapper input"
+      ).should("have.prop", "type", "file")
+    })
+  })
+
+  describe("file upload without a requestBody description", () => {
+    beforeEach(() => {
+      cy.get("#operations-default-uploadWithoutDescription").click()
+    })
+
+    it("does not render a Markdown block when description is absent (before Try it out)", () => {
+      cy.get(
+        ".opblock-section-request-body .opblock-description-wrapper .markdown"
+      ).should("not.exist")
+      cy.get(
+        ".opblock-section-request-body .opblock-description-wrapper i"
+      ).should(
+        "have.text",
+        "Example values are not available for application/octet-stream media types."
+      )
+    })
+
+    it("does not render a Markdown block when description is absent (after Try it out)", () => {
+      cy.get(".try-out__btn").click()
+      cy.get(
+        ".opblock-section-request-body .opblock-description-wrapper .markdown"
+      ).should("not.exist")
+      cy.get(
+        ".opblock-section-request-body .opblock-description-wrapper input"
+      ).should("have.prop", "type", "file")
+    })
+  })
+})

--- a/test/e2e-cypress/e2e/features/plugins/oas3/request-body-file-upload-description.cy.js
+++ b/test/e2e-cypress/e2e/features/plugins/oas3/request-body-file-upload-description.cy.js
@@ -16,12 +16,12 @@ describe("OpenAPI 3.0 Request Body description on file upload content types", ()
 
     it("renders the Markdown description before Try it out is enabled", () => {
       cy.get(
-        ".opblock-section-request-body .opblock-description-wrapper .markdown"
+        ".opblock-section-request-body .opblock-description-wrapper .renderedMarkdown"
       )
         .should("exist")
         .and("contain.text", "Upload a binary blob")
       cy.get(
-        ".opblock-section-request-body .opblock-description-wrapper .markdown strong"
+        ".opblock-section-request-body .opblock-description-wrapper .renderedMarkdown strong"
       ).should("have.text", "Upload a binary blob")
       cy.get(
         ".opblock-section-request-body .opblock-description-wrapper i"
@@ -34,7 +34,7 @@ describe("OpenAPI 3.0 Request Body description on file upload content types", ()
     it("renders the Markdown description after Try it out is enabled", () => {
       cy.get(".try-out__btn").click()
       cy.get(
-        ".opblock-section-request-body .opblock-description-wrapper .markdown"
+        ".opblock-section-request-body .opblock-description-wrapper .renderedMarkdown"
       )
         .should("exist")
         .and("contain.text", "Upload a binary blob")
@@ -51,19 +51,19 @@ describe("OpenAPI 3.0 Request Body description on file upload content types", ()
 
     it("renders the Markdown description before Try it out is enabled", () => {
       cy.get(
-        ".opblock-section-request-body .opblock-description-wrapper .markdown"
+        ".opblock-section-request-body .opblock-description-wrapper .renderedMarkdown"
       )
         .should("exist")
         .and("contain.text", "Upload a PNG image")
       cy.get(
-        ".opblock-section-request-body .opblock-description-wrapper .markdown em"
+        ".opblock-section-request-body .opblock-description-wrapper .renderedMarkdown em"
       ).should("have.text", "Upload a PNG image")
     })
 
     it("renders the Markdown description after Try it out is enabled", () => {
       cy.get(".try-out__btn").click()
       cy.get(
-        ".opblock-section-request-body .opblock-description-wrapper .markdown"
+        ".opblock-section-request-body .opblock-description-wrapper .renderedMarkdown"
       )
         .should("exist")
         .and("contain.text", "Upload a PNG image")
@@ -80,7 +80,7 @@ describe("OpenAPI 3.0 Request Body description on file upload content types", ()
 
     it("renders the Markdown description before Try it out is enabled", () => {
       cy.get(
-        ".opblock-section-request-body .opblock-description-wrapper .markdown"
+        ".opblock-section-request-body .opblock-description-wrapper .renderedMarkdown"
       )
         .should("exist")
         .and("contain.text", "Empty media type object")
@@ -89,7 +89,7 @@ describe("OpenAPI 3.0 Request Body description on file upload content types", ()
     it("renders the Markdown description after Try it out is enabled", () => {
       cy.get(".try-out__btn").click()
       cy.get(
-        ".opblock-section-request-body .opblock-description-wrapper .markdown"
+        ".opblock-section-request-body .opblock-description-wrapper .renderedMarkdown"
       )
         .should("exist")
         .and("contain.text", "Empty media type object")
@@ -106,7 +106,7 @@ describe("OpenAPI 3.0 Request Body description on file upload content types", ()
 
     it("renders the Markdown description before Try it out is enabled", () => {
       cy.get(
-        ".opblock-section-request-body .opblock-description-wrapper .markdown"
+        ".opblock-section-request-body .opblock-description-wrapper .renderedMarkdown"
       )
         .should("exist")
         .and("contain.text", "application/x-custom")
@@ -115,7 +115,7 @@ describe("OpenAPI 3.0 Request Body description on file upload content types", ()
     it("renders the Markdown description after Try it out is enabled", () => {
       cy.get(".try-out__btn").click()
       cy.get(
-        ".opblock-section-request-body .opblock-description-wrapper .markdown"
+        ".opblock-section-request-body .opblock-description-wrapper .renderedMarkdown"
       )
         .should("exist")
         .and("contain.text", "application/x-custom")
@@ -132,7 +132,7 @@ describe("OpenAPI 3.0 Request Body description on file upload content types", ()
 
     it("does not render a Markdown block when description is absent (before Try it out)", () => {
       cy.get(
-        ".opblock-section-request-body .opblock-description-wrapper .markdown"
+        ".opblock-section-request-body .opblock-description-wrapper .renderedMarkdown"
       ).should("not.exist")
       cy.get(
         ".opblock-section-request-body .opblock-description-wrapper i"
@@ -145,7 +145,7 @@ describe("OpenAPI 3.0 Request Body description on file upload content types", ()
     it("does not render a Markdown block when description is absent (after Try it out)", () => {
       cy.get(".try-out__btn").click()
       cy.get(
-        ".opblock-section-request-body .opblock-description-wrapper .markdown"
+        ".opblock-section-request-body .opblock-description-wrapper .renderedMarkdown"
       ).should("not.exist")
       cy.get(
         ".opblock-section-request-body .opblock-description-wrapper input"

--- a/test/e2e-cypress/static/documents/features/oas3-request-body-file-upload-description.yaml
+++ b/test/e2e-cypress/static/documents/features/oas3-request-body-file-upload-description.yaml
@@ -1,0 +1,54 @@
+openapi: 3.0.4
+info:
+  title: "Request body description on file upload content types"
+  description: |-
+    This document exercises rendering of `requestBody.description` (Markdown)
+    on file-upload-intended content types. The description should render both
+    before and after "Try it out" is enabled.
+  version: "1.0.0"
+paths:
+  /upload-application-octet-stream:
+    post:
+      operationId: uploadApplicationOctetStream
+      requestBody:
+        description: |-
+          **Upload a binary blob** as `application/octet-stream`.
+          See [the docs](https://example.com) for details.
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+  /upload-image-png:
+    post:
+      operationId: uploadImagePng
+      requestBody:
+        description: "*Upload a PNG image* of the user avatar."
+        content:
+          image/png:
+            schema:
+              type: string
+  /upload-application-octet-stream-empty:
+    post:
+      operationId: uploadApplicationOctetStreamEmpty
+      requestBody:
+        description: "Empty media type object with **octet-stream** description."
+        content:
+          application/octet-stream: {}
+  /upload-schema-format-binary:
+    post:
+      operationId: uploadSchemaFormatBinary
+      requestBody:
+        description: "`application/x-custom` with **binary** format."
+        content:
+          application/x-custom:
+            schema:
+              type: string
+              format: binary
+  /upload-without-description:
+    post:
+      operationId: uploadWithoutDescription
+      requestBody:
+        content:
+          application/octet-stream:
+            schema:
+              type: string

--- a/test/unit/core/plugins/oas3/components/request-body.jsx
+++ b/test/unit/core/plugins/oas3/components/request-body.jsx
@@ -1,0 +1,145 @@
+/**
+ * @prettier
+ */
+import React from "react"
+import PropTypes from "prop-types"
+import { shallow } from "enzyme"
+import { fromJS, List } from "immutable"
+
+import RequestBody from "core/plugins/oas3/components/request-body"
+
+describe("<RequestBody/>", function () {
+  const Markdown = ({ source }) => <div className="markdown-stub">{source}</div>
+  Markdown.propTypes = { source: PropTypes.string }
+  const Input = () => null
+  const RequestBodyEditor = () => null
+  const HighlightCode = () => null
+  const ModelExample = () => null
+  const ExamplesSelectValueRetainer = () => null
+  const Example = () => null
+  const ParameterIncludeEmpty = () => null
+
+  const components = {
+    Markdown,
+    Input,
+    RequestBodyEditor,
+    HighlightCode,
+    modelExample: ModelExample,
+    ExamplesSelectValueRetainer,
+    Example,
+    ParameterIncludeEmpty,
+  }
+
+  const getComponentStub = (name) => components[name] || null
+
+  const baseProps = {
+    userHasEditedBody: false,
+    requestBodyValue: fromJS({}),
+    requestBodyInclusionSetting: fromJS({}),
+    requestBodyErrors: List(),
+    getComponent: getComponentStub,
+    getConfigs: () => ({}),
+    specSelectors: {},
+    fn: {
+      isFileUploadIntended: () => true,
+      hasSchemaType: () => false,
+      getSampleSchema: () => "",
+    },
+    specPath: List(),
+    onChange: () => {},
+    onChangeIncludeEmpty: () => {},
+    updateActiveExamplesKey: () => {},
+    setRetainRequestBodyValueFlag: () => {},
+    oas3Actions: {},
+  }
+
+  it("renders the request body description for file upload content types when isExecute is true", function () {
+    const props = {
+      ...baseProps,
+      isExecute: true,
+      contentType: "application/octet-stream",
+      requestBody: fromJS({
+        description: "A zip file containing files that will be unzipped",
+        content: {
+          "application/octet-stream": {
+            schema: { type: "string", format: "binary" },
+          },
+        },
+      }),
+    }
+
+    const wrapper = shallow(<RequestBody {...props} />)
+
+    const markdown = wrapper.find(Markdown)
+    expect(markdown.length).toEqual(1)
+    expect(markdown.prop("source")).toEqual(
+      "A zip file containing files that will be unzipped"
+    )
+    expect(wrapper.find(Input).length).toEqual(1)
+  })
+
+  it("renders the request body description for file upload content types when isExecute is false", function () {
+    const props = {
+      ...baseProps,
+      isExecute: false,
+      contentType: "application/octet-stream",
+      requestBody: fromJS({
+        description: "A zip file containing files that will be unzipped",
+        content: {
+          "application/octet-stream": {
+            schema: { type: "string", format: "binary" },
+          },
+        },
+      }),
+    }
+
+    const wrapper = shallow(<RequestBody {...props} />)
+
+    const markdown = wrapper.find(Markdown)
+    expect(markdown.length).toEqual(1)
+    expect(markdown.prop("source")).toEqual(
+      "A zip file containing files that will be unzipped"
+    )
+    expect(wrapper.text()).toContain("Example values are not available")
+  })
+
+  it("does not render a Markdown description when the request body has none (isExecute true)", function () {
+    const props = {
+      ...baseProps,
+      isExecute: true,
+      contentType: "application/octet-stream",
+      requestBody: fromJS({
+        content: {
+          "application/octet-stream": {
+            schema: { type: "string", format: "binary" },
+          },
+        },
+      }),
+    }
+
+    const wrapper = shallow(<RequestBody {...props} />)
+
+    expect(wrapper.find(Markdown).length).toEqual(0)
+    expect(wrapper.find(Input).length).toEqual(1)
+  })
+
+  it("does not render a Markdown description when the request body has none (isExecute false)", function () {
+    const props = {
+      ...baseProps,
+      isExecute: false,
+      contentType: "application/octet-stream",
+      requestBody: fromJS({
+        content: {
+          "application/octet-stream": {
+            schema: { type: "string", format: "binary" },
+          },
+        },
+      }),
+    }
+
+    const wrapper = shallow(<RequestBody {...props} />)
+
+    expect(wrapper.find(Markdown).length).toEqual(0)
+    expect(wrapper.text()).toContain("Example values are not available")
+  })
+})


### PR DESCRIPTION
### Description

When a request body uses a content type like `application/octet-stream` that triggers file upload mode, the `description` from the `requestBody` object was not displayed. The early return in the file upload branch skipped the description rendering that exists for other content types.

This change renders the `requestBody.description` (via Markdown component) above the file input or the "Example values are not available" message, consistent with how descriptions are shown for `application/json`, `multipart/form-data`, and other content types.

### Motivation and Context

Fixes #5637

Users who document their file upload endpoints with descriptions (e.g., "A zip file containing files that will be unzipped") expect those descriptions to be visible in Swagger UI, regardless of the content type.

### How Has This Been Tested?

- Verified that the `Markdown` component and `requestBodyDescription` variable are already available in scope at the point of the change
- The pattern `{ requestBodyDescription && <Markdown source={requestBodyDescription} /> }` is reused from lines 146-148 and 276-278 in the same file
- Both the execute and non-execute branches now render the description

### Screenshots (if appropriate):

N/A - description text is now visible above file upload inputs

## Checklist

### My PR contains...
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.