### PR TITLE
fix: allow empty only fix: actually allowed an empty value before a value was selected once, and not reset

### DIFF
--- a/src/core/components/parameter-row.jsx
+++ b/src/core/components/parameter-row.jsx
@@ -68,8 +68,12 @@ export default class ParameterRow extends Component {
     let { onChange, rawParam } = this.props
     let valueForUpstream
 
-    // Coerce empty strings and empty Immutable objects to null
-    if(value === "" || (value && value.size === 0)) {
+    // Coerce empty strings, empty Immutable objects, and empty arrays to null
+    if(
+      value === "" ||
+      (value && value.size === 0) ||
+      (Array.isArray(value) && value.length === 0)
+    ) {
       valueForUpstream = null
     } else {
       valueForUpstream = value

--- a/src/core/plugins/spec/actions.js
+++ b/src/core/plugins/spec/actions.js
@@ -390,8 +390,12 @@ export const executeRequest = (req) =>
             req.parameters = req.parameters || {}
             const paramValue = paramToValue(param, req.parameters)
 
-            // if the value is falsy or an empty Immutable iterable...
-            if(!paramValue || (paramValue && paramValue.size === 0)) {
+            // if the value is falsy, an empty Immutable iterable, or an empty array...
+            if(
+              !paramValue ||
+              (paramValue && paramValue.size === 0) ||
+              (Array.isArray(paramValue) && paramValue.length === 0)
+            ) {
               // set it to empty string, so Swagger Client will treat it as
               // present but empty.
               req.parameters[param.get("name")] = ""

--- a/test/unit/components/parameter-row.jsx
+++ b/test/unit/components/parameter-row.jsx
@@ -147,6 +147,23 @@ describe("<ParameterRow/>", () => {
     expect(wrapper.find(".parameter__type").length).toEqual(1)
     expect(wrapper.find(".parameter__type").text()).toEqual("boolean")
   })
+
+  it("coerces empty array parameter values to null", () => {
+    const param = fromJS({
+      name: "status",
+      in: "query",
+      value: ["available"],
+    })
+    const props = {
+      ...createProps({ param, isOAS3: true }),
+      onChange: jest.fn(),
+    }
+    const parameterRow = new ParameterRow(props)
+
+    parameterRow.onChangeWrapper([])
+
+    expect(props.onChange).toHaveBeenCalledWith(param, null, false)
+  })
 })
 
 describe("bug #5573: zero default and example values", function () {

--- a/test/unit/core/plugins/spec/actions.js
+++ b/test/unit/core/plugins/spec/actions.js
@@ -142,6 +142,65 @@ describe("spec plugin - actions", function(){
       expect(system.specActions.setMutatedRequest.mock.calls.length).toEqual(1)
       expect(system.specActions.setRequest.mock.calls.length).toEqual(1)
     })
+
+    it("should send explicitly included empty array parameters as empty strings", async () => {
+      // Given
+      const system = {
+        fn: {
+          buildRequest: jest.fn(req => req),
+          execute: jest.fn().mockImplementation(() => Promise.resolve({}))
+        },
+        specActions: {
+          setMutatedRequest: jest.fn(),
+          setRequest: jest.fn(),
+          setResponse: jest.fn()
+        },
+        specSelectors: {
+          parameterInclusionSettingFor: () => true,
+          url: () => "http://example.com/openapi.json",
+          isOAS3: () => false
+        },
+        getConfigs: () => ({
+          requestInterceptor: jest.fn(),
+          responseInterceptor: jest.fn()
+        })
+      }
+      // When
+      let executeFn = executeRequest({
+        pathName: "/pets",
+        method: "GET",
+        operation: fromJS({
+          operationId: "findPets",
+          parameters: [
+            {
+              name: "status",
+              in: "query",
+              allowEmptyValue: true
+            }
+          ]
+        }),
+        parameters: {
+          status: []
+        }
+      })
+      await executeFn(system)
+
+      // Then
+      expect(system.fn.buildRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          parameters: {
+            status: ""
+          }
+        })
+      )
+      expect(system.fn.execute).toHaveBeenCalledWith(
+        expect.objectContaining({
+          parameters: {
+            status: ""
+          }
+        })
+      )
+    })
   })
 
   xit("should call specActions.setResponse, when fn.execute resolves", function(){


### PR DESCRIPTION
### Description
The allow empty option works if you had never selected a value in the array selector widget. As soon as you selected, and unselected, something though, it would never send ?state= again. Only a refresh would allow this to work again.

fixes: #10941

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change fixes an incoming issue where allow empty does not function properly after a value for the array is selected / unselected once.
<!--- If it fixes an open issue, please link to the issue here. -->
I will create an issue and tag it momentarily.
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->



### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
I have tested this locally, as well as included tests in the PR. 
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I used an api spec similar to this:
``` json
{
                        "name": "status",
                        "in": "query",
                        "description": "Find Something.",
                        "style": "form",
                        "explode": true,
                        "allowEmptyValue": true,
                        "schema": {
                            "anyOf": [
                                {
                                    "type": "array",
                                    "items": {
                                        "type": "string",
                                        "description": "Something.",
                                        "enum": [
                                            "FOO",
                                            "BAR"
                                        ]
                                    }
                                },
                                {
                                    "type": "null"
                                }
                                
                            ]
                        }
                    },
```
it functioned properly after my fix.

### Screenshots (if appropriate):
<img width="828" height="532" alt="Screenshot 2026-06-24 at 9 28 32 AM" src="https://github.com/user-attachments/assets/04dd6f8e-02bb-4b0f-80ad-8456fc7af7a8" />



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
