### PR TITLE
fix(docker): address CVE-2026-27135 nghttp2-libs vulnerability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ RUN apk add --update-cache --no-cache \
     "libcrypto3>=3.5.6-r0" \
     "libssl3>=3.5.6-r0" \
     "musl>=1.2.5-r23" \
-    "musl-utils>=1.2.5-r23"
+    "musl-utils>=1.2.5-r23" \
+    "nghttp2-libs>=1.68.1-r0"
 
 LABEL maintainer="char0n"
 


### PR DESCRIPTION
## Summary

- Pins `nghttp2-libs` to `>=1.68.1-r0` in the Dockerfile to fix HIGH severity **CVE-2026-27135**
- Vulnerability: Denial of Service via malformed HTTP/2 frames after session termination
- Detected by Trivy in the `docker.swagger.io/swaggerapi/swagger-ui:unstable` image (Alpine 3.23.4)
- Follows the same pattern already used in the Dockerfile for other pinned Alpine packages


## How Has This Been Tested?

- The fix will be validated by the next scheduled Trivy Docker image security scan
- No functional code changes; only the Alpine package version constraint is updated

## Screenshots

N/A — no UI changes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)