### PR TITLE
feat(curl): add visible "Copy" label to curl clipboard buttons

### DIFF
--- a/src/core/components/curl.jsx
+++ b/src/core/components/curl.jsx
@@ -18,7 +18,7 @@ export default class Curl extends React.Component {
       <div className="curl-command">
         <h4>Curl</h4>
         <div className="copy-to-clipboard">
-            <CopyToClipboard text={curl}><button/></CopyToClipboard>
+            <CopyToClipboard text={curl}><button type="button">Copy</button></CopyToClipboard>
         </div>
         <div>
           <SyntaxHighlighter

--- a/src/core/plugins/request-snippets/request-snippets.jsx
+++ b/src/core/plugins/request-snippets/request-snippets.jsx
@@ -133,7 +133,7 @@ const RequestSnippets = ({ request, requestSnippetsSelectors, getComponent }) =>
           </div>
           <div className="copy-to-clipboard">
             <CopyToClipboard text={snippet}>
-              <button />
+              <button type="button">Copy</button>
             </CopyToClipboard>
           </div>
           <div>

--- a/src/style/_buttons.scss
+++ b/src/style/_buttons.scss
@@ -180,15 +180,20 @@ button {
   background: none;
 }
 
-// overrides for smaller copy button for curl command
+// overrides for copy button with visible label for curl command
 .curl-command .copy-to-clipboard {
   bottom: 5px;
   right: 10px;
-  width: 20px;
+  width: auto;
   height: 20px;
 
   button {
     height: 18px;
+    padding: 0 8px 0 22px;
+    color: #fff;
+    font-size: 12px;
+    line-height: 18px;
+    background-position: 5px center;
   }
 }
 

--- a/src/style/_dark-mode.scss
+++ b/src/style/_dark-mode.scss
@@ -359,6 +359,11 @@ html.dark-mode {
       }
     }
 
+    .curl-command .copy-to-clipboard button {
+      color: $neutral-20;
+      background-position: 5px center;
+    }
+
     // ------ TAG ------
 
     .opblock-tag {


### PR DESCRIPTION
## Description

Adds a visible "Copy" label to the curl copy-to-clipboard buttons, which were previously icon-only.

- `src/core/components/curl.jsx` — Curl block shown after executing a request
- `src/core/plugins/request-snippets/request-snippets.jsx` — request-snippets panel
- `src/style/_buttons.scss` — widen the curl copy button and left-align the icon so the label fits
- `src/style/_dark-mode.scss` — matching dark-mode override for icon position and label color

## Motivation and Context

The copy button rendered only a clipboard icon, which is not obvious as an interactive control. A visible "Copy" label improves discoverability.

## How Has This Been Tested?

`npm run lint` (stylelint clean; no new ESLint warnings) and `npm run build` (all bundles compile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)