### PR TITLE
fix(core): suppress synthetic example for binary response media types

### DIFF
--- a/src/core/components/response.jsx
+++ b/src/core/components/response.jsx
@@ -164,12 +164,22 @@ export default class Response extends React.Component {
       }
     }
 
-    const sampleResponse = getSampleSchema(
-      sampleSchema,
-      activeContentType,
-      sampleGenConfig,
-      shouldOverrideSchemaExample ? mediaTypeExample : undefined
-    )
+    // Suppress synthetic sample generation for file-upload media types
+    // (e.g. application/octet-stream, image/*) where rendering a placeholder
+    // sample like "string" is misleading. User-supplied examples are kept.
+    const isFileUploadMediaType =
+      typeof fn.isFileUploadIntended === "function" &&
+      fn.isFileUploadIntended(sampleSchema, activeContentType)
+
+    const sampleResponse =
+      isFileUploadMediaType && !shouldOverrideSchemaExample
+        ? null
+        : getSampleSchema(
+            sampleSchema,
+            activeContentType,
+            sampleGenConfig,
+            shouldOverrideSchemaExample ? mediaTypeExample : undefined
+          )
 
     const example = getExampleComponent( sampleResponse, HighlightCode )
 

--- a/test/e2e-cypress/e2e/bugs/4791.cy.js
+++ b/test/e2e-cypress/e2e/bugs/4791.cy.js
@@ -1,0 +1,25 @@
+describe("#4791: application/octet-stream response should not show synthetic example", () => {
+  it("does not render a synthetic 'string' example for a binary response with no user example", () => {
+    cy.visit("?url=/documents/bugs/4791.yaml")
+      .get("#operations-default-downloadBinary")
+      .click()
+      .get(".responses-wrapper")
+      .within(() => {
+        cy.get('[data-name="examplePanel"]')
+          .should("contain.text", "no example available")
+        cy.get('[data-name="examplePanel"] .example')
+          .should("not.exist")
+      })
+  })
+
+  it("renders the user-supplied example for a binary response", () => {
+    cy.visit("?url=/documents/bugs/4791.yaml")
+      .get("#operations-default-downloadBinaryWithExample")
+      .click()
+      .get(".responses-wrapper")
+      .within(() => {
+        cy.get('[data-name="examplePanel"] .example')
+          .should("include.text", "user-supplied-example")
+      })
+  })
+})

--- a/test/e2e-cypress/static/documents/bugs/4791.yaml
+++ b/test/e2e-cypress/static/documents/bugs/4791.yaml
@@ -1,0 +1,30 @@
+openapi: 3.0.4
+info:
+  title: Octet-stream response example
+  version: "1.0"
+paths:
+  /download:
+    get:
+      summary: Download a binary file
+      operationId: downloadBinary
+      responses:
+        "200":
+          description: Binary download (no example expected)
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+  /downloadWithExample:
+    get:
+      summary: Download a binary file with a user-provided example
+      operationId: downloadBinaryWithExample
+      responses:
+        "200":
+          description: Binary download with explicit example
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+              example: user-supplied-example

