### PR TITLE
chore(deps): bump react-copy-to-clipboard from 5.1.0 to 5.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "randexp": "^0.5.3",
         "randombytes": "^2.1.0",
         "react": ">=16.8.0 <20",
-        "react-copy-to-clipboard": "5.1.0",
+        "react-copy-to-clipboard": "^5.1.1",
         "react-debounce-input": "=3.3.0",
         "react-dom": ">=16.8.0 <20",
         "react-immutable-proptypes": "2.2.0",
@@ -6122,6 +6122,40 @@
         "node": ">=18"
       }
     },
+    "node_modules/@release-it/conventional-changelog/node_modules/conventional-commits-parser": {
+      "version": "6.4.0",
+      "resolved": "https://nexus.dev.norvax.net/repository/npm-all/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.2.0",
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@release-it/conventional-changelog/node_modules/meow": {
+      "version": "13.2.0",
+      "resolved": "https://nexus.dev.norvax.net/repository/npm-all/meow/-/meow-13.2.0.tgz",
+      "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@release-it/conventional-changelog/node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -7959,9 +7993,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7976,9 +8007,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7993,9 +8021,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8010,9 +8035,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8027,9 +8049,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8044,9 +8063,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8061,9 +8077,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8078,9 +8091,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10977,6 +10987,8 @@
     },
     "node_modules/copy-to-clipboard": {
       "version": "3.3.3",
+      "resolved": "https://nexus.dev.norvax.net/repository/npm-all/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
+      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
       "license": "MIT",
       "dependencies": {
         "toggle-selection": "^1.0.6"
@@ -23651,14 +23663,16 @@
       }
     },
     "node_modules/react-copy-to-clipboard": {
-      "version": "5.1.0",
+      "version": "5.1.1",
+      "resolved": "https://nexus.dev.norvax.net/repository/npm-all/react-copy-to-clipboard/-/react-copy-to-clipboard-5.1.1.tgz",
+      "integrity": "sha512-s+HrzLyJBxrpGTYXF15dTgMjAJpEPZT/Yp6NytAtZMRngejxt6Pt5WrfFxLAcsqUDU6sY1Jz6tyHwIicE1U2Xg==",
       "license": "MIT",
       "dependencies": {
-        "copy-to-clipboard": "^3.3.1",
+        "copy-to-clipboard": "^3.3.3",
         "prop-types": "^15.8.1"
       },
       "peerDependencies": {
-        "react": "^15.3.0 || 16 || 17 || 18"
+        "react": ">=15.3.0"
       }
     },
     "node_modules/react-debounce-input": {
@@ -27403,6 +27417,8 @@
     },
     "node_modules/toggle-selection": {
       "version": "1.0.6",
+      "resolved": "https://nexus.dev.norvax.net/repository/npm-all/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
       "license": "MIT"
     },
     "node_modules/toidentifier": {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "randexp": "^0.5.3",
     "randombytes": "^2.1.0",
     "react": ">=16.8.0 <20",
-    "react-copy-to-clipboard": "5.1.0",
+    "react-copy-to-clipboard": "^5.1.1",
     "react-debounce-input": "=3.3.0",
     "react-dom": ">=16.8.0 <20",
     "react-immutable-proptypes": "2.2.0",


### PR DESCRIPTION
### Description

Bumps `react-copy-to-clipboard` from `5.1.0` to `5.1.1`. The version constraint was also updated from a pinned version (`5.1.0`) to a caret range (`^5.1.1`) to allow future compatible patch updates.

### Motivation and Context

Keeps the dependency up to date with the latest patch release of `react-copy-to-clipboard`, which may include bug fixes or minor improvements.

### How Has This Been Tested?

This is a dependency-only update. The existing test suite (unit + E2E) covers the clipboard functionality in the application.

### Screenshots (if appropriate):

N/A

## Checklist

### My PR contains...
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [x] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [x] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.