### PR TITLE
fix(oauth2-redirect): guard window.opener for cross-origin flows

### DIFF
--- a/dev-helpers/oauth2-redirect.js
+++ b/dev-helpers/oauth2-redirect.js
@@ -1,5 +1,9 @@
 "use strict"
 function run () {
+    if (!window.opener || !window.opener.swaggerUIRedirectOauth2) {
+        document.body.innerText = "OAuth redirect cannot complete because the window that started the flow is no longer reachable. Close this tab and start authorization again from Swagger UI."
+        return
+    }
     var oauth2 = window.opener.swaggerUIRedirectOauth2
     var sentState = oauth2.state
     var redirectUrl = oauth2.redirectUrl

--- a/test/unit/core/oauth2-redirect.js
+++ b/test/unit/core/oauth2-redirect.js
@@ -1,0 +1,110 @@
+/**
+ * @prettier
+ */
+import fs from "fs"
+import path from "path"
+
+const REDIRECT_SCRIPT_PATH = path.resolve(
+  __dirname,
+  "../../../dev-helpers/oauth2-redirect.js"
+)
+const REDIRECT_SCRIPT = fs.readFileSync(REDIRECT_SCRIPT_PATH, "utf8")
+
+const setLocation = (search, hash) => {
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: {
+      hash: hash || "",
+      search: search || "",
+    },
+  })
+}
+
+const setOpener = (opener) => {
+  Object.defineProperty(window, "opener", {
+    configurable: true,
+    value: opener,
+  })
+}
+
+const runRedirectScript = () => {
+  // Evaluate the script in the current jsdom window context
+  // eslint-disable-next-line no-new-func
+  new Function(REDIRECT_SCRIPT)()
+}
+
+describe("oauth2-redirect", () => {
+  let originalLocation
+  let originalOpener
+  let closeSpy
+
+  beforeEach(() => {
+    originalLocation = window.location
+    originalOpener = window.opener
+    while (document.body.firstChild) {
+      document.body.removeChild(document.body.firstChild)
+    }
+    closeSpy = jest.spyOn(window, "close").mockImplementation(() => {})
+    setLocation("", "")
+  })
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: originalLocation,
+    })
+    setOpener(originalOpener)
+    closeSpy.mockRestore()
+  })
+
+  describe("when window.opener is null", () => {
+    it("renders an explanatory message and does not throw", () => {
+      setOpener(null)
+
+      expect(() => runRedirectScript()).not.toThrow()
+      expect(document.body.innerText).toMatch(/OAuth redirect cannot complete/)
+      expect(closeSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("when window.opener has no swaggerUIRedirectOauth2", () => {
+    it("renders an explanatory message and does not throw", () => {
+      setOpener({})
+
+      expect(() => runRedirectScript()).not.toThrow()
+      expect(document.body.innerText).toMatch(/OAuth redirect cannot complete/)
+      expect(closeSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("when window.opener.swaggerUIRedirectOauth2 is present", () => {
+    it("relays the auth code via callback for authorization_code flow", () => {
+      const callback = jest.fn()
+      const errCb = jest.fn()
+      const oauth2 = {
+        state: "abc",
+        redirectUrl: "https://example.org/callback",
+        auth: {
+          name: "OAuth2",
+          schema: {
+            get: (key) => (key === "flow" ? "authorization_code" : null),
+          },
+        },
+        callback,
+        errCb,
+      }
+      setOpener({ swaggerUIRedirectOauth2: oauth2 })
+      setLocation("?code=auth-code-123&state=abc", "")
+
+      runRedirectScript()
+
+      expect(callback).toHaveBeenCalledTimes(1)
+      expect(callback.mock.calls[0][0]).toEqual({
+        auth: expect.objectContaining({ code: "auth-code-123" }),
+        redirectUrl: "https://example.org/callback",
+      })
+      expect(errCb).not.toHaveBeenCalled()
+      expect(closeSpy).toHaveBeenCalledTimes(1)
+    })
+  })
+})


### PR DESCRIPTION
## Description

When the OAuth2 authorization flow goes through a cross-origin redirect, browser policy can sever `window.opener` on the redirect tab. The current `dev-helpers/oauth2-redirect.js` (which webpack copies to `dist/oauth2-redirect.html`) accesses `window.opener.swaggerUIRedirectOauth2` unconditionally, throwing `TypeError: Cannot read properties of null (reading 'swaggerUIRedirectOauth2')` and leaving the user staring at a blank redirect tab.

This PR adds a single guard at the top of `run()` that detects the missing opener and surfaces a clear instruction to the user instead of crashing silently.

## Motivation and Context

Refs: #10786, #6150

Both issues report the redirect tab failing without a useful message in cross-origin OAuth flows. The fix is the minimum needed to convert the silent crash into actionable feedback; it does not alter the success path.

## How Has This Been Tested?

- New Jest unit test `test/unit/core/oauth2-redirect.js` exercises the script under three scenarios:
  - `window.opener` is `null` → no throw, instruction text is shown
  - `window.opener` exists but `swaggerUIRedirectOauth2` is missing → no throw, instruction text is shown
  - opener and oauth2 state are present → existing success path is preserved
- 3/3 unit tests pass locally:
  ```
  PASS test/unit/core/oauth2-redirect.js (47 s)
  Tests:       3 passed, 3 total
  ```

### Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.