### PR TITLE
fix(parameters): render items format for array-type parameters (#4516)

### DIFF
--- a/src/core/plugins/json-schema-5/fn.js
+++ b/src/core/plugins/json-schema-5/fn.js
@@ -19,7 +19,11 @@ export const hasSchemaType = (schema, type) => {
   )
 }
 
-const getType = (schema, processedSchemas = new WeakSet()) => {
+const getType = (
+  schema,
+  processedSchemas = new WeakSet(),
+  withFormat = false
+) => {
   if (schema == null) {
     return "any"
   }
@@ -30,11 +34,14 @@ const getType = (schema, processedSchemas = new WeakSet()) => {
 
   processedSchemas.add(schema)
 
-  const { type, items } = schema
+  const { type, format, items } = schema
 
   const getArrayType = () => {
     if (items) {
-      const itemsType = getType(items, processedSchemas)
+      // Inline items format (e.g. "string($uuid)") inside the array<...> label,
+      // because the array's items have no separate rendering path that would
+      // append their format. See issue #4516.
+      const itemsType = getType(items, processedSchemas, true)
       return `array<${itemsType}>`
     } else {
       return "array<any>"
@@ -43,6 +50,9 @@ const getType = (schema, processedSchemas = new WeakSet()) => {
 
   if (Object.hasOwn(schema, "items")) {
     return getArrayType()
+  }
+  if (withFormat && type && format) {
+    return `${type}($${format})`
   }
   return type
 }

--- a/test/e2e-cypress/e2e/bugs/4516.cy.js
+++ b/test/e2e-cypress/e2e/bugs/4516.cy.js
@@ -1,0 +1,32 @@
+/**
+ * @prettier
+ */
+
+describe("UI #4516: array parameter items.format is rendered", () => {
+  beforeEach(() => {
+    cy.visit("/?url=/documents/bugs/4516.yaml")
+      .get("#operations-default-searchUsers")
+      .click()
+  })
+
+  it("renders items format for an array of strings with format uuid", () => {
+    cy.get('tr[data-param-name="targetUserIds"]')
+      .find(".parameter__type")
+      .invoke("text")
+      .should("match", /^array<string\(\$uuid\)>/)
+  })
+
+  it("renders items format for an array of integers with format int64", () => {
+    cy.get('tr[data-param-name="limits"]')
+      .find(".parameter__type")
+      .invoke("text")
+      .should("match", /^array<integer\(\$int64\)>/)
+  })
+
+  it("does not alter non-array parameter type rendering", () => {
+    cy.get('tr[data-param-name="tag"]')
+      .find(".parameter__type")
+      .invoke("text")
+      .should("match", /^string(\s|$)/)
+  })
+})

--- a/test/e2e-cypress/static/documents/bugs/4516.yaml
+++ b/test/e2e-cypress/static/documents/bugs/4516.yaml
@@ -1,0 +1,35 @@
+swagger: "2.0"
+info:
+  description: "Swagger 2.0 spec exercising issue #4516"
+  version: "0.0.1"
+  title: "Swagger 4516 sample"
+paths:
+  /users:
+    get:
+      summary: "Search users by UUID"
+      operationId: "searchUsers"
+      parameters:
+        - in: "query"
+          name: "targetUserIds"
+          description: "List of user UUIDs to query for"
+          collectionFormat: "multi"
+          required: true
+          type: "array"
+          items:
+            type: "string"
+            format: "uuid"
+        - in: "query"
+          name: "limits"
+          description: "Pagination limits"
+          collectionFormat: "csv"
+          type: "array"
+          items:
+            type: "integer"
+            format: "int64"
+        - in: "query"
+          name: "tag"
+          description: "Plain string parameter, no format"
+          type: "string"
+      responses:
+        "200":
+          description: "OK"

--- a/test/unit/components/parameter-row.jsx
+++ b/test/unit/components/parameter-row.jsx
@@ -147,6 +147,67 @@ describe("<ParameterRow/>", () => {
     expect(wrapper.find(".parameter__type").length).toEqual(1)
     expect(wrapper.find(".parameter__type").text()).toEqual("boolean")
   })
+
+  it("Can render Swagger 2 array parameter type with items format (#4516)", () => {
+    const param = fromJS({
+      name: "targetUserIds",
+      in: "query",
+      type: "array",
+      collectionFormat: "multi",
+      items: {
+        type: "string",
+        format: "uuid",
+      },
+    })
+
+    const props = createProps({ param, isOAS3: false })
+    const wrapper = render(<ParameterRow {...props} />)
+
+    expect(wrapper.find(".parameter__type").length).toEqual(1)
+    expect(wrapper.find(".parameter__type").text()).toEqual(
+      "array<string($uuid)>"
+    )
+  })
+
+  it("Can render Swagger 2 array parameter type without items format", () => {
+    const param = fromJS({
+      name: "tags",
+      in: "query",
+      type: "array",
+      collectionFormat: "multi",
+      items: {
+        type: "string",
+      },
+    })
+
+    const props = createProps({ param, isOAS3: false })
+    const wrapper = render(<ParameterRow {...props} />)
+
+    expect(wrapper.find(".parameter__type").length).toEqual(1)
+    expect(wrapper.find(".parameter__type").text()).toEqual("array<string>")
+  })
+
+  it("Can render OAS3 array parameter type with items format (#4516)", () => {
+    const param = fromJS({
+      name: "targetUserIds",
+      in: "query",
+      schema: {
+        type: "array",
+        items: {
+          type: "string",
+          format: "uuid",
+        },
+      },
+    })
+
+    const props = createProps({ param, isOAS3: true })
+    const wrapper = render(<ParameterRow {...props} />)
+
+    expect(wrapper.find(".parameter__type").length).toEqual(1)
+    expect(wrapper.find(".parameter__type").text()).toEqual(
+      "array<string($uuid)>"
+    )
+  })
 })
 
 describe("bug #5573: zero default and example values", function () {

--- a/test/unit/core/plugins/json-schema-5/fn.js
+++ b/test/unit/core/plugins/json-schema-5/fn.js
@@ -1,0 +1,78 @@
+/**
+ * @prettier
+ */
+import { fromJS } from "immutable"
+
+import { getSchemaObjectTypeLabel } from "core/plugins/json-schema-5/fn"
+
+describe("json-schema-5 fn", () => {
+  describe("getSchemaObjectTypeLabel", () => {
+    it("returns the type for a primitive schema", () => {
+      const schema = fromJS({ type: "string" })
+
+      expect(getSchemaObjectTypeLabel(schema)).toEqual("string")
+    })
+
+    it("returns the type without inline format for a top-level primitive", () => {
+      // Format on a primitive top-level schema is rendered separately by the
+      // calling component, so the label itself should not embed it.
+      const schema = fromJS({ type: "string", format: "uuid" })
+
+      expect(getSchemaObjectTypeLabel(schema)).toEqual("string")
+    })
+
+    it("returns array<itemsType> when items has no format", () => {
+      const schema = fromJS({
+        type: "array",
+        items: { type: "string" },
+      })
+
+      expect(getSchemaObjectTypeLabel(schema)).toEqual("array<string>")
+    })
+
+    it("inlines items format inside the array<...> label (#4516)", () => {
+      const schema = fromJS({
+        type: "array",
+        items: { type: "string", format: "uuid" },
+      })
+
+      expect(getSchemaObjectTypeLabel(schema)).toEqual("array<string($uuid)>")
+    })
+
+    it("inlines items format for integer arrays (#4516)", () => {
+      const schema = fromJS({
+        type: "array",
+        items: { type: "integer", format: "int64" },
+      })
+
+      expect(getSchemaObjectTypeLabel(schema)).toEqual("array<integer($int64)>")
+    })
+
+    it("inlines items format for nested arrays (#4516)", () => {
+      const schema = fromJS({
+        type: "array",
+        items: {
+          type: "array",
+          items: { type: "string", format: "uuid" },
+        },
+      })
+
+      expect(getSchemaObjectTypeLabel(schema)).toEqual(
+        "array<array<string($uuid)>>"
+      )
+    })
+
+    it("inlines items format for the issue's repro spec (#4516)", () => {
+      // Excerpt from https://github.com/swagger-api/swagger-ui/issues/4516
+      const schema = fromJS({
+        items: { format: "uuid", type: "string" },
+        in: "query",
+        name: "targetUserIds",
+        collectionFormat: "multi",
+        type: "array",
+      })
+
+      expect(getSchemaObjectTypeLabel(schema)).toEqual("array<string($uuid)>")
+    })
+  })
+})


### PR DESCRIPTION
## Description

For an array-type parameter whose items declare a `format`, Swagger UI dropped that format from the rendered type column. For example a Swagger 2.0 query parameter:

```yaml
- in: query
  name: targetUserIds
  type: array
  collectionFormat: multi
  items:
    type: string
    format: uuid
```

rendered as `array<string>` instead of something carrying the `uuid` format. Non-array parameters already render their format (see #4231 / #4245), so the gap was specific to arrays.

## Root cause

`getType` in `src/core/plugins/json-schema-5/fn.js` builds the `array<...>` label by recursing into `items`, but the recursive call only returned the items' `type` and ignored their `format`. The calling component `src/core/components/parameter-row.jsx` then renders the resulting label as-is and appends a separate `(format)` span derived from the **top-level** schema's `format`, which is undefined for array parameters. Net result: array items' `format` had no rendering path.

This affects Swagger 2.0 and OpenAPI 3.0, which share `json-schema-5`. OpenAPI 3.1+ uses `json-schema-2020-12` and is intentionally out of scope here.

## Fix

`getType` accepts an internal `withFormat` flag that the array recursion turns on, so item types are emitted inline as `<type>($<format>)` within the `array<...>` label, e.g. `array<string($uuid)>`. The top-level call path is unchanged, so primitive parameter rendering still produces a separate `(format)` span and existing test expectations hold.

## Motivation and Context

Closes #4516.

## How Has This Been Tested?

- New Jest unit tests for `getSchemaObjectTypeLabel` in `test/unit/core/plugins/json-schema-5/fn.js` covering: plain primitive, primitive with format (no inline format at top level), `array<string>`, `array<string($uuid)>`, `array<integer($int64)>`, nested `array<array<string($uuid)>>`, and the exact spec excerpt from the issue.
- New `<ParameterRow/>` unit tests in `test/unit/components/parameter-row.jsx` for both Swagger 2.0 and OpenAPI 3.0 array parameters with and without items format.
- New Cypress e2e spec at `test/e2e-cypress/e2e/bugs/4516.cy.js` driven by a small Swagger 2.0 fixture `test/e2e-cypress/static/documents/bugs/4516.yaml`. Verified locally: 3/3 passing.
- Existing `<ParameterRow/>` unit tests still pass (10/10) — the non-array path is unchanged.

## Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] My change requires no documentation updates
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass