### PR TITLE
feat(ux): separate server response and possible responses into distinct panels

### DIFF
--- a/src/core/components/live-response.jsx
+++ b/src/core/components/live-response.jsx
@@ -85,48 +85,50 @@ export default class LiveResponse extends React.Component {
           </div>
         }
         <h4>Server response</h4>
-        <table className="responses-table live-responses-table">
-          <thead>
-          <tr className="responses-header">
-            <td className="col_header response-col_status">Code</td>
-            <td className="col_header response-col_description">Details</td>
-          </tr>
-          </thead>
-          <tbody>
-            <tr className="response">
-              <td className="response-col_status">
-                { status }
-                {
-                  notDocumented ? <div className="response-undocumented">
-                                    <i> Undocumented </i>
-                                  </div>
-                                : null
-                }
-              </td>
-              <td className="response-col_description">
-                {
-                  isError ? <Markdown source={`${response.get("name") !== "" ? `${response.get("name")}: ` : ""}${response.get("message")}`}/>
-                          : null
-                }
-                {
-                  body ? <ResponseBody content={ body }
-                                       contentType={ contentType }
-                                       url={ url }
-                                       headers={ headers }
-                                       getConfigs={ getConfigs }
-                                       getComponent={ getComponent }/>
-                       : null
-                }
-                {
-                  hasHeaders ? <Headers headers={ returnObject }/> : null
-                }
-                {
-                  displayRequestDuration && duration ? <Duration duration={ duration } /> : null
-                }
-              </td>
+        <div className="server-response-panel">
+          <table className="responses-table live-responses-table">
+            <thead>
+            <tr className="responses-header">
+              <td className="col_header response-col_status">Code</td>
+              <td className="col_header response-col_description">Details</td>
             </tr>
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              <tr className="response">
+                <td className="response-col_status">
+                  { status }
+                  {
+                    notDocumented ? <div className="response-undocumented">
+                                      <i> Undocumented </i>
+                                    </div>
+                                  : null
+                  }
+                </td>
+                <td className="response-col_description">
+                  {
+                    isError ? <Markdown source={`${response.get("name") !== "" ? `${response.get("name")}: ` : ""}${response.get("message")}`}/>
+                            : null
+                  }
+                  {
+                    body ? <ResponseBody content={ body }
+                                         contentType={ contentType }
+                                         url={ url }
+                                         headers={ headers }
+                                         getConfigs={ getConfigs }
+                                         getComponent={ getComponent }/>
+                         : null
+                  }
+                  {
+                    hasHeaders ? <Headers headers={ returnObject }/> : null
+                  }
+                  {
+                    displayRequestDuration && duration ? <Duration duration={ duration } /> : null
+                  }
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </div>
     )
   }