--- a/test/unit/core/plugins/json-schema-5/components/response-octet-stream.jsx
+++ b/test/unit/core/plugins/json-schema-5/components/response-octet-stream.jsx
@@ -1,0 +1,166 @@
+/**
+ * @prettier
+ */
+import React from "react"
+import { shallow } from "enzyme"
+import { fromJS, List } from "immutable"
+
+import Response from "core/components/response"
+import ModelExample from "core/plugins/json-schema-5/components/model-example"
+import {
+  inferSchema,
+  memoizedSampleFromSchema,
+  memoizedCreateXMLExample,
+} from "core/plugins/json-schema-5-samples/fn/index"
+import makeGetSampleSchema from "core/plugins/json-schema-5-samples/fn/get-sample-schema"
+import makeGetJsonSampleSchema from "core/plugins/json-schema-5-samples/fn/get-json-sample-schema"
+import makeGetYamlSampleSchema from "core/plugins/json-schema-5-samples/fn/get-yaml-sample-schema"
+import makeGetXmlSampleSchema from "core/plugins/json-schema-5-samples/fn/get-xml-sample-schema"
+import { makeIsFileUploadIntended } from "core/plugins/oas3/fn"
+
+describe("<Response /> file-upload media types", function () {
+  const dummyComponent = () => null
+  const components = {
+    headers: dummyComponent,
+    highlightCode: dummyComponent,
+    modelExample: ModelExample,
+    Markdown: dummyComponent,
+    operationLink: dummyComponent,
+    contentType: dummyComponent,
+  }
+  const buildSystem = (isOAS3) => {
+    const getConfigs = () => ({
+      fileUploadMediaTypes: [
+        "application/octet-stream",
+        "image/",
+        "audio/",
+        "video/",
+      ],
+    })
+    const getSystem = () => ({
+      getComponent: (c) => components[c],
+      getConfigs,
+      specSelectors: {
+        isOAS3() {
+          return isOAS3
+        },
+      },
+      fn: {
+        inferSchema,
+        memoizedSampleFromSchema,
+        memoizedCreateXMLExample,
+        getJsonSampleSchema: makeGetJsonSampleSchema(getSystem),
+        getYamlSampleSchema: makeGetYamlSampleSchema(getSystem),
+        getXmlSampleSchema: makeGetXmlSampleSchema(getSystem),
+        getSampleSchema: makeGetSampleSchema(getSystem),
+        hasSchemaType: (schema, type) => {
+          if (!schema) return false
+          const schemaType =
+            typeof schema?.get === "function" ? schema.get("type") : schema.type
+          return schemaType === type
+        },
+        isFileUploadIntended: makeIsFileUploadIntended(getSystem),
+      },
+    })
+    return getSystem()
+  }
+
+  it("does not render a synthetic example for application/octet-stream responses (OAS3)", function () {
+    const props = {
+      ...buildSystem(true),
+      contentType: "application/octet-stream",
+      className: "for-test",
+      specPath: List(),
+      response: fromJS({
+        content: {
+          "application/octet-stream": {
+            schema: {
+              type: "string",
+              format: "binary",
+            },
+          },
+        },
+      }),
+      code: "200",
+    }
+
+    const wrapper = shallow(<Response {...props} />)
+    const renderedModelExample = wrapper.find(ModelExample)
+    expect(renderedModelExample.length).toEqual(1)
+    expect(renderedModelExample.props().example).toBeNull()
+  })
+
+  it("renders user-supplied example for application/octet-stream responses (OAS3)", function () {
+    const props = {
+      ...buildSystem(true),
+      contentType: "application/octet-stream",
+      className: "for-test",
+      specPath: List(),
+      response: fromJS({
+        content: {
+          "application/octet-stream": {
+            schema: {
+              type: "string",
+              format: "binary",
+            },
+            example: "user-provided-example",
+          },
+        },
+      }),
+      code: "200",
+    }
+
+    const wrapper = shallow(<Response {...props} />)
+    const renderedModelExample = wrapper.find(ModelExample)
+    expect(renderedModelExample.length).toEqual(1)
+    expect(renderedModelExample.props().example).not.toBeNull()
+  })
+
+  it("does not render a synthetic example for OAS 2.0 octet-stream responses", function () {
+    const props = {
+      ...buildSystem(false),
+      contentType: "application/octet-stream",
+      className: "for-test",
+      specPath: List(),
+      response: fromJS({
+        schema: {
+          type: "string",
+          format: "binary",
+        },
+      }),
+      code: "200",
+    }
+
+    const wrapper = shallow(<Response {...props} />)
+    const renderedModelExample = wrapper.find(ModelExample)
+    expect(renderedModelExample.length).toEqual(1)
+    expect(renderedModelExample.props().example).toBeNull()
+  })
+
+  it("still renders a synthetic example for application/json responses", function () {
+    const props = {
+      ...buildSystem(true),
+      contentType: "application/json",
+      className: "for-test",
+      specPath: List(),
+      response: fromJS({
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              properties: {
+                a: { type: "string" },
+              },
+            },
+          },
+        },
+      }),
+      code: "200",
+    }
+
+    const wrapper = shallow(<Response {...props} />)
+    const renderedModelExample = wrapper.find(ModelExample)
+    expect(renderedModelExample.length).toEqual(1)
+    expect(renderedModelExample.props().example).not.toBeNull()
+  })
+})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

When a response uses a file-upload media type such as `application/octet-stream` (or `image/*`, `audio/*`, `video/*`) together with a schema like `{ type: string, format: binary }`, Swagger UI renders a synthetic sample value of `"string"` in the response example. That placeholder is misleading: the content is binary and no JSON-renderable example exists, but the UI implies one is available.

The request body already handles this correctly — `fn.isFileUploadIntended` is consulted for `RequestBody`, which substitutes a file picker (or an explanatory message). The same check was missing for response rendering.

Closes #4791

## What is the new behavior?

`core/components/response.jsx` now consults `fn.isFileUploadIntended(schema, contentType)` when computing the example to display for a response. If the media type/schema is recognized as a file upload **and** the spec does not supply a user-defined example, the synthetic sample is suppressed and the example panel falls back to the existing `"(no example available)"` placeholder rendered by `ModelExample`.

User-supplied examples (via `example` or `examples` on the media type, in both OAS 3.x and OAS 2.0) continue to render as before.

The check is conditional on `fn.isFileUploadIntended` being defined, so the change is a no-op when the OpenAPI 3.x plugin is not loaded.

## How has this been tested?

### Jest unit tests (`test/unit/core/plugins/json-schema-5/components/response-octet-stream.jsx`)

- OAS 3 `application/octet-stream` response with `{ type: string, format: binary }` and no example → `ModelExample` receives `example={null}`.
- OAS 3 `application/octet-stream` response with a user-supplied `example` → the example is still rendered.
- OAS 2.0 response producing `application/octet-stream` with `{ type: string, format: binary }` → no synthetic example.
- OAS 3 `application/json` response → unchanged; synthetic example is still produced.

### Cypress e2e (`test/e2e-cypress/e2e/bugs/4791.cy.js`, fixture `test/e2e-cypress/static/documents/bugs/4791.yaml`)

- Operation with a binary response and no example → example panel shows `"no example available"`, no `.example` highlight block.
- Operation with a binary response that supplies `example: user-supplied-example` → example panel renders the user-supplied value.

Both Jest and Cypress suites were verified to fail without the source change and pass with it applied.

## Checklist

- [x] No breaking changes
- [x] Unit tests added
- [x] Cypress e2e tests added
- [x] Existing response tests still pass
- [x] Conventional Commit format