### PR TITLE
fix(docker): emit literal null for string env vars set to "null"

### DIFF
--- a/docker/configurator/translator.js
+++ b/docker/configurator/translator.js
@@ -99,7 +99,14 @@ function objectToKeyValueString(env, { injectBaseConfig = false, schema = config
     const escapedName = /[^a-zA-Z0-9]/.test(key) ? `"${key}"` : key
 
     if (value.schema.type === "string") {
-      result += `${escapedName}: "${value.value}",\n`
+      // The literal string "null" should be emitted as the JS `null` value
+      // so that env vars like `VALIDATOR_URL=null` correctly disable the
+      // feature, rather than being treated as the URL "null". See #5519.
+      if (value.value === "null") {
+        result += `${escapedName}: null,\n`
+      } else {
+        result += `${escapedName}: "${value.value}",\n`
+      }
     } else {
       result += `${escapedName}: ${value.value === "" ? `undefined` : value.value},\n`
     }

--- a/test/unit/docker/translator.js
+++ b/test/unit/docker/translator.js
@@ -341,5 +341,28 @@ describe("docker: env translator", function() {
       validatorUrl: "http://smartbear.com/",`
       ).trim())
     })
+
+    it("should emit `null` (not the string \"null\") for string-typed env vars set to \"null\"", function () {
+      // Regression test for https://github.com/swagger-api/swagger-ui/issues/5519
+      // Setting `VALIDATOR_URL=null` in Docker is documented as the way to
+      // disable the validator badge. Previously this was emitted as the
+      // string `"null"`, producing a broken link.
+      const input = {
+        VALIDATOR_URL: "null"
+      }
+
+      expect(translator(input)).toEqual(`validatorUrl: null,`)
+    })
+
+    it("should emit `null` for other string-typed env vars set to \"null\"", function () {
+      // The same fix should apply to any string-typed config variable,
+      // not just VALIDATOR_URL. e.g. URL, FILTER, OAUTH2_REDIRECT_URL.
+      const input = {
+        URL: "null",
+        FILTER: "null"
+      }
+
+      expect(translator(input)).toEqual(`url: null,\nfilter: null,`)
+    })
   })
 })


### PR DESCRIPTION
## Description

The Docker entrypoint translator emits the string `"null"` instead of the JS literal `null` whenever a string-typed env var is set to `null` (e.g. `VALIDATOR_URL=null`). Per [docs/usage/configuration.md](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md#network), `null` is the documented way to disable the validator badge:

> `validatorUrl` | `VALIDATOR_URL` | `String="https://validator.swagger.io/validator" OR null`

Today, running

```sh
docker run -d -p 80:8080 -e URL=http://mySwaggerSpec -e VALIDATOR_URL=null swaggerapi/swagger-ui
```

injects

```js
validatorUrl: "null",
```

into the swagger-initializer.js, which the validator badge component then treats as a relative URL and renders as a broken link.

This change makes the translator detect the literal string `"null"` for string-typed config variables and emit the JS `null` value instead, restoring the documented behaviour. The fix applies to every string-typed config variable (`URL`, `VALIDATOR_URL`, `OAUTH2_REDIRECT_URL`, `FILTER`, etc.), which matches what the issue reporter and follow-up commenters described.

## Motivation and Context

Closes #5519. The bug was acknowledged by a maintainer in the original thread:

> Thanks for the report. You indeed discovered a bug in the docker work, as it's likely that `NULL` is parsed as `"NULL"`, so we'll have to get that fixed.

A follow-up comment confirmed it also breaks `URL=null` (and any other string variable that allows `null`), which the present fix addresses.

## How Has This Been Tested?

- `npm run test:unit -- test/unit/docker/translator.js` — 17 tests pass (15 existing + 2 new).
- `npx eslint --max-warnings 0 docker/configurator/translator.js test/unit/docker/translator.js` — clean.
- Two new regression tests cover both `VALIDATOR_URL=null` and the more general case (`URL=null`, `FILTER=null`).

The translator is build-time configuration code (it edits the dist HTML before nginx serves it), so it does not have a Cypress/browser surface to exercise.

## Checklist

- [x] My change requires a change to the documentation. — No, the existing docs already promise this behaviour.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.