### PR TITLE
fix: render arrays with boolean false item schemas

### DIFF
--- a/src/core/plugins/json-schema-5/components/json-schema-components.jsx
+++ b/src/core/plugins/json-schema-5/components/json-schema-components.jsx
@@ -206,7 +206,7 @@ export class JsonSchema_array extends PureComponent {
       ArrayItemsComponent = getComponent(`JsonSchema_${schemaItemsType}`)
     }
 
-    if (List.isList(schemaItems?.get("type")) && (schemaItemsType === "array" || schemaItemsType === "object")) {
+    if (List.isList(schemaItems?.get?.("type")) && (schemaItemsType === "array" || schemaItemsType === "object")) {
       ArrayItemsComponent = getComponent(`JsonSchema_object`)
     }
 

--- a/test/unit/core/plugins/json-schema-5/components/json-schema-form.jsx
+++ b/test/unit/core/plugins/json-schema-5/components/json-schema-form.jsx
@@ -1,12 +1,19 @@
 import React from "react"
 import Immutable, { List } from "immutable"
-import { Select, Input, TextArea } from "core/components/layout-utils"
+import { Select, Input, TextArea, Button } from "core/components/layout-utils"
 import { mount, render } from "enzyme"
 import { getSchemaObjectType } from "core/plugins/json-schema-5-samples/fn/index"
+import { foldType } from "core/plugins/json-schema-2020-12-samples/fn/core/type"
+import {
+  isBooleanJSONSchema,
+  makeGetType,
+} from "core/plugins/json-schema-2020-12/fn"
 import * as JsonSchemaComponents from "core/plugins/json-schema-5/components/json-schema-components"
 import { makeIsFileUploadIntended } from "core/plugins/oas3/fn"
 
-const components = {...JsonSchemaComponents, Select, Input, TextArea}
+const components = {...JsonSchemaComponents, Select, Input, TextArea, Button}
+const jsonSchema202012GetType = makeGetType(() => ({ isBooleanJSONSchema }))
+const toJS = (schema) => schema?.toJS ? schema.toJS() : schema
 
 const getComponentStub = (name) => {
   if(components[name]) return components[name]
@@ -241,6 +248,50 @@ describe("<JsonSchemaComponents.JsonSchemaForm/>", function(){
 
       expect(wrapper.find("textarea").length).toEqual(1)
       expect(wrapper.find("textarea").text()).toEqual(`{\n  "id": "abc123"\n}`)
+    })
+  })
+  describe("arrays", function() {
+    it("renders tuple array items when additional items are disallowed", function() {
+      let props = {
+        getComponent: getComponentStub,
+        value: Immutable.fromJS([["triggered-at", "desc-nulls-last"]]),
+        onChange: () => {},
+        keyName: "",
+        fn: {
+          getSchemaObjectType: (schema) => foldType(toJS(schema)?.type),
+          getSchemaObjectTypeLabel: (schema) => jsonSchema202012GetType(toJS(schema)),
+          isFileUploadIntended: makeIsFileUploadIntended(getSystemStub)
+        },
+        errors: List(),
+        schema: Immutable.fromJS({
+          type: "array",
+          items: {
+            type: "array",
+            prefixItems: [
+              {
+                type: "string",
+                enum: ["triggered-at"]
+              },
+              {
+                type: "string",
+                enum: [
+                  "asc-nulls-first",
+                  "asc-nulls-last",
+                  "desc-nulls-first",
+                  "desc-nulls-last"
+                ]
+              }
+            ],
+            items: false
+          }
+        })
+      }
+
+      let wrapper = render(<JsonSchemaComponents.JsonSchemaForm {...props}/>)
+
+      expect(wrapper.find("input").length).toEqual(2)
+      expect(wrapper.find("input").eq(0).attr("value")).toEqual("triggered-at")
+      expect(wrapper.find("input").eq(1).attr("value")).toEqual("desc-nulls-last")
     })
   })
   describe("unknown types", function() {


### PR DESCRIPTION
### Description

Guard the array item schema type lookup so JSON Schema boolean schemas such as `items: false` do not throw while rendering nested array parameters.

Adds a regression test for an OpenAPI 3.1-style tuple schema using `prefixItems` with `items: false`.

### Motivation and Context

Fixes #10921.

OpenAPI 3.1 uses JSON Schema 2020-12, where tuple schemas can disallow additional items with `items: false`. Rendering the parameter form reached `schemaItems?.get("type")`; because boolean schemas do not implement `get`, the endpoint details crashed instead of rendering.

### How Has This Been Tested?

- `npm run test:unit -- --runTestsByPath test/unit/core/plugins/json-schema-5/components/json-schema-form.jsx --runInBand`
- `./node_modules/.bin/eslint --quiet src/core/plugins/json-schema-5/components/json-schema-components.jsx test/unit/core/plugins/json-schema-5/components/json-schema-form.jsx`
- `git diff --check`

### Screenshots (if appropriate):

N/A

## Checklist

### My PR contains... 
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
