### PR TITLE
fix(a11y): add aria-label to operations filter input

### DIFF
--- a/src/core/containers/filter.jsx
+++ b/src/core/containers/filter.jsx
@@ -32,7 +32,7 @@ export default class FilterContainer extends React.Component {
         {filter === false ? null :
           <div className="filter-container">
             <Col className="filter wrapper" mobile={12}>
-              <input className={classNames.join(" ")} placeholder="Filter by tag" type="text"
+              <input className={classNames.join(" ")} aria-label="Filter by tag" placeholder="Filter by tag" type="text"
                      onChange={this.onFilterChange} value={typeof filter === "string" ? filter : ""}
                      disabled={isLoading}/>
             </Col>

--- a/test/e2e-cypress/e2e/a11y/filter-input.cy.js
+++ b/test/e2e-cypress/e2e/a11y/filter-input.cy.js
@@ -1,0 +1,17 @@
+describe("Filter input accessibility", () => {
+  describe("with filter enabled", () => {
+    it("should expose an accessible name via aria-label on the filter input", () => {
+      cy.visit("/?url=/documents/petstore.swagger.yaml&filter=true")
+        .get(".operation-filter-input")
+        .should("exist")
+        .should("have.attr", "aria-label", "Filter by tag")
+    })
+
+    it("should still render the visual placeholder for sighted users", () => {
+      cy.visit("/?url=/documents/petstore.swagger.yaml&filter=true")
+        .get(".operation-filter-input")
+        .should("exist")
+        .should("have.attr", "placeholder", "Filter by tag")
+    })
+  })
+})

--- a/test/unit/components/filter.jsx
+++ b/test/unit/components/filter.jsx
@@ -44,4 +44,20 @@ describe("<FilterContainer/>", function(){
     const renderedColInsideFilter = wrapper.find(Col)
     expect(renderedColInsideFilter.length).toEqual(0)
   })
+
+  it("exposes an accessible name on the filter input via aria-label", function(){
+
+    // Given
+    let props = {...mockedProps}
+    props.layoutSelectors = {...mockedProps.specSelectors}
+    props.layoutSelectors.currentFilter = function() {return true}
+
+    // When
+    let wrapper = mount(<FilterContainer {...props}/>)
+
+    // Then
+    const input = wrapper.find("input.operation-filter-input")
+    expect(input.length).toEqual(1)
+    expect(input.prop("aria-label")).toEqual("Filter by tag")
+  })
 })


### PR DESCRIPTION
## Description

The operations filter input (rendered when `filter=true`) only had a
`placeholder` attribute. Browsers and assistive technologies do not
expose `placeholder` as the accessible name of an input — once the user
types, the placeholder disappears entirely, and screen readers announce
the field as an unlabeled text box. This violates WCAG 2.1 success
criteria 4.1.2 (Name, Role, Value) and 1.3.1 (Info and Relationships).

This PR adds `aria-label="Filter by tag"` to the input so it has a
stable accessible name regardless of whether a value is present. The
visible placeholder is preserved so sighted-user UX is unchanged.

## Motivation and Context

`placeholder` is widely flagged by automated and manual a11y audits
(axe, WAVE, Lighthouse) as not satisfying the "accessible name"
requirement. Inputs without an accessible name are a long-standing pain
point for users of screen readers and voice-control software.

## How Has This Been Tested?

- New Jest unit test: `test/unit/components/filter.jsx` asserts the
  rendered input carries `aria-label="Filter by tag"`.
- New Cypress e2e spec: `test/e2e-cypress/e2e/a11y/filter-input.cy.js`
  visits a real spec with `filter=true` and asserts both `aria-label`
  and the original `placeholder` are present on the live DOM input.
- Existing regression spec `test/e2e-cypress/e2e/bugs/6276.cy.js`
  continues to pass.

```
PASS test/unit/components/filter.jsx
  <FilterContainer/>
    √ renders FilterContainer if filter is provided
    √ does not render FilterContainer if filter is false
    √ exposes an accessible name on the filter input via aria-label

✔  filter-input.cy.js   2 passing
✔  6276.cy.js           3 passing
```

## Screenshots (if appropriate):

N/A — DOM-only change. The input renders identically; only the
accessibility tree gains a name.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.