### PR TITLE
fix(config): fix parameterMacro typo in type-cast mappings

### DIFF
--- a/src/core/config/type-cast/mappings.js
+++ b/src/core/config/type-cast/mappings.js
@@ -63,7 +63,7 @@ const mappings = {
   operationsSorter: {
     typeCaster: sorterTypeCaster,
   },
-  paramaterMacro: { typeCaster: nullableFunctionTypeCaster },
+  parameterMacro: { typeCaster: nullableFunctionTypeCaster },
   persistAuthorization: {
     typeCaster: booleanTypeCaster,
     defaultValue: defaultOptions.persistAuthorization,


### PR DESCRIPTION
### Description

The type-cast mapping key for `parameterMacro` was misspelled as `paramaterMacro` (missing the 'e' in "parameter") in `src/core/config/type-cast/mappings.js`.

This typo meant that the `parameterMacro` configuration option was never matched by the type-casting system when provided via query string or other string-based configuration sources. The key in `mappings.js` did not match the key used everywhere else in the codebase (`parameterMacro` in `defaults.js`, `spec/actions.js`, `swagger-client/index.js`, etc.).

### Motivation and Context

Found while reviewing the type-cast mappings for completeness. Every other reference in the codebase uses `parameterMacro` (with an 'e'), confirming this was an inadvertent typo.

### How Has This Been Tested?

- Searched the entire codebase for both `paramaterMacro` and `parameterMacro` 
- Only `mappings.js` used the misspelled version
- All other references (`defaults.js`, `spec/actions.js`, `swagger-client/index.js`, `parameter-row.jsx`) consistently use `parameterMacro`

### Screenshots (if appropriate):

N/A

## Checklist

### My PR contains...
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.