### PR TITLE
docs(scripts): refresh development scripts reference

### DIFF
--- a/docs/development/scripts.md
+++ b/docs/development/scripts.md
@@ -6,35 +6,47 @@ Any of the scripts below can be run by typing `npm run <script name>` in the pro
 Script name | Description
 --- | ---
 `dev` | Spawn a hot-reloading dev server on port 3200.
+`start` | Serve the contents of `dist/` on port 3002 and open it in the default browser.
+`serve-static` | Serve the contents of `dist/` on port 3002 without opening a browser.
 `deps-check` | Generate a size and licensing report on Swagger UI's dependencies.
+`deps-license` | Generate the dependency license CSVs only.
+`deps-size` | Generate the dependency bundle-size report only.
 `lint` | Report ESLint style errors and warnings.
 `lint-errors` | Report ESLint style errors, without warnings.
 `lint-fix` | Attempt to fix style errors automatically.
 `lint-styles` | Report Stylelint style errors and warnings.
 `lint-styles-fix` | Attempt to fix Stylelint errors and warnings automatically.
-`watch` | Rebuild the core files in `/dist` when the source code changes. Useful for `npm link` with Swagger Editor.
 
 ### Building
 Script name | Description
 --- | ---
 `build` | Build a new set of JS and CSS assets, and output them to `/dist`.
-`build-bundle` | Build `swagger-ui-bundle.js` only (commonJS). 
-`build-core` | Build `swagger-ui.(js\|css)` only (commonJS).
-`build-standalone` | Build `swagger-ui-standalone-preset.js` only (commonJS).
+`build-all-bundles` | Build every JS bundle in parallel (no stylesheets, no clean step).
 `build-stylesheets` | Build `swagger-ui.css` only.
-`build:es:bundle` | Build `swagger-ui-es-bundle.js` only (es2015).
-`build:es:bundle:core` | Build `swagger-ui-es-bundle-core.js` only (es2015).
+`build:core` | Build `swagger-ui.js` only (CommonJS, browser).
+`build:bundle` | Build `swagger-ui-bundle.js` only (CommonJS, isomorphic).
+`build:standalone` | Build `swagger-ui-standalone-preset.js` only (CommonJS).
+`build:es:bundle` | Build `swagger-ui-es-bundle.js` only (ES module, isomorphic).
+`build:es:bundle:core` | Build `swagger-ui-es-bundle-core.js` only (ES module, browser).
+`clean` | Remove the `dist/` directory.
 
 ### Testing
 Script name | Description
 --- | ---
-`test` | Run unit tests in Node, run Cypress end-to-end tests, and run ESLint in errors-only mode.
+`test` | Run ESLint in errors-only mode, Jest unit tests, and the full Cypress end-to-end suite.
 `test:unit` | Run Jest unit tests in Node.
-`e2e` | Run end-to-end tests (requires JDK and Selenium).
-`e2e-cypress` | Run end-to-end browser tests with Cypress.
-`dev-e2e-cypress` | Dev mode, open Cypress runner and manually select tests to run.
-`lint` | Run ESLint test
-`test:artifact` | Run list of bundle artifact tests in Jest
-`test:artifact:umd:bundle` | Run unit test that confirms `swagger-ui-bundle` exports as a Function
-`test:artifact:es:bundle` | Run unit test that confirms `swagger-ui-es-bundle` exports as a Function
-`test:artifact:es:bundle:core` | Run unit test that confirms `swagger-ui-es-bundle-core` exports as a Function
+`test:artifact` | Run the bundle artifact tests in Jest, which verify that each built bundle exports correctly.
+`cy:ci` | Start the dev server and mock API, then run all Cypress tests headlessly.
+`cy:dev` | Start the dev server and mock API, then open the interactive Cypress runner.
+`cy:run` | Run Cypress tests headlessly against an already-running server.
+`cy:open` | Open the interactive Cypress runner against an already-running server.
+`cy:start` | Start the Cypress webpack dev server and the JSON-server mock API in parallel.
+`cy:server` | Start the Cypress webpack dev server only.
+`cy:mock-api` | Start the JSON-server mock API on port 3204 only.
+
+### Security
+Script name | Description
+--- | ---
+`security-audit` | Run both the moderate-threshold audit on all dependencies and the low-threshold audit on production dependencies.
+`security-audit:all` | Run `npm audit` on every dependency at the moderate threshold.
+`security-audit:prod` | Run `npm audit` on production dependencies only at the low threshold.


### PR DESCRIPTION
## Description

The script table in [`docs/development/scripts.md`](https://github.com/swagger-api/swagger-ui/blob/master/docs/development/scripts.md) was last meaningfully updated several years ago and has drifted from the actual `scripts` block in `package.json`. The page still documents scripts that have been renamed or removed, and is missing many that exist today, which makes it misleading for new contributors trying to find the right command.

## Motivation and Context

Concretely, the doc currently lists the following scripts that no longer exist in `package.json`:

- `watch`
- `build-bundle`, `build-core`, `build-standalone` (renamed to `build:bundle`, `build:core`, `build:standalone`)
- `e2e` (the Selenium runner is gone)
- `e2e-cypress`, `dev-e2e-cypress` (replaced by the `cy:*` family)
- `test:artifact:umd:bundle`, `test:artifact:es:bundle`, `test:artifact:es:bundle:core`

And it never mentions these scripts that currently exist:

- `start`, `serve-static`, `clean`, `build-all-bundles`
- `cy:mock-api`, `cy:server`, `cy:start`, `cy:open`, `cy:run`, `cy:ci`, `cy:dev`
- `deps-license`, `deps-size`
- `security-audit`, `security-audit:all`, `security-audit:prod`

This PR rewrites the table so each section matches the current `package.json` and groups scripts by purpose (Developing, Building, Testing, Security).

## How Has This Been Tested?

Pure documentation change — verified each row in the new table maps 1:1 to a script currently defined in `package.json`. No code paths touched.

### Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.