### PR TITLE
feat(oas2): support x-examples in body parameter request preview

### DIFF
--- a/src/core/components/param-body.jsx
+++ b/src/core/components/param-body.jsx
@@ -57,12 +57,38 @@ export default class ParamBody extends PureComponent {
       this.setState({ value: val })
       this.onChange(val, {isXml: isXml, isEditBox: isExecute})
     } else {
-      if (isXml) {
+      let xExampleValue = this.xExampleValue()
+      if (xExampleValue !== undefined) {
+        this.onChange(xExampleValue, {isXml: isXml, isEditBox: isExecute})
+      } else if (isXml) {
         this.onChange(this.sample("xml"), {isXml: isXml, isEditBox: isExecute})
       } else {
         this.onChange(this.sample(), {isEditBox: isExecute})
       }
     }
+  }
+
+  xExampleValue = () => {
+    const { param } = this.props
+    const xExamples = param.get("x-examples")
+    if (!xExamples || typeof xExamples.get !== "function" || xExamples.size === 0) {
+      return undefined
+    }
+    const defaultExample = xExamples.get("default")
+    const example = defaultExample !== undefined ? defaultExample : xExamples.first()
+    if (example === undefined) {
+      return undefined
+    }
+    if (typeof example === "string") {
+      return example
+    }
+    if (typeof example.toJS === "function") {
+      return JSON.stringify(example.toJS(), null, 2)
+    }
+    if (typeof example === "object") {
+      return JSON.stringify(example, null, 2)
+    }
+    return String(example)
   }
 
   sample = (xml) => {

--- a/test/e2e-cypress/e2e/bugs/3233.cy.js
+++ b/test/e2e-cypress/e2e/bugs/3233.cy.js
@@ -1,0 +1,25 @@
+describe("#3233: x-examples should populate the body parameter example for OAS 2.0", () => {
+  it("renders the x-examples 'default' value as the request body example", () => {
+    cy.visit("?url=/documents/bugs/3233.yaml")
+      .get("#operations-default-dataTargets")
+      .click()
+      .get(".opblock-section")
+      .within(() => {
+        cy.get(".body-param__example")
+          .should("be.visible")
+          .should("include.text", "targets")
+          .should("include.text", "1")
+          .should("include.text", "4")
+      })
+  })
+
+  it("populates the request body textarea with x-examples when 'Try it out' is enabled", () => {
+    cy.visit("?url=/documents/bugs/3233.yaml")
+      .get("#operations-default-dataTargets")
+      .click()
+      .get(".try-out__btn")
+      .click()
+      .get("textarea.body-param__text")
+      .should("contain.value", "targets")
+  })
+})

--- a/test/e2e-cypress/static/documents/bugs/3233.yaml
+++ b/test/e2e-cypress/static/documents/bugs/3233.yaml
@@ -1,0 +1,28 @@
+swagger: "2.0"
+info:
+  description: "OAS 2.0 sample with x-examples in body parameter (issue #3233)"
+  version: "0.0.1"
+  title: "Swagger Sample"
+paths:
+  /data/targets:
+    post:
+      summary: "Returns validation results of given list of targets."
+      description: ""
+      operationId: "dataTargets"
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: Targets list in JSON format.
+          required: true
+          schema:
+            type: object
+          x-examples:
+            default:
+              targets: [1, 2, 3, 4]
+      responses:
+        "200":
+          description: OK

--- a/test/unit/components/param-body.jsx
+++ b/test/unit/components/param-body.jsx
@@ -1,0 +1,150 @@
+import React from "react"
+import expect from "expect"
+import { mount } from "enzyme"
+import { fromJS } from "immutable"
+import ParamBody from "core/components/param-body"
+
+describe("<ParamBody/>", () => {
+  const baseFn = {
+    inferSchema: () => ({}),
+    getSampleSchema: () => "GENERATED_SAMPLE",
+  }
+
+  const baseSpecSelectors = {
+    parameterWithMetaByIdentity: (pathMethod, param) => param,
+    contentTypeValues: () => fromJS({ requestContentType: "application/json" }),
+  }
+
+  const fakeGetComponent = () => () => null
+
+  const createProps = (overrides = {}) => ({
+    fn: baseFn,
+    getComponent: fakeGetComponent,
+    specSelectors: baseSpecSelectors,
+    pathMethod: ["/foo", "post"],
+    consumes: fromJS(["application/json"]),
+    consumesValue: "application/json",
+    isExecute: false,
+    onChange: jest.fn(),
+    onChangeConsumes: jest.fn(),
+    ...overrides,
+  })
+
+  it("emits the user-provided value when one is set", () => {
+    const onChange = jest.fn()
+    const props = createProps({
+      param: fromJS({
+        name: "body",
+        in: "body",
+        value: "{\"hello\":\"world\"}",
+      }),
+      onChange,
+    })
+
+    mount(<ParamBody {...props} />)
+
+    expect(onChange).toHaveBeenCalledWith("{\"hello\":\"world\"}", false)
+  })
+
+  it("emits the generated sample when no value and no x-examples are present", () => {
+    const onChange = jest.fn()
+    const props = createProps({
+      param: fromJS({
+        name: "body",
+        in: "body",
+        schema: { type: "string" },
+      }),
+      onChange,
+    })
+
+    mount(<ParamBody {...props} />)
+
+    expect(onChange).toHaveBeenCalledWith("GENERATED_SAMPLE", undefined)
+  })
+
+  it("prefers the x-examples 'default' value over the generated sample", () => {
+    const onChange = jest.fn()
+    const props = createProps({
+      param: fromJS({
+        name: "body",
+        in: "body",
+        schema: { type: "object" },
+        "x-examples": {
+          default: { targets: [1, 2, 3, 4] },
+        },
+      }),
+      onChange,
+    })
+
+    mount(<ParamBody {...props} />)
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith(
+      JSON.stringify({ targets: [1, 2, 3, 4] }, null, 2),
+      false
+    )
+  })
+
+  it("falls back to the first x-examples entry when 'default' is missing", () => {
+    const onChange = jest.fn()
+    const props = createProps({
+      param: fromJS({
+        name: "body",
+        in: "body",
+        schema: { type: "object" },
+        "x-examples": {
+          first: { foo: "bar" },
+          second: { baz: "qux" },
+        },
+      }),
+      onChange,
+    })
+
+    mount(<ParamBody {...props} />)
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith(
+      JSON.stringify({ foo: "bar" }, null, 2),
+      false
+    )
+  })
+
+  it("uses string x-examples values verbatim", () => {
+    const onChange = jest.fn()
+    const props = createProps({
+      param: fromJS({
+        name: "body",
+        in: "body",
+        schema: { type: "string" },
+        "x-examples": {
+          default: "{\"targets\": \"[1, 2, 3, 4]\"}",
+        },
+      }),
+      onChange,
+    })
+
+    mount(<ParamBody {...props} />)
+
+    expect(onChange).toHaveBeenCalledWith(
+      "{\"targets\": \"[1, 2, 3, 4]\"}",
+      false
+    )
+  })
+
+  it("ignores empty x-examples and falls back to the generated sample", () => {
+    const onChange = jest.fn()
+    const props = createProps({
+      param: fromJS({
+        name: "body",
+        in: "body",
+        schema: { type: "object" },
+        "x-examples": {},
+      }),
+      onChange,
+    })
+
+    mount(<ParamBody {...props} />)
+
+    expect(onChange).toHaveBeenCalledWith("GENERATED_SAMPLE", undefined)
+  })
+})


### PR DESCRIPTION
### Description

Adds support for the OpenAPI 2.0 `x-examples` vendor extension on body parameters. When a body parameter declares an `x-examples` map and the user has not yet supplied a value, Swagger UI now renders that example as the request body preview (and pre-fills the textarea once "Try it out" is enabled) instead of the auto-generated schema sample.

Lookup order:

1. `x-examples.default`
2. The first entry in the `x-examples` map (preserving spec order)
3. The existing schema-derived sample (current behaviour)

String examples are emitted verbatim; structured values are pretty-printed as JSON.

### Motivation and Context

`x-examples` is widely produced by OAS 2.0 tooling such as `springfox`, `swagger-jaxrs`, and `io.swagger.models.parameters.AbstractSerializableParameter` (which serialises the user-defined `example` field as `x-examples`). Authors who set `x-examples` reasonably expect Swagger UI to surface those values, but until now they were silently dropped because `ParamBody.updateValues` only consulted `value`/`value_xml` before falling back to `fn.getSampleSchema`.

Closes #3233. The original issue includes a maintainer ack from @shockey on this exact code path:

> Your change to `param-body.jsx` seems like a step in the right direction - if you'd like to open a PR for this feature, I'd be happy to review it.

This change is conservative on purpose:

- It only fires when the parameter has no `value`/`value_xml` of its own, so it cannot override anything the user has typed or anything Swagger UI has already populated.
- It does not touch OAS 3.x, which has first-class `example`/`examples` support and a different code path (`parameter-row.jsx` + `ExamplesSelectValueRetainer`).
- It leaves the `x-examples` data structure untouched in state — it only consults it when picking the initial preview value.

### How Has This Been Tested?

- New Jest unit tests in `test/unit/components/param-body.jsx` cover six scenarios: existing user value wins, falls back to generated sample when there are no examples, prefers `x-examples.default`, falls back to the first entry when `default` is absent, passes string examples through verbatim, and ignores empty `x-examples` maps.
- New Cypress e2e spec `test/e2e-cypress/e2e/bugs/3233.cy.js` (with fixture `test/e2e-cypress/static/documents/bugs/3233.yaml`) loads an OAS 2.0 document with `x-examples` and asserts that the rendered preview (`.body-param__example`) and the `Try it out` textarea (`textarea.body-param__text`) both contain the example payload.
- Local results: `npm run test:unit -- test/unit/components/param-body.jsx` → 6/6 pass; existing `parameter-row` tests still pass; `npm run cy:run -- --spec "test/e2e-cypress/e2e/bugs/3233.cy.js"` → 2/2 pass; `npm run build:core` → success.

### Screenshots (if appropriate)

Not applicable — behaviour is identical for specs without `x-examples`. The change is observable only when an OAS 2.0 spec opts in by declaring `x-examples` on a body parameter, in which case the example payload now appears inside the existing `.body-param__example` block.

## Checklist

### My PR contains...

- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...

- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation

- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests

- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.