### PR TITLE
fix(deep-linking): preserve current pathname/search when setting hash

### DIFF
--- a/src/core/plugins/deep-linking/helpers.js
+++ b/src/core/plugins/deep-linking/helpers.js
@@ -1,6 +1,11 @@
 export const setHash = (value) => {
   if(value) {
-    return history.pushState(null, null, `#${value}`)
+    // Include the current pathname and search explicitly so that a
+    // document-level `<base href>` (set by frameworks like Angular) does not
+    // cause `pushState` to resolve `#value` against the base URL and replace
+    // the current route. See https://github.com/swagger-api/swagger-ui/issues/10591
+    const { pathname, search } = window.location
+    return history.pushState(null, null, `${pathname}${search}#${value}`)
   } else {
     return window.location.hash = ""
   }

--- a/test/e2e-cypress/e2e/bugs/10591.cy.js
+++ b/test/e2e-cypress/e2e/bugs/10591.cy.js
@@ -1,0 +1,33 @@
+describe("#10591: deep-linking with document <base href> should not replace current route", () => {
+  const baseUrl = "/?deepLinking=true&url=/documents/features/deep-linking.openapi.yaml"
+
+  it("should preserve the page pathname and search when an operation is expanded", () => {
+    cy.intercept(
+      {
+        method: "GET",
+        pathname: "/",
+      },
+      (req) => {
+        req.continue((res) => {
+          if (typeof res.body === "string" && res.body.includes("</head>")) {
+            res.body = res.body.replace("</head>", "<base href=\"/\">\n</head>")
+          }
+        })
+      }
+    ).as("indexHtml")
+
+    cy.visit(baseUrl)
+    cy.wait("@indexHtml")
+    cy.get(".opblock-get").first().click()
+
+    cy.location().should((loc) => {
+      // The URL hash must change to reflect the deep link...
+      expect(loc.hash).to.not.equal("")
+      // ...but the pathname (and search) must NOT have been replaced by the
+      // browser resolving "#..." against the document <base href="/">.
+      expect(loc.pathname).to.equal("/")
+      expect(loc.search).to.contain("deepLinking=true")
+      expect(loc.search).to.contain("url=/documents/features/deep-linking.openapi.yaml")
+    })
+  })
+})

--- a/test/unit/core/plugins/deep-linking/helpers.js
+++ b/test/unit/core/plugins/deep-linking/helpers.js
@@ -1,0 +1,63 @@
+/**
+ * @prettier
+ */
+import { setHash } from "core/plugins/deep-linking/helpers"
+
+describe("deep-linking plugin - helpers", () => {
+  describe("setHash", () => {
+    let originalLocation
+    let pushStateSpy
+
+    beforeEach(() => {
+      originalLocation = window.location
+      pushStateSpy = jest
+        .spyOn(window.history, "pushState")
+        .mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      pushStateSpy.mockRestore()
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: originalLocation,
+      })
+    })
+
+    const stubLocation = (pathname, search) => {
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: { ...originalLocation, pathname, search, hash: "" },
+      })
+    }
+
+    it("should preserve the current pathname and search when pushing a hash", () => {
+      stubLocation("/app/api-docs", "?env=staging")
+
+      setHash("/myTag/myOperation")
+
+      expect(pushStateSpy).toHaveBeenCalledWith(
+        null,
+        null,
+        "/app/api-docs?env=staging#/myTag/myOperation"
+      )
+    })
+
+    it("should still push a hash when the current URL has no search string", () => {
+      stubLocation("/swagger", "")
+
+      setHash("/foo")
+
+      expect(pushStateSpy).toHaveBeenCalledWith(null, null, "/swagger#/foo")
+    })
+
+    it("should clear window.location.hash when called with an empty value", () => {
+      stubLocation("/swagger", "")
+      window.location.hash = "#/foo"
+
+      setHash("")
+
+      expect(window.location.hash).toBe("")
+      expect(pushStateSpy).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
### Description

`setHash` in the deep-linking plugin calls `history.pushState(null, null, "#value")`. When the third argument to `pushState` is a hash-only URL, the browser resolves it against the document's base URL — i.e. the `<base href>` tag — instead of the current location. Frameworks like Angular always inject `<base href=\"/\">`, so the resolved URL becomes `/#value`, which wipes out the page's pathname and search string. The originally requested route is gone.

This PR builds the URL passed to `pushState` from `window.location.pathname` and `window.location.search`. The behavior is:

- Unchanged in pages with no `<base>` tag (the new URL is identical to what the browser would have produced on its own).
- Correct in pages that declare a `<base href>` (the existing path and query are preserved).

### Motivation and Context

Fixes #10591.

Reported and root-caused by the issue author: an Angular host that mounts Swagger UI with `deepLinking: true` loses its route the moment a user expands an operation, because `pushState(\"#…\")` is resolved against `<base href=\"/\">`.

### How Has This Been Tested?

- New Jest unit suite at `test/unit/core/plugins/deep-linking/helpers.js` covers the three branches of `setHash`. Verified the suite fails on `master` (asserts include the full path) and passes with the patch.
  - `cross-env NODE_ENV=test BABEL_ENV=commonjs BROWSERSLIST_ENV=node-development jest --config ./config/jest/jest.unit.config.js --no-cache test/unit/core/plugins/deep-linking/helpers.js`
- New Cypress regression `test/e2e-cypress/e2e/bugs/10591.cy.js` intercepts the dev-e2e `index.html` response, injects `<base href=\"/\">`, then asserts that expanding an operation preserves both `location.pathname` and `location.search`. Verified the spec fails on `master` (the search string is wiped) and passes with the patch.
  - `cross-env BROWSERSLIST_ENV=browser-production cypress run --spec test/e2e-cypress/e2e/bugs/10591.cy.js`
- Targeted ESLint pass on the three touched files (no warnings).

### Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Notes:
- No documentation change is needed — `setHash` is an internal helper and the public deep-linking contract is unchanged for hosts without a `<base>` tag.