### PR TITLE
fix(a11y): replace <pre> with <span> for version labels

### DIFF
--- a/src/core/components/openapi-version.jsx
+++ b/src/core/components/openapi-version.jsx
@@ -4,7 +4,7 @@ import PropTypes from "prop-types"
 
 const OpenAPIVersion = ({ oasVersion }) => (
   <small className="version-stamp">
-    <pre className="version">OAS {oasVersion}</pre>
+    <span className="version">OAS {oasVersion}</span>
   </small>
 )
 

--- a/src/core/components/version-stamp.jsx
+++ b/src/core/components/version-stamp.jsx
@@ -2,7 +2,7 @@ import React from "react"
 import PropTypes from "prop-types"
 
 const VersionStamp = ({ version }) => {
-  return <small><pre className="version"> { version } </pre></small>
+  return <small><span className="version"> { version } </span></small>
 }
 
 VersionStamp.propTypes = {

--- a/src/style/_information.scss
+++ b/src/style/_information.scss
@@ -88,7 +88,7 @@
         background-color: #89bf04;
       }
 
-      pre {
+      .version {
         margin: 0;
         padding: 0;
 

--- a/test/e2e-cypress/e2e/a11y/version-stamp.cy.js
+++ b/test/e2e-cypress/e2e/a11y/version-stamp.cy.js
@@ -1,0 +1,26 @@
+describe("a11y: API version label", () => {
+  it("should render the API version stamp without a <pre> element (OpenAPI 3)", () => {
+    cy.visit("/?url=/documents/petstore-expanded.openapi.yaml")
+      .get(".info .title small")
+      .first()
+      .should("be.visible")
+      .within(() => {
+        cy.get("pre").should("not.exist")
+        cy.get(".version").should("exist").and("not.match", "pre")
+      })
+  })
+
+  it("should render the OAS version stamp without a <pre> element", () => {
+    cy.visit("/?url=/documents/petstore-expanded.openapi.yaml")
+      .get(".info .title small.version-stamp")
+      .first()
+      .should("be.visible")
+      .within(() => {
+        cy.get("pre").should("not.exist")
+        cy.get(".version")
+          .should("exist")
+          .and("not.match", "pre")
+          .and("contain.text", "OAS")
+      })
+  })
+})

--- a/test/unit/components/version-stamp.jsx
+++ b/test/unit/components/version-stamp.jsx
@@ -1,0 +1,41 @@
+/**
+ * @prettier
+ */
+
+import React from "react"
+import { mount } from "enzyme"
+import expect from "expect"
+import VersionStamp from "core/components/version-stamp"
+import OpenAPIVersion from "core/components/openapi-version"
+
+describe("<VersionStamp/>", function () {
+  it("should not render a <pre> element for the version label", function () {
+    const wrapper = mount(<VersionStamp version="1.0.0" />)
+
+    expect(wrapper.find("pre").length).toEqual(0)
+  })
+
+  it("should render the version inside an inline element with the .version class", function () {
+    const wrapper = mount(<VersionStamp version="1.0.0" />)
+    const versionEl = wrapper.find("small").find(".version")
+
+    expect(versionEl.length).toEqual(1)
+    expect(versionEl.text().trim()).toEqual("1.0.0")
+  })
+})
+
+describe("<OpenAPIVersion/>", function () {
+  it("should not render a <pre> element for the OAS version label", function () {
+    const wrapper = mount(<OpenAPIVersion oasVersion="3.0.0" />)
+
+    expect(wrapper.find("pre").length).toEqual(0)
+  })
+
+  it("should render the OAS version inside an inline element with the .version class", function () {
+    const wrapper = mount(<OpenAPIVersion oasVersion="3.0.0" />)
+    const versionEl = wrapper.find("small.version-stamp").find(".version")
+
+    expect(versionEl.length).toEqual(1)
+    expect(versionEl.text()).toEqual("OAS 3.0.0")
+  })
+})


### PR DESCRIPTION
## Description

Render the API version stamp and OAS version stamp inside `<span>` elements instead of `<pre>` so the version badges in the `info` block are no longer marked up as preformatted code blocks.

- `src/core/components/version-stamp.jsx` — `<small><pre className="version">…</pre></small>` -> `<small><span className="version">…</span></small>`
- `src/core/components/openapi-version.jsx` — `<small class="version-stamp"><pre className="version">OAS …</pre></small>` -> `<span className="version">OAS …</span>` inside the same `<small>`
- `src/style/_information.scss` — descendant selector under `.info .title small` switched from `pre` to `.version` (the className that was already on the element) so the existing reset and `text_headline` typography still apply.

## Motivation and Context

`<pre>` is reserved for preformatted blocks of computer code or ASCII figures. Wrapping a short, decorative version label in `<pre>` misleads assistive tech (screen readers may announce it as a code block) and was flagged in the linked issue.

Fixes #10481

## How Has This Been Tested?

- `npx jest --config ./config/jest/jest.unit.config.js test/unit/components/version-stamp.jsx` -> 4/4 passing. New tests assert no `<pre>` is rendered and the `.version` element still contains the version text for both `<VersionStamp/>` and `<OpenAPIVersion/>`.
- `npx cypress run --spec test/e2e-cypress/e2e/a11y/version-stamp.cy.js` -> 2/2 passing against `petstore-expanded.openapi.yaml`. Asserts the version stamps render without a `<pre>` element and that the `.version` element still exists and is visible.
- `npx eslint` on the changed JS/JSX -> clean.
- `npx stylelint src/style/_information.scss` -> clean.

## Screenshots

No visual change is expected — `<pre>` was already styled via `small pre { margin:0; padding:0; … }` and the matching SCSS rule was updated to `.version`. The badge still renders inline with the same typography and background.

## Checklist

- [x] Bug fix
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation — **No**
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed