### PR TITLE
fix: use array widget when using a OA 3.1 foldable array

### DIFF
--- a/src/core/plugins/json-schema-5/components/json-schema-components.jsx
+++ b/src/core/plugins/json-schema-5/components/json-schema-components.jsx
@@ -57,8 +57,16 @@ export class JsonSchemaForm extends Component {
       getComponentSilently(`JsonSchema_${type}`) :
       getComponent("JsonSchema_string")
 
-    if (!isFileUploadIntended && List.isList(type) && (objectType === "array" || objectType === "object")) {
-      Comp = getComponent("JsonSchema_object")
+    if (!isFileUploadIntended && List.isList(type)) {
+      // OpenAPI 3.1 type lists (e.g. ["array", "null"] or ["object", "null"])
+      // fold down to a primary type. Render the dedicated widget for that type
+      // so nullable arrays/objects keep their pickers instead of falling back
+      // to the raw JSON editor.
+      if (objectType === "array") {
+        Comp = getComponent("JsonSchema_array")
+      } else if (objectType === "object") {
+        Comp = getComponent("JsonSchema_object")
+      }
     }
 
     if (!Comp) {

--- a/test/unit/core/plugins/json-schema-5/components/json-schema-form.jsx
+++ b/test/unit/core/plugins/json-schema-5/components/json-schema-form.jsx
@@ -3,6 +3,7 @@ import Immutable, { List } from "immutable"
 import { Select, Input, TextArea } from "core/components/layout-utils"
 import { mount, render } from "enzyme"
 import { getSchemaObjectType } from "core/plugins/json-schema-5-samples/fn/index"
+import { foldType } from "core/plugins/json-schema-2020-12-samples/fn/core/type"
 import * as JsonSchemaComponents from "core/plugins/json-schema-5/components/json-schema-components"
 import { makeIsFileUploadIntended } from "core/plugins/oas3/fn"
 
@@ -243,6 +244,94 @@ describe("<JsonSchemaComponents.JsonSchemaForm/>", function(){
       expect(wrapper.find("textarea").text()).toEqual(`{\n  "id": "abc123"\n}`)
     })
   })
+  describe("nullable arrays (OpenAPI 3.1 type lists)", function() {
+    // In OAS 3.1/3.2, `getSchemaObjectType` is `foldType`, which folds a type
+    // list such as ["array", "null"] down to "array".
+    const oas31Fn = {
+      getSchemaObjectType: (schema) => foldType(schema?.toJS?.()?.type),
+      getSchemaObjectTypeLabel: (schema) => foldType(schema?.toJS?.()?.type),
+      isFileUploadIntended: makeIsFileUploadIntended(getSystemStub),
+    }
+
+    it("renders the array enum picker (Select) for a single 'array' type", function(){
+      let props = {
+        getComponent: getComponentStub,
+        value: List(),
+        onChange: () => {},
+        keyName: "",
+        fn: oas31Fn,
+        errors: List(),
+        schema: Immutable.fromJS({
+          type: "array",
+          items: {
+            type: "string",
+            enum: ["ACTIVE", "INACTIVE", "DELETED"]
+          }
+        })
+      }
+
+      let wrapper = mount(<JsonSchemaComponents.JsonSchemaForm {...props}/>)
+
+      // The "array picker" widget is a multi-select dropdown of the enum values.
+      expect(wrapper.find("select").length).toEqual(1)
+      expect(wrapper.find("select").props().multiple).toEqual(true)
+      const optionLabels = wrapper.find("select option").map((o) => o.text())
+      expect(optionLabels).toEqual(expect.arrayContaining(["ACTIVE", "INACTIVE", "DELETED"]))
+      expect(wrapper.find("textarea").length).toEqual(0)
+    })
+
+    it("renders the array enum picker for a nullable array type [\"array\", \"null\"] (#9056)", function(){
+      let props = {
+        getComponent: getComponentStub,
+        value: List(),
+        onChange: () => {},
+        keyName: "",
+        fn: oas31Fn,
+        errors: List(),
+        schema: Immutable.fromJS({
+          // Idiomatic OpenAPI 3.1 way to express a nullable array.
+          type: ["array", "null"],
+          items: {
+            type: "string",
+            enum: ["ACTIVE", "INACTIVE", "DELETED"]
+          }
+        })
+      }
+
+      let wrapper = mount(<JsonSchemaComponents.JsonSchemaForm {...props}/>)
+
+      // Regression for swagger-api/swagger-ui#9056: a nullable array must still
+      // render the array enum picker, not the generic object/JSON textarea.
+      expect(wrapper.find("select").length).toEqual(1)
+      expect(wrapper.find("select").props().multiple).toEqual(true)
+      const optionLabels = wrapper.find("select option").map((o) => o.text())
+      expect(optionLabels).toEqual(expect.arrayContaining(["ACTIVE", "INACTIVE", "DELETED"]))
+      expect(wrapper.find("textarea").length).toEqual(0)
+    })
+
+    it("renders the JSON editor for a nullable object type [\"object\", \"null\"]", function(){
+      let props = {
+        getComponent: getComponentStub,
+        value: `{\n  "id": "abc123"\n}`,
+        onChange: () => {},
+        keyName: "",
+        fn: oas31Fn,
+        errors: List(),
+        schema: Immutable.fromJS({
+          type: ["object", "null"],
+          properties: {
+            id: { type: "string", example: "abc123" }
+          }
+        })
+      }
+
+      let wrapper = mount(<JsonSchemaComponents.JsonSchemaForm {...props}/>)
+
+      // Nullable objects keep the existing JSON editor behavior.
+      expect(wrapper.find("textarea").length).toEqual(1)
+    })
+  })
+
   describe("unknown types", function() {
     it("should render unknown types as strings", function(){
 


### PR DESCRIPTION
### Description
When using OA 3.1 and a type like ["array", "null"], the gross json editor was shown, instead of the gorgeous array item picker.


### Motivation and Context
This is required because this is a bug.
Fixes: #10943 


### How Has This Been Tested?
A unit test was added first that recreated the issue, then when we did the code-fixes the test began to pass. We also loaded this into our application using swagger that highlighted the issue, and it properly went away.

### Screenshots (if appropriate):
<img width="372" height="143" alt="Screenshot 2026-06-24 at 7 55 00 PM" src="https://github.com/user-attachments/assets/6d2dd655-0177-4d68-9f2c-70cfbbac1c7c" />



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
