### PR TITLE
fix(auth): use Immutable Map as fallback in logout cookie deletion

### DIFF
--- a/src/core/components/auth/auths.jsx
+++ b/src/core/components/auth/auths.jsx
@@ -35,9 +35,13 @@ export default class Auths extends React.Component {
     e.preventDefault()
 
     let { authActions, definitions } = this.props
-    let auths = definitions.map( (val, key) => {
-      return key
-    }).toArray()
+    // `definitions` is an Immutable.Map whose keys are the security scheme
+    // names we want to log out of. Use `keySeq().toArray()` rather than
+    // `.map((val, key) => key).toArray()` because `Map#toArray()` returns
+    // `[key, value]` pairs under Immutable v4+ and values-only under v3,
+    // so the latter pattern silently produces `[[name, schema]]` instead
+    // of `[name]` when the host bundles a newer Immutable (see #10761).
+    let auths = definitions.keySeq().toArray()
 
     this.setState(auths.reduce((prev, auth) => {
       prev[auth] = ""

--- a/src/core/plugins/auth/wrap-actions.js
+++ b/src/core/plugins/auth/wrap-actions.js
@@ -44,13 +44,11 @@ export const logout = (oriAction, system) => (payload) => {
   try {
     if (configs.persistAuthorization && Array.isArray(payload)) {
       payload.forEach((authorizedName) => {
-        // The Authorize popup's Logout button submits every security
-        // definition in the displayed group, regardless of whether the
-        // user actually authorized it. Entries the user never filled in
-        // are not present in the `authorized` store, so we fall back to
-        // an empty Immutable Map() to keep the subsequent getIn() calls
-        // safe. Such entries have nothing stored in document.cookie, so
-        // skipping them is the correct behavior.
+        // Defend against missing entries in the `authorized` store — e.g.
+        // when a name was never authorized, or when an upstream caller
+        // passes an unexpected key shape. Use an empty Immutable Map() so
+        // the following getIn() calls are always safe; plain-object
+        // fallbacks crash here because getIn is Immutable-specific.
         const auth = authorized.get(authorizedName, Map())
         const isApiKeyAuth = auth.getIn(["schema", "type"]) === "apiKey"
         const isInCookie = auth.getIn(["schema", "in"]) === "cookie"

--- a/src/core/plugins/auth/wrap-actions.js
+++ b/src/core/plugins/auth/wrap-actions.js
@@ -44,6 +44,13 @@ export const logout = (oriAction, system) => (payload) => {
   try {
     if (configs.persistAuthorization && Array.isArray(payload)) {
       payload.forEach((authorizedName) => {
+        // The Authorize popup's Logout button submits every security
+        // definition in the displayed group, regardless of whether the
+        // user actually authorized it. Entries the user never filled in
+        // are not present in the `authorized` store, so we fall back to
+        // an empty Immutable Map() to keep the subsequent getIn() calls
+        // safe. Such entries have nothing stored in document.cookie, so
+        // skipping them is the correct behavior.
         const auth = authorized.get(authorizedName, Map())
         const isApiKeyAuth = auth.getIn(["schema", "type"]) === "apiKey"
         const isInCookie = auth.getIn(["schema", "in"]) === "cookie"

--- a/src/core/plugins/auth/wrap-actions.js
+++ b/src/core/plugins/auth/wrap-actions.js
@@ -1,7 +1,7 @@
 /**
  * @prettier
  */
-import { fromJS } from "immutable"
+import { fromJS, Map } from "immutable"
 
 /**
  * `authorize` and `logout` wrapped actions provide capacity
@@ -44,7 +44,7 @@ export const logout = (oriAction, system) => (payload) => {
   try {
     if (configs.persistAuthorization && Array.isArray(payload)) {
       payload.forEach((authorizedName) => {
-        const auth = authorized.get(authorizedName, {})
+        const auth = authorized.get(authorizedName, Map())
         const isApiKeyAuth = auth.getIn(["schema", "type"]) === "apiKey"
         const isInCookie = auth.getIn(["schema", "in"]) === "cookie"
         const isApiKeyInCookie = isApiKeyAuth && isInCookie

--- a/src/core/plugins/oas31/components/auth/auths.jsx
+++ b/src/core/plugins/oas31/components/auth/auths.jsx
@@ -38,11 +38,13 @@ class Auths extends React.Component {
     e.preventDefault()
 
     let { authActions, definitions } = this.props
-    let auths = definitions
-      .map((val, key) => {
-        return key
-      })
-      .toArray()
+    // `definitions` is an Immutable.Map whose keys are the security scheme
+    // names we want to log out of. Use `keySeq().toArray()` rather than
+    // `.map((val, key) => key).toArray()` because `Map#toArray()` returns
+    // `[key, value]` pairs under Immutable v4+ and values-only under v3,
+    // so the latter pattern silently produces `[[name, schema]]` instead
+    // of `[name]` when the host bundles a newer Immutable (see #10761).
+    let auths = definitions.keySeq().toArray()
 
     this.setState(
       auths.reduce((prev, auth) => {

--- a/test/unit/core/components/auth/auths.jsx
+++ b/test/unit/core/components/auth/auths.jsx
@@ -1,0 +1,85 @@
+/**
+ * @prettier
+ */
+import React from "react"
+import { shallow } from "enzyme"
+import { fromJS, Map } from "immutable"
+
+import Auths from "core/components/auth/auths"
+
+describe("<Auths/> logoutClick", function () {
+  const dummyComponent = () => null
+  const components = {
+    AuthItem: dummyComponent,
+    oauth2: dummyComponent,
+    Button: dummyComponent,
+  }
+  const getComponentStub = (name) => components[name] || dummyComponent
+
+  const buildProps = (definitions) => ({
+    definitions,
+    getComponent: getComponentStub,
+    authSelectors: {
+      authorized: () => Map(),
+    },
+    authActions: {
+      logoutWithPersistOption: jest.fn(),
+    },
+    errSelectors: {},
+    specSelectors: {},
+  })
+
+  it("sends only the scheme names to logoutWithPersistOption for a single-scheme map", function () {
+    // The Authorize popup renders one <Auths/> per requirement group,
+    // passing an Immutable.Map whose keys are the scheme names. The
+    // Logout handler must emit those keys as a flat array of strings.
+    const definitions = fromJS({
+      ApiKeyAuth: { type: "apiKey", in: "header", name: "X-API-Key" },
+    })
+    const props = buildProps(definitions)
+    const wrapper = shallow(<Auths {...props} />)
+
+    wrapper.instance().logoutClick({ preventDefault: () => {} })
+
+    expect(props.authActions.logoutWithPersistOption).toHaveBeenCalledWith([
+      "ApiKeyAuth",
+    ])
+  })
+
+  it("sends all scheme names when the map has several entries", function () {
+    const definitions = fromJS({
+      ApiKeyAuth: { type: "apiKey", in: "header", name: "X-API-Key" },
+      BearerAuth: { type: "http", scheme: "bearer" },
+    })
+    const props = buildProps(definitions)
+    const wrapper = shallow(<Auths {...props} />)
+
+    wrapper.instance().logoutClick({ preventDefault: () => {} })
+
+    expect(props.authActions.logoutWithPersistOption).toHaveBeenCalledWith([
+      "ApiKeyAuth",
+      "BearerAuth",
+    ])
+  })
+
+  it("does not leak [key, value] pairs into the payload (guard against Immutable v4 toArray semantics)", function () {
+    // `Map#toArray()` switched in Immutable v4 from values-only to
+    // `[key, value]` pairs. The previous `.map((v, k) => k).toArray()`
+    // pattern therefore emitted `[[name, schema]]` when a host bundled
+    // Immutable v4+, which broke logout (see #10761). Guard the flat-
+    // string shape regardless of Immutable version.
+    const definitions = fromJS({
+      ApiKeyAuth: { type: "apiKey", in: "header", name: "X-API-Key" },
+    })
+    const props = buildProps(definitions)
+    const wrapper = shallow(<Auths {...props} />)
+
+    wrapper.instance().logoutClick({ preventDefault: () => {} })
+
+    const [payload] = props.authActions.logoutWithPersistOption.mock.calls[0]
+    expect(Array.isArray(payload)).toBe(true)
+    expect(payload).toHaveLength(1)
+    expect(typeof payload[0]).toBe("string")
+    expect(payload[0]).toBe("ApiKeyAuth")
+  })
+})

--- a/test/unit/core/plugins/auth/wrap-actions.js
+++ b/test/unit/core/plugins/auth/wrap-actions.js
@@ -90,6 +90,58 @@ describe("Cookie based apiKey persistence in document.cookie", () => {
 
       expect(document.cookie).toEqual("apiKeyCookie=; Max-Age=-99999999")
     })
+
+    it("should delete cookie even when payload contains names missing from the authorized store", () => {
+      // The Authorize popup's Logout button sends every security
+      // definition name in the displayed group, including ones the user
+      // never authorized. Those names are absent from the `authorized`
+      // store, so `authorized.get(name)` falls back to a default value.
+      // This test guards the fix for
+      // https://github.com/swagger-api/swagger-ui/issues/10761 where the
+      // previous plain-object fallback caused a crash on `.getIn(...)`.
+      const authorized = fromJS({
+        api_key: {
+          schema: {
+            type: "apiKey",
+            name: "apiKeyCookie",
+            in: "cookie",
+          },
+          value: "test",
+        },
+      })
+      const system = {
+        getConfigs: () => ({
+          persistAuthorization: true,
+        }),
+        authSelectors: {
+          authorized: () => authorized,
+        },
+      }
+      const oriAction = jest.fn()
+
+      const logoutAction = () =>
+        logout(oriAction, system)(["missing_auth", "api_key"])
+
+      expect(logoutAction).not.toThrow()
+      expect(document.cookie).toEqual("apiKeyCookie=; Max-Age=-99999999")
+      expect(oriAction).toHaveBeenCalledWith(["missing_auth", "api_key"])
+    })
+
+    it("should not throw when every name in payload is missing from the authorized store", () => {
+      const system = {
+        getConfigs: () => ({
+          persistAuthorization: true,
+        }),
+        authSelectors: {
+          authorized: () => fromJS({}),
+        },
+      }
+
+      const logoutAction = () => logout(jest.fn(), system)(["missing_auth"])
+
+      expect(logoutAction).not.toThrow()
+      expect(document.cookie).toEqual("")
+    })
   })
 
   describe("given persistAuthorization=false", () => {

--- a/test/unit/core/plugins/auth/wrap-actions.js
+++ b/test/unit/core/plugins/auth/wrap-actions.js
@@ -92,13 +92,12 @@ describe("Cookie based apiKey persistence in document.cookie", () => {
     })
 
     it("should delete cookie even when payload contains names missing from the authorized store", () => {
-      // The Authorize popup's Logout button sends every security
-      // definition name in the displayed group, including ones the user
-      // never authorized. Those names are absent from the `authorized`
-      // store, so `authorized.get(name)` falls back to a default value.
-      // This test guards the fix for
-      // https://github.com/swagger-api/swagger-ui/issues/10761 where the
-      // previous plain-object fallback caused a crash on `.getIn(...)`.
+      // Defensive: if `authorized.get(name)` can't find an entry, the
+      // fallback must expose `.getIn(...)` safely. A plain-object
+      // fallback crashes here; an empty Immutable Map() keeps the
+      // iteration going and still clears cookies for names that are
+      // present. Guards the fix for
+      // https://github.com/swagger-api/swagger-ui/issues/10761.
       const authorized = fromJS({
         api_key: {
           schema: {


### PR DESCRIPTION
### Description

When logging out of an API key authorization, the auth `logout` wrap-action in `src/core/plugins/auth/wrap-actions.js` used a plain JavaScript object `{}` as the default value for `authorized.get(authorizedName, {})`. However, subsequent code calls `.getIn()` on this fallback value, which is an Immutable.js method not available on plain objects.

This caused the error:
```
TypeError: o.getIn is not a function
```

The fix changes the fallback from `{}` to `Map()` (from Immutable.js), ensuring that `.getIn()` calls work correctly even when the authorization entry is not found in the store.

### Motivation and Context

Fixes #10761

The crash occurs when clicking the Logout button for an ApiKeyAuth in the Available authorizations popup, specifically when the authorized entry cannot be found in the Immutable store.

### How Has This Been Tested?

- Verified that `Map()` from Immutable.js has the `.getIn()` method
- `Map().getIn(["schema", "type"])` returns `undefined` rather than throwing, which correctly prevents the cookie deletion logic from executing
- The `authorize` action in the same file already uses `fromJS()` to convert to Immutable, confirming that Immutable types are the expected data type

### Screenshots (if appropriate):

N/A

## Checklist

### My PR contains...
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.