--- a/src/core/components/responses.jsx
+++ b/src/core/components/responses.jsx
@@ -108,61 +108,60 @@ export default class Responses extends React.Component {
         </div>
         <div className="responses-inner">
           {
-            !tryItOutResponse ? null
-                              : <div>
-                                  <LiveResponse response={ tryItOutResponse }
-                                                getComponent={ getComponent }
-                                                getConfigs={ getConfigs }
-                                                specSelectors={ specSelectors }
-                                                path={ this.props.path }
-                                                method={ this.props.method }
-                                                displayRequestDuration={ displayRequestDuration } />
-                                  <h4>Responses</h4>
-                                </div>
-
-          }
-
-          <table aria-live="polite" className="responses-table" id={regionId} role="region">
-            <thead>
-              <tr className="responses-header">
-                <td className="col_header response-col_status">Code</td>
-                <td className="col_header response-col_description">Description</td>
-                { specSelectors.isOAS3() ? <td className="col col_header response-col_links">Links</td> : null }
-              </tr>
-            </thead>
-            <tbody>
-              {
-                nonExtensionResponses.entrySeq().map( ([code, response]) => {
-
-                  let className = tryItOutResponse && tryItOutResponse.get("status") == code ? "response_current" : ""
-                  return (
-                    <Response key={ code }
-                              path={path}
-                              method={method}
-                              specPath={specPath.push(code)}
-                              isDefault={defaultCode === code}
-                              fn={fn}
-                              className={ className }
-                              code={ code }
-                              response={ response }
-                              specSelectors={ specSelectors }
-                              controlsAcceptHeader={response === acceptControllingResponse}
-                              onContentTypeChange={this.onResponseContentTypeChange}
-                              contentType={ producesValue }
+            tryItOutResponse
+              ? <LiveResponse response={ tryItOutResponse }
+                              getComponent={ getComponent }
                               getConfigs={ getConfigs }
-                              activeExamplesKey={oas3Selectors.activeExamplesMember(
-                                path,
-                                method,
-                                "responses",
-                                code
-                              )}
-                              oas3Actions={oas3Actions}
-                              getComponent={ getComponent }/>
-                    )
-                }).toArray()
-              }
-            </tbody>
-          </table>
+                              specSelectors={ specSelectors }
+                              path={ this.props.path }
+                              method={ this.props.method }
+                              displayRequestDuration={ displayRequestDuration } />
+              : null
+          }
+          { tryItOutResponse ? <h4>Possible Responses</h4> : null }
+          <div className="possible-responses-wrapper">
+            <table aria-live="polite" className="responses-table" id={regionId} role="region">
+              <thead>
+                <tr className="responses-header">
+                  <td className="col_header response-col_status">Code</td>
+                  <td className="col_header response-col_description">Description</td>
+                  { specSelectors.isOAS3() ? <td className="col col_header response-col_links">Links</td> : null }
+                </tr>
+              </thead>
+              <tbody>
+                {
+                  nonExtensionResponses.entrySeq().map( ([code, response]) => {
+
+                    let className = tryItOutResponse && tryItOutResponse.get("status") == code ? "response_current" : ""
+                    return (
+                      <Response key={ code }
+                                path={path}
+                                method={method}
+                                specPath={specPath.push(code)}
+                                isDefault={defaultCode === code}
+                                fn={fn}
+                                className={ className }
+                                code={ code }
+                                response={ response }
+                                specSelectors={ specSelectors }
+                                controlsAcceptHeader={response === acceptControllingResponse}
+                                onContentTypeChange={this.onResponseContentTypeChange}
+                                contentType={ producesValue }
+                                getConfigs={ getConfigs }
+                                activeExamplesKey={oas3Selectors.activeExamplesMember(
+                                  path,
+                                  method,
+                                  "responses",
+                                  code
+                                )}
+                                oas3Actions={oas3Actions}
+                                getComponent={ getComponent }/>
+                      )
+                  }).toArray()
+                }
+              </tbody>
+            </table>
+          </div>
         </div>
       </div>
     )

--- a/src/core/components/responses.jsx
+++ b/src/core/components/responses.jsx
@@ -118,7 +118,7 @@ export default class Responses extends React.Component {
                               displayRequestDuration={ displayRequestDuration } />
               : null
           }
-          { tryItOutResponse ? <h4>Possible Responses</h4> : null }
+          { tryItOutResponse ? <h4>Possible responses</h4> : null }
           <div className="possible-responses-wrapper">
             <table aria-live="polite" className="responses-table" id={regionId} role="region">
               <thead>

