### PR TITLE
fix(json-schema-5-samples): unwrap schema example referencing components.examples

### DIFF
--- a/src/core/plugins/json-schema-5-samples/fn/index.js
+++ b/src/core/plugins/json-schema-5-samples/fn/index.js
@@ -58,6 +58,25 @@ const primitive = (schema) => {
 const sanitizeRef = (value) => deeplyStripKey(value, "$$ref", (val) =>
   typeof val === "string" && val.indexOf("#") > -1)
 
+// When a schema's `example` keyword is `{$ref: '#/components/examples/X'}`,
+// swagger-client inlines the referenced Example Object verbatim, leaving
+// `{ value: <user data>, $$ref: '#/components/examples/X' }`. The sample
+// generator must use the inner `value`, not the wrapper.
+const unwrapTopLevelExampleReference = (value) => {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return value
+  }
+  const ref = value.$$ref
+  if (
+    typeof ref === "string" &&
+    ref.indexOf("#/components/examples/") > -1 &&
+    Object.prototype.hasOwnProperty.call(value, "value")
+  ) {
+    return value.value
+  }
+  return value
+}
+
 const objectContracts = ["maxProperties", "minProperties"]
 const arrayContracts = ["minItems", "maxItems"]
 const numberContracts = [
@@ -383,9 +402,9 @@ export const sampleFromSchemaGeneric = (schema, config={}, exampleOverride = und
   if(usePlainValue) {
     let sample
     if(exampleOverride !== undefined) {
-      sample = sanitizeRef(exampleOverride)
+      sample = sanitizeRef(unwrapTopLevelExampleReference(exampleOverride))
     } else if(example !== undefined) {
-      sample = sanitizeRef(example)
+      sample = sanitizeRef(unwrapTopLevelExampleReference(example))
     } else {
       sample = sanitizeRef(schema.default)
     }

--- a/test/e2e-cypress/e2e/bugs/5748.cy.js
+++ b/test/e2e-cypress/e2e/bugs/5748.cy.js
@@ -1,0 +1,22 @@
+/**
+ * @prettier
+ */
+
+// https://github.com/swagger-api/swagger-ui/issues/5748
+
+describe("#5748: schema property `example: $ref` to a components.examples entry", () => {
+  it("renders the referenced Example Object's value without the `value:` wrapper", () => {
+    cy.visit("/?url=/documents/bugs/5748.yaml")
+      .get("#operations-default-getFirst")
+      .click()
+      .get(".model-example .highlight-code")
+      .should("be.visible")
+      .invoke("text")
+      .then((text) => {
+        expect(text).to.include("Individual")
+        expect(text).to.include("Variant")
+        expect(text).to.include("ga4gh-phenopacket-individual-v0.1")
+        expect(text).not.to.match(/"value"\s*:/)
+      })
+  })
+})

--- a/test/e2e-cypress/static/documents/bugs/5748.yaml
+++ b/test/e2e-cypress/static/documents/bugs/5748.yaml
@@ -1,0 +1,37 @@
+openapi: 3.0.2
+info:
+  title: "Issue 5748: schema example $ref renders value keyword"
+  version: "0.1"
+paths:
+  /first:
+    get:
+      operationId: getFirst
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RequestMeta'
+components:
+  schemas:
+    RequestMeta:
+      description: Wrapper schema whose `request` property example references a reusable Example Object.
+      type: object
+      required:
+        - request
+      properties:
+        request:
+          description: Should render the Example Object's `value` contents, not the wrapper.
+          type: object
+          example:
+            $ref: '#/components/examples/MetaContent'
+  examples:
+    MetaContent:
+      value:
+        Individual:
+          - "ga4gh-phenopacket-individual-v0.1"
+          - "ga4gh-schemablocks-individual-v0.1"
+        Variant:
+          - "ga4gh-variant-representation-v0.1"
+          - "ga4gh-schemablocks-beacon-variant-v0.1"

--- a/test/unit/core/plugins/json-schema-5-samples/fn/index.js
+++ b/test/unit/core/plugins/json-schema-5-samples/fn/index.js
@@ -265,7 +265,7 @@ describe("sampleFromSchema", () => {
     expect(sampleFromSchema(definition, { includeWriteOnly: true })).toEqual(expected)
   })
 
-  it("returns object without any $$ref fields at the root schema level", function () {
+  it("unwraps a top-level schema example that references a components.examples entry", function () {
     let definition = {
     type: "object",
     properties: {
@@ -283,12 +283,49 @@ describe("sampleFromSchema", () => {
   }
 
     let expected = {
-      "value": {
-        "message": "Hello, World!"
-      }
+      message: "Hello, World!"
     }
 
     expect(sampleFromSchema(definition, { includeWriteOnly: true })).toEqual(expected)
+  })
+
+  it("preserves a top-level example object that has a `value` key but no $$ref", function () {
+    let definition = {
+      type: "object",
+      example: {
+        value: {
+          message: "Hello, World!"
+        }
+      }
+    }
+
+    let expected = {
+      value: {
+        message: "Hello, World!"
+      }
+    }
+
+    expect(sampleFromSchema(definition)).toEqual(expected)
+  })
+
+  it("preserves a top-level example object whose $$ref does not point to components.examples", function () {
+    let definition = {
+      type: "object",
+      example: {
+        value: {
+          message: "Hello, World!"
+        },
+        $$ref: "#/components/schemas/SomethingElse"
+      }
+    }
+
+    let expected = {
+      value: {
+        message: "Hello, World!"
+      }
+    }
+
+    expect(sampleFromSchema(definition)).toEqual(expected)
   })
 
   it("returns object without any $$ref fields at nested schema levels", function () {


### PR DESCRIPTION
## Description

When a schema property's `example` keyword is `{$ref: '#/components/examples/X'}`, the rendered example incorrectly includes a `value:` wrapper key.

### Root cause

`swagger-client`'s ref resolver (`refs.js`) substitutes the resolved Example Object verbatim — only response/requestBody/parameter `examples[*].value` paths are on its skip list. So a schema-level `example: { \$ref: '#/components/examples/X' }` is replaced with `{ value: <user data>, \$\$ref: '#/components/examples/X' }`.

`sampleFromSchemaGeneric` in `src/core/plugins/json-schema-5-samples/fn/index.js` then reads that object as the literal sample, leaving the `value:` wrapper visible in the rendered output. The same example referenced from a response's `examples:` block does *not* hit this code path and renders correctly (the asymmetry described in the issue).

### Fix

A new helper `unwrapTopLevelExampleReference` checks whether the top-level example object has *both* a `\$\$ref` matching `#/components/examples/` *and* an own `value` key. Only that exact shape (which `swagger-client` injects deterministically for resolved Example Objects) is unwrapped; everything else passes through untouched.

The fix is intentionally conservative:
- It only fires when the resolver's distinctive Example-Object marker (`\$\$ref` pointing into `#/components/examples/`) is present.
- It is **top-level only** — nested occurrences are left to `sanitizeRef` exactly as before, so existing tests at `test/unit/core/plugins/json-schema-5-samples/fn/index.js:294` and `:324` are unaffected.
- User-authored objects with a literal `value` key (no `\$\$ref`) or with a `\$\$ref` pointing elsewhere are preserved verbatim.

## Motivation and Context

Fixes #5748.

## How Has This Been Tested?

- **Unit:** updated the existing root-level `\$\$ref` test in `test/unit/core/plugins/json-schema-5-samples/fn/index.js` to expect the unwrapped shape, and added two new negative tests (no `\$\$ref`; `\$\$ref` pointing outside `#/components/examples/`). Full file: 121 tests pass.
- **Cypress (CI):** new fixture `test/e2e-cypress/static/documents/bugs/5748.yaml` reproduces the issue's repro spec; new spec `test/e2e-cypress/e2e/bugs/5748.cy.js` asserts the rendered example contains the inner keys (`Individual`, `Variant`) and does **not** contain the `\"value\":` wrapper.
- **Lint:** `eslint --max-warnings 0` clean on changed files.

## Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] My change requires no documentation update
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed