### PR TITLE
fix(config): add missing queryConfigEnabled to type-cast mappings

### DIFF
--- a/src/core/config/type-cast/mappings.js
+++ b/src/core/config/type-cast/mappings.js
@@ -68,6 +68,10 @@ const mappings = {
     typeCaster: booleanTypeCaster,
     defaultValue: defaultOptions.persistAuthorization,
   },
+  queryConfigEnabled: {
+    typeCaster: booleanTypeCaster,
+    defaultValue: defaultOptions.queryConfigEnabled,
+  },
   plugins: {
     typeCaster: arrayTypeCaster,
     defaultValue: defaultOptions.plugins,


### PR DESCRIPTION
### Description

The `queryConfigEnabled` configuration option is defined in `src/core/config/defaults.js` (line 66) with a default value of `false`, but it was missing from the type-cast mappings in `src/core/config/type-cast/mappings.js`. 

This means when `queryConfigEnabled` was provided via a string-based configuration source (e.g., query string), it would not be properly type-cast from a string to a boolean.

### Motivation and Context

Fixes #10744

Every other boolean config option in `defaults.js` has a corresponding entry in `mappings.js`. This was the only one missing.

### How Has This Been Tested?

- Compared all keys in `defaults.js` against `mappings.js` to verify `queryConfigEnabled` was the only missing entry
- The mapping follows the exact same pattern as other boolean options like `persistAuthorization`, `tryItOutEnabled`, etc.

### Screenshots (if appropriate):

N/A

## Checklist

### My PR contains...
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.