--- a/src/style/_dark-mode.scss
+++ b/src/style/_dark-mode.scss
@@ -548,6 +548,11 @@ html.dark-mode {
         h5 {
           color: $neutral-20;
         }
+
+        .server-response-panel,
+        .possible-responses-wrapper {
+          background: rgba($neutral-20, 0.05);
+        }
       }
 
       .response-control-media-type--accept-controller {

--- a/src/style/_layout.scss
+++ b/src/style/_layout.scss
@@ -557,13 +557,28 @@
 .responses-inner {
   padding: 20px;
 
-  h5,
-  h4 {
+  h5 {
     font-size: 12px;
 
     margin: 10px 0 5px 0;
 
     @include type.text_body();
+  }
+
+  h4 {
+    font-size: 14px;
+
+    margin: 10px 0 5px 0;
+
+    @include type.text_body();
+  }
+
+  .server-response-panel,
+  .possible-responses-wrapper {
+    background: $alabaster;
+    border-radius: 4px;
+    padding: 10px;
+    margin-top: 10px;
   }
 
   .curl {

--- a/src/style/_layout.scss
+++ b/src/style/_layout.scss
@@ -565,6 +565,7 @@
     @include type.text_body();
   }
 
+  // Applies to "Server response", "Request URL", and "Possible responses" headings
   h4 {
     font-size: 14px;
 

--- a/test/e2e-selenium/scenarios/oas3/pet.js
+++ b/test/e2e-selenium/scenarios/oas3/pet.js
@@ -43,7 +43,8 @@ describe("render pet api container", function () {
       .setValue("#operations-pet-updatePetWithForm td.parameters-col_description > input", "12345")
       .click("#operations-pet-updatePetWithForm > div:nth-child(2) > div > div.execute-wrapper > button")
       .pause(800) // for swagger-api/swagger-ui#4269, which happens above 350ms
-      .assert.containsText("#operations-pet-updatePetWithForm div.responses-inner > div > div > div:nth-child(2) > div > pre", "http://localhost:3204/pet/12345")
+      // The LiveResponse component is a direct child of responses-inner (no extra wrapper div)
+      .assert.containsText("#operations-pet-updatePetWithForm div.responses-inner > div > div:nth-child(2) > div > pre", "http://localhost:3204/pet/12345")
       .assert.value("#operations-pet-updatePetWithForm td.parameters-col_description > input", "12345")
 
       client.end()

--- a/test/unit/components/responses.jsx
+++ b/test/unit/components/responses.jsx
@@ -1,0 +1,50 @@
+import React from "react"
+import { fromJS } from "immutable"
+import { shallow } from "enzyme"
+import Responses from "core/components/responses"
+
+describe("<Responses/>", function () {
+  const baseProps = {
+    responses: fromJS({ "200": { description: "OK" } }),
+    tryItOutResponse: null,
+    displayRequestDuration: false,
+    path: "/pets",
+    method: "get",
+    getComponent: () => () => null,
+    getConfigs: () => ({}),
+    specSelectors: {
+      isOAS3: () => false,
+    },
+    specActions: {},
+    oas3Actions: {},
+    oas3Selectors: {
+      activeExamplesMember: () => null,
+    },
+    specPath: fromJS([]),
+    fn: {},
+  }
+
+  it("does not render 'Possible responses' heading when no server response", function () {
+    const wrapper = shallow(<Responses {...baseProps} />)
+    expect(wrapper.find("h4").map((n) => n.text())).not.toContain("Possible responses")
+  })
+
+  it("renders 'Possible responses' heading when a server response is present", function () {
+    const props = {
+      ...baseProps,
+      tryItOutResponse: fromJS({ status: 200, headers: {}, text: "" }),
+      getComponent: (name) => {
+        if (name === "liveResponse") return () => null
+        return () => null
+      },
+    }
+    const wrapper = shallow(<Responses {...props} />)
+    const h4Texts = wrapper.find("h4").map((n) => n.text())
+    expect(h4Texts).toContain("Possible responses")
+  })
+
+  it("wraps the responses table in .possible-responses-wrapper regardless of server response", function () {
+    const wrapper = shallow(<Responses {...baseProps} />)
+    expect(wrapper.find("div.possible-responses-wrapper").length).toEqual(1)
+  })
+})


### PR DESCRIPTION
### Description

After executing a "Try It Out" request, the actual server response and the documented possible responses were visually indistinguishable, forcing users to mentally parse the layout on every use.

This PR introduces clear visual separation between the two:

- Rename the "Responses" label to **"Possible responses"** when a server response is present, to distinguish it from the actual response.
- Wrap each section's table in its own panel with a light grey background (`.server-response-panel` and `.possible-responses-wrapper`).
- Increase the `.responses-inner` `h4` title size from 12px to 14px so section titles ("Server response", "Possible responses") stand out from table content.
- Add a dark mode override for the panel backgrounds.

### Motivation and Context

Fixes #6548

The issue requested making the "Server response" / "Responses" titles more prominent and visually grouping the documented responses into their own sub-panel, so users can immediately tell apart what the server actually returned from what the API documents as possible.

Note on scope: the `.responses-inner h4` size bump also applies to the "Request URL" heading inside the live response. This is intentional and kept consistent — documented inline in `_layout.scss`.

### How Has This Been Tested?

- `npm run test:unit` — all suites pass, including new unit tests for the `Responses` component covering the conditional "Possible responses" heading and the `.possible-responses-wrapper`.
- `npm run lint-errors` — zero errors.
- `npm run build` — all bundles compile.
- Manual testing in the dev server (port 3200) with OAS 2.0 and OAS 3.x specs, in both light and dark mode, before and after executing a request.

A legacy Selenium selector in `test/e2e-selenium/scenarios/oas3/pet.js` was updated to account for the removed wrapper `<div>` around `LiveResponse`.

### Screenshots

_Screenshot showing the separated "Server response" and "Possible responses" panels (to be attached):_
<img width="2196" height="1436" alt="swagger-ui-6548-separate-response-panels" src="https://github.com/user-attachments/assets/817d44e3-cb28-4136-8fad-e06f729cd37d" />


## Checklist

### My PR contains...
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.

### Usage of AI

Claude Opus 4.8 & Sonnet 4.6 was used for the following parts of this contribution:
- Initial analysis of the codebase to locate the relevant components and styles.
- Code reviews of the changes hand-written by the author.
- Writing the unit test(s).
- Writing the commit messages and the text of this pull request.

The core implementation was written by hand by the author.
