### PR TITLE
feat (change-history): add sidebar with topbar toggle

### DIFF
--- a/src/core/config/defaults.js
+++ b/src/core/config/defaults.js
@@ -19,6 +19,10 @@ const defaultOptions = Object.freeze({
   persistAuthorization: false,
   changeHistory: true,
   changeHistoryMaxEntries: 20,
+  // --- soft cap for the full-spec snapshot persisted to localStorage (UTF-8 bytes)
+  changeHistoryMaxSnapshotBytes: 512 * 1024,
+  // --- drop change-history data older than this (30 days)
+  changeHistoryTtlMs: 30 * 24 * 60 * 60 * 1000,
   configs: {},
   displayOperationId: false,
   displayRequestDuration: false,

--- a/src/core/config/defaults.js
+++ b/src/core/config/defaults.js
@@ -17,6 +17,8 @@ const defaultOptions = Object.freeze({
   validatorUrl: "https://validator.swagger.io/validator",
   oauth2RedirectUrl: undefined,
   persistAuthorization: false,
+  changeHistory: true,
+  changeHistoryMaxEntries: 20,
   configs: {},
   displayOperationId: false,
   displayRequestDuration: false,

--- a/src/core/containers/change-history.jsx
+++ b/src/core/containers/change-history.jsx
@@ -1,0 +1,56 @@
+import React from "react"
+import PropTypes from "prop-types"
+
+import ChangeHistorySidebar from "core/plugins/change-history/components/ChangeHistorySidebar"
+
+export default class ChangeHistoryContainer extends React.Component {
+  static propTypes = {
+    changeHistorySelectors: PropTypes.object.isRequired,
+    changeHistoryActions: PropTypes.object.isRequired,
+    specSelectors: PropTypes.object.isRequired,
+    getComponent: PropTypes.func.isRequired,
+    getConfigs: PropTypes.func.isRequired,
+  }
+
+  onClose = () => {
+    this.props.changeHistoryActions.setPanelOpen(false)
+  }
+
+  onClear = () => {
+    this.props.changeHistoryActions.clearHistory()
+  }
+
+  render() {
+    const { changeHistorySelectors, specSelectors, getComponent, getConfigs } =
+      this.props
+    const configs = getConfigs()
+
+    if (configs.changeHistory === false) {
+      return null
+    }
+
+    const isLoading = specSelectors.loadingStatus() === "loading"
+    const isPanelOpen = changeHistorySelectors.isPanelOpen()
+    const history = changeHistorySelectors.history()
+
+    if (isLoading || !isPanelOpen) {
+      return null
+    }
+
+    return (
+      <>
+        <div
+          className="change-history-backdrop"
+          onClick={this.onClose}
+          role="presentation"
+        />
+        <ChangeHistorySidebar
+          history={history}
+          onClose={this.onClose}
+          onClear={this.onClear}
+          getComponent={getComponent}
+        />
+      </>
+    )
+  }
+}

--- a/src/core/plugins/change-history/actions.js
+++ b/src/core/plugins/change-history/actions.js
@@ -1,0 +1,32 @@
+export const SET_HISTORY = "change_history_set_history"
+export const SET_PANEL_OPEN = "change_history_set_panel_open"
+export const SET_UNSEEN_CHANGES = "change_history_set_unseen_changes"
+export const SET_STORAGE_KEY = "change_history_set_storage_key"
+
+export function setHistory(history) {
+  return {
+    type: SET_HISTORY,
+    payload: history,
+  }
+}
+
+export function setPanelOpen(isOpen) {
+  return {
+    type: SET_PANEL_OPEN,
+    payload: isOpen,
+  }
+}
+
+export function setUnseenChanges(hasUnseenChanges) {
+  return {
+    type: SET_UNSEEN_CHANGES,
+    payload: hasUnseenChanges,
+  }
+}
+
+export function setStorageKey(storageKey) {
+  return {
+    type: SET_STORAGE_KEY,
+    payload: storageKey,
+  }
+}

--- a/src/core/plugins/change-history/components/ChangeHistorySidebar.jsx
+++ b/src/core/plugins/change-history/components/ChangeHistorySidebar.jsx
@@ -1,0 +1,106 @@
+import React from "react"
+import PropTypes from "prop-types"
+
+import { formatChangeSummary } from "core/plugins/change-history/fn"
+
+class ChangeHistorySidebar extends React.Component {
+  static propTypes = {
+    history: PropTypes.object,
+    onClose: PropTypes.func.isRequired,
+    onClear: PropTypes.func.isRequired,
+    getComponent: PropTypes.func.isRequired,
+  }
+
+  formatTimestamp(timestamp) {
+    return new Date(timestamp).toLocaleString()
+  }
+
+  renderChange(change, index) {
+    const isAddition = change.type.includes("added")
+    const isRemoval = change.type.includes("removed")
+    const className = [
+      "change-history-item",
+      isAddition ? "change-added" : "",
+      isRemoval ? "change-removed" : "",
+      !isAddition && !isRemoval ? "change-modified" : "",
+    ]
+      .filter(Boolean)
+      .join(" ")
+
+    return (
+      <li key={`${change.type}-${index}`} className={className}>
+        {formatChangeSummary(change)}
+      </li>
+    )
+  }
+
+  renderEntry(entry, index) {
+    const changes = entry.changes || []
+    const isBaseline = entry.isBaseline
+    const timestamp = entry.timestamp
+    const version = entry.version
+    const title = entry.title
+
+    return (
+      <div key={entry.id || index} className="change-history-entry">
+        <div className="change-history-entry-header">
+          <span className="change-history-entry-time">
+            {this.formatTimestamp(timestamp)}
+          </span>
+          {version ? (
+            <span className="change-history-entry-version">v{version}</span>
+          ) : null}
+          {title ? <span className="change-history-entry-title">{title}</span> : null}
+        </div>
+
+        {isBaseline ? (
+          <p className="change-history-baseline">Initial snapshot saved</p>
+        ) : changes.length ? (
+          <ul className="change-history-changes">
+            {changes.map((change, changeIndex) =>
+              this.renderChange(change, changeIndex)
+            )}
+          </ul>
+        ) : (
+          <p className="change-history-no-changes">No structural changes detected</p>
+        )}
+      </div>
+    )
+  }
+
+  render() {
+    const { history, onClose, onClear, getComponent } = this.props
+    const Button = getComponent("Button")
+    const entries = history?.toJS?.() || history || []
+
+    return (
+      <aside className="change-history-sidebar" aria-label="API change history">
+        <div className="change-history-sidebar-header">
+          <h4>API Change History</h4>
+          <div className="change-history-sidebar-actions">
+            {entries.length ? (
+              <Button className="btn change-history-clear-btn" onClick={onClear}>
+                Clear history
+              </Button>
+            ) : null}
+            <Button className="btn change-history-close-btn" onClick={onClose}>
+              Close
+            </Button>
+          </div>
+        </div>
+
+        {!entries.length ? (
+          <p className="change-history-empty">
+            No history yet. Reload the spec after backend changes to capture diffs.
+          </p>
+        ) : (
+          <div className="change-history-entries">
+            {entries.map((entry, index) => this.renderEntry(entry, index))}
+          </div>
+        )}
+      </aside>
+    )
+  }
+}
+
+export default ChangeHistorySidebar

--- a/src/core/plugins/change-history/fn.js
+++ b/src/core/plugins/change-history/fn.js
@@ -603,3 +603,102 @@ export function formatChangeSummary(change) {
 export const STORAGE_PREFIX = "swagger-ui-change-history"
 export const SNAPSHOT_PREFIX = "swagger-ui-change-snapshot"
 export const VIEWED_PREFIX = "swagger-ui-change-history-viewed"
+
+/** Soft cap for a single persisted snapshot (UTF-8 bytes). */
+export const DEFAULT_MAX_SNAPSHOT_BYTES = 512 * 1024
+
+/** Drop history/snapshots older than this (30 days). */
+export const DEFAULT_TTL_MS = 30 * 24 * 60 * 60 * 1000
+
+export function getSerializedByteLength(value) {
+  const text = typeof value === "string" ? value : JSON.stringify(value)
+  if (typeof TextEncoder !== "undefined") {
+    return new TextEncoder().encode(text).length
+  }
+  return text.length
+}
+
+export function wrapSnapshot(spec, savedAt = Date.now()) {
+  return { savedAt, spec }
+}
+
+export function wrapOversizedSnapshotMarker(specHash, savedAt = Date.now()) {
+  return { savedAt, oversized: true, specHash }
+}
+
+export function unwrapSnapshot(value, { ttlMs, now = Date.now() } = {}) {
+  if (!value || typeof value !== "object") {
+    return null
+  }
+
+  // Oversized markers intentionally omit the full spec
+  if (value.oversized) {
+    return null
+  }
+
+  const isWrapped =
+    Object.prototype.hasOwnProperty.call(value, "spec") &&
+    Object.prototype.hasOwnProperty.call(value, "savedAt")
+
+  const spec = isWrapped ? value.spec : value
+  const savedAt = isWrapped ? value.savedAt : null
+
+  if (!spec || typeof spec !== "object") {
+    return null
+  }
+
+  if (
+    savedAt != null &&
+    ttlMs != null &&
+    ttlMs > 0 &&
+    now - savedAt > ttlMs
+  ) {
+    return null
+  }
+
+  return { spec, savedAt }
+}
+
+export function isOversizedSnapshotMarker(value, { ttlMs, now = Date.now() } = {}) {
+  if (!value || typeof value !== "object" || !value.oversized) {
+    return false
+  }
+
+  if (
+    value.savedAt != null &&
+    ttlMs != null &&
+    ttlMs > 0 &&
+    now - value.savedAt > ttlMs
+  ) {
+    return false
+  }
+
+  return true
+}
+
+export function filterHistoryByTtl(history, ttlMs, now = Date.now()) {
+  if (!Array.isArray(history)) {
+    return []
+  }
+
+  if (!ttlMs || ttlMs <= 0) {
+    return history
+  }
+
+  return history.filter(
+    (entry) =>
+      entry &&
+      typeof entry.timestamp === "number" &&
+      now - entry.timestamp <= ttlMs
+  )
+}
+
+export function canPersistSnapshot(spec, maxBytes, savedAt = Date.now()) {
+  if (!maxBytes || maxBytes <= 0) {
+    return true
+  }
+
+  return (
+    getSerializedByteLength(wrapSnapshot(spec, savedAt)) <= maxBytes
+  )
+}

--- a/src/core/plugins/change-history/fn.js
+++ b/src/core/plugins/change-history/fn.js
@@ -1,0 +1,605 @@
+const HTTP_METHODS = [
+  "get",
+  "put",
+  "post",
+  "delete",
+  "options",
+  "head",
+  "patch",
+  "trace",
+]
+
+const INFO_FIELDS = ["title", "version", "description"]
+
+const OPERATION_FIELDS = ["summary", "description", "operationId", "deprecated"]
+
+const PARAMETER_FIELDS = ["required", "description", "schema", "type"]
+
+export function stableStringify(value) {
+  if (value === null || value === undefined) {
+    return "null"
+  }
+
+  if (typeof value !== "object") {
+    return JSON.stringify(value)
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`
+  }
+
+  const keys = Object.keys(value).sort()
+  return `{${keys
+    .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`)
+    .join(",")}}`
+}
+
+export function hashSpec(spec) {
+  return simpleHash(stableStringify(spec))
+}
+
+function simpleHash(str) {
+  let hash = 0
+
+  for (let i = 0; i < str.length; i++) {
+    hash = (hash << 5) - hash + str.charCodeAt(i)
+    hash |= 0
+  }
+
+  return hash.toString(36)
+}
+
+export function getStorageKey(url, spec) {
+  if (url) {
+    return url
+  }
+
+  const title = spec?.info?.title
+  if (title) {
+    return `inline:${title}`
+  }
+
+  return "inline"
+}
+
+function getByPointer(root, ref) {
+  const path = ref
+    .slice(2)
+    .split("/")
+    .map((segment) => segment.replace(/~1/g, "/").replace(/~0/g, "~"))
+
+  let current = root
+
+  for (const segment of path) {
+    if (current == null || typeof current !== "object") {
+      return undefined
+    }
+    current = current[segment]
+  }
+
+  return current
+}
+
+/**
+ * Dereferences internal ($ref: "#/...") pointers so that structural changes to
+ * a referenced schema surface on every operation that uses it. Circular
+ * references are left intact via a per-branch resolution stack.
+ */
+export function resolveRefs(spec) {
+  if (!spec || typeof spec !== "object") {
+    return spec
+  }
+
+  const resolve = (node, stack) => {
+    if (Array.isArray(node)) {
+      return node.map((item) => resolve(item, stack))
+    }
+
+    if (node && typeof node === "object") {
+      const ref = node.$ref
+
+      if (typeof ref === "string" && ref.startsWith("#/")) {
+        if (stack.includes(ref)) {
+          return { $ref: ref }
+        }
+
+        const target = getByPointer(spec, ref)
+
+        if (target === undefined) {
+          return node
+        }
+
+        return resolve(target, [...stack, ref])
+      }
+
+      const out = {}
+      for (const key of Object.keys(node)) {
+        out[key] = resolve(node[key], stack)
+      }
+      return out
+    }
+
+    return node
+  }
+
+  return resolve(spec, [])
+}
+
+function getOperationMap(spec) {
+  const map = new Map()
+  const paths = spec?.paths || {}
+
+  Object.keys(paths).forEach((path) => {
+    const pathItem = paths[path]
+
+    HTTP_METHODS.forEach((method) => {
+      if (pathItem?.[method]) {
+        map.set(`${method.toUpperCase()} ${path}`, {
+          path,
+          method: method.toUpperCase(),
+          operation: pathItem[method],
+        })
+      }
+    })
+  })
+
+  return map
+}
+
+function getSchemas(spec) {
+  if (spec?.components?.schemas) {
+    return spec.components.schemas
+  }
+
+  if (spec?.definitions) {
+    return spec.definitions
+  }
+
+  return {}
+}
+
+function paramKey(param) {
+  return `${param.in}:${param.name}`
+}
+
+function compareInfo(oldSpec, newSpec, changes) {
+  const oldInfo = oldSpec?.info || {}
+  const newInfo = newSpec?.info || {}
+
+  INFO_FIELDS.forEach((field) => {
+    if (oldInfo[field] !== newInfo[field]) {
+      changes.push({
+        type: "info-changed",
+        field,
+        oldValue: oldInfo[field],
+        newValue: newInfo[field],
+      })
+    }
+  })
+}
+
+function compareTags(oldSpec, newSpec, changes) {
+  const oldTags = new Set((oldSpec?.tags || []).map((tag) => tag.name))
+  const newTags = new Set((newSpec?.tags || []).map((tag) => tag.name))
+
+  newTags.forEach((tag) => {
+    if (!oldTags.has(tag)) {
+      changes.push({ type: "tag-added", name: tag })
+    }
+  })
+
+  oldTags.forEach((tag) => {
+    if (!newTags.has(tag)) {
+      changes.push({ type: "tag-removed", name: tag })
+    }
+  })
+}
+
+function compareSecurity(oldSpec, newSpec, changes) {
+  if (
+    stableStringify(oldSpec?.security) !== stableStringify(newSpec?.security)
+  ) {
+    changes.push({ type: "security-changed" })
+  }
+}
+
+function compareParameters(oldParams, newParams, changes, context) {
+  const oldMap = new Map(
+    (oldParams || []).map((param) => [paramKey(param), param])
+  )
+  const newMap = new Map(
+    (newParams || []).map((param) => [paramKey(param), param])
+  )
+
+  newMap.forEach((param, key) => {
+    if (!oldMap.has(key)) {
+      changes.push({
+        type: "parameter-added",
+        ...context,
+        parameter: param.name,
+        location: param.in,
+      })
+    }
+  })
+
+  oldMap.forEach((param, key) => {
+    if (!newMap.has(key)) {
+      changes.push({
+        type: "parameter-removed",
+        ...context,
+        parameter: param.name,
+        location: param.in,
+      })
+    }
+  })
+
+  oldMap.forEach((oldParam, key) => {
+    if (!newMap.has(key)) {
+      return
+    }
+
+    const newParam = newMap.get(key)
+    const fields = PARAMETER_FIELDS.filter(
+      (field) =>
+        stableStringify(oldParam[field]) !== stableStringify(newParam[field])
+    )
+
+    if (fields.length) {
+      changes.push({
+        type: "parameter-modified",
+        ...context,
+        parameter: oldParam.name,
+        location: oldParam.in,
+        fields,
+      })
+    }
+  })
+}
+
+function compareResponses(oldResponses, newResponses, changes, context) {
+  const oldCodes = new Set(Object.keys(oldResponses || {}))
+  const newCodes = new Set(Object.keys(newResponses || {}))
+
+  newCodes.forEach((code) => {
+    if (!oldCodes.has(code)) {
+      changes.push({
+        type: "response-added",
+        ...context,
+        statusCode: code,
+      })
+    }
+  })
+
+  oldCodes.forEach((code) => {
+    if (!newCodes.has(code)) {
+      changes.push({
+        type: "response-removed",
+        ...context,
+        statusCode: code,
+      })
+    }
+  })
+
+  oldCodes.forEach((code) => {
+    if (!newCodes.has(code)) {
+      return
+    }
+
+    const oldResponse = oldResponses[code]
+    const newResponse = newResponses[code]
+
+    if (stableStringify(oldResponse) === stableStringify(newResponse)) {
+      return
+    }
+
+    changes.push({
+      type: "response-modified",
+      ...context,
+      statusCode: code,
+    })
+
+    const oldMediaTypes = new Set(Object.keys(oldResponse?.content || {}))
+    const newMediaTypes = new Set(Object.keys(newResponse?.content || {}))
+
+    newMediaTypes.forEach((mediaType) => {
+      if (!oldMediaTypes.has(mediaType)) {
+        changes.push({
+          type: "response-content-added",
+          ...context,
+          statusCode: code,
+          mediaType,
+        })
+      }
+    })
+
+    oldMediaTypes.forEach((mediaType) => {
+      if (!newMediaTypes.has(mediaType)) {
+        changes.push({
+          type: "response-content-removed",
+          ...context,
+          statusCode: code,
+          mediaType,
+        })
+      }
+    })
+  })
+}
+
+function compareOperation(oldOperation, newOperation, changes, context) {
+  const fields = OPERATION_FIELDS.filter(
+    (field) => oldOperation[field] !== newOperation[field]
+  )
+
+  if (fields.length) {
+    changes.push({
+      type: "endpoint-modified",
+      ...context,
+      fields,
+    })
+  }
+
+  if (
+    stableStringify(oldOperation.tags || []) !==
+    stableStringify(newOperation.tags || [])
+  ) {
+    changes.push({
+      type: "endpoint-tags-changed",
+      ...context,
+    })
+  }
+
+  if (
+    stableStringify(oldOperation.security) !==
+    stableStringify(newOperation.security)
+  ) {
+    changes.push({
+      type: "endpoint-security-changed",
+      ...context,
+    })
+  }
+
+  compareParameters(
+    oldOperation.parameters,
+    newOperation.parameters,
+    changes,
+    context
+  )
+
+  if (
+    stableStringify(oldOperation.requestBody) !==
+    stableStringify(newOperation.requestBody)
+  ) {
+    changes.push({
+      type: "request-body-modified",
+      ...context,
+    })
+  }
+
+  compareResponses(
+    oldOperation.responses,
+    newOperation.responses,
+    changes,
+    context
+  )
+}
+
+function comparePaths(oldSpec, newSpec, changes) {
+  const oldOps = getOperationMap(oldSpec)
+  const newOps = getOperationMap(newSpec)
+
+  newOps.forEach((entry, key) => {
+    if (!oldOps.has(key)) {
+      changes.push({
+        type: "endpoint-added",
+        path: entry.path,
+        method: entry.method,
+        summary: entry.operation.summary,
+      })
+    }
+  })
+
+  oldOps.forEach((entry, key) => {
+    if (!newOps.has(key)) {
+      changes.push({
+        type: "endpoint-removed",
+        path: entry.path,
+        method: entry.method,
+      })
+    }
+  })
+
+  oldOps.forEach((oldEntry, key) => {
+    if (!newOps.has(key)) {
+      return
+    }
+
+    const newEntry = newOps.get(key)
+    compareOperation(oldEntry.operation, newEntry.operation, changes, {
+      path: oldEntry.path,
+      method: oldEntry.method,
+    })
+  })
+}
+
+function compareSchemaObject(name, oldSchema, newSchema, changes) {
+  const oldProps = oldSchema?.properties || {}
+  const newProps = newSchema?.properties || {}
+  const oldPropNames = new Set(Object.keys(oldProps))
+  const newPropNames = new Set(Object.keys(newProps))
+
+  newPropNames.forEach((property) => {
+    if (!oldPropNames.has(property)) {
+      changes.push({ type: "schema-property-added", name, property })
+    }
+  })
+
+  oldPropNames.forEach((property) => {
+    if (!newPropNames.has(property)) {
+      changes.push({ type: "schema-property-removed", name, property })
+    }
+  })
+
+  oldPropNames.forEach((property) => {
+    if (!newPropNames.has(property)) {
+      return
+    }
+
+    if (
+      stableStringify(oldProps[property]) !==
+      stableStringify(newProps[property])
+    ) {
+      changes.push({ type: "schema-property-modified", name, property })
+    }
+  })
+
+  const oldRequired = new Set(oldSchema?.required || [])
+  const newRequired = new Set(newSchema?.required || [])
+
+  newRequired.forEach((property) => {
+    if (!oldRequired.has(property)) {
+      changes.push({ type: "schema-required-added", name, property })
+    }
+  })
+
+  oldRequired.forEach((property) => {
+    if (!newRequired.has(property)) {
+      changes.push({ type: "schema-required-removed", name, property })
+    }
+  })
+
+  if (oldSchema?.type !== newSchema?.type) {
+    changes.push({
+      type: "schema-type-changed",
+      name,
+      oldValue: oldSchema?.type,
+      newValue: newSchema?.type,
+    })
+  }
+}
+
+function compareSchemas(oldSpec, newSpec, changes) {
+  const oldSchemas = getSchemas(oldSpec)
+  const newSchemas = getSchemas(newSpec)
+  const oldNames = new Set(Object.keys(oldSchemas))
+  const newNames = new Set(Object.keys(newSchemas))
+
+  newNames.forEach((name) => {
+    if (!oldNames.has(name)) {
+      changes.push({ type: "schema-added", name })
+    }
+  })
+
+  oldNames.forEach((name) => {
+    if (!newNames.has(name)) {
+      changes.push({ type: "schema-removed", name })
+    }
+  })
+
+  oldNames.forEach((name) => {
+    if (!newNames.has(name)) {
+      return
+    }
+
+    const oldSchema = oldSchemas[name]
+    const newSchema = newSchemas[name]
+
+    if (stableStringify(oldSchema) === stableStringify(newSchema)) {
+      return
+    }
+
+    const before = changes.length
+    compareSchemaObject(name, oldSchema, newSchema, changes)
+
+    if (changes.length === before) {
+      changes.push({ type: "schema-modified", name })
+    }
+  })
+}
+
+export function compareSpecs(oldSpec, newSpec) {
+  if (!oldSpec || !newSpec) {
+    return []
+  }
+
+  const changes = []
+
+  // Operation-level comparison runs against dereferenced specs so that a change
+  // to a shared schema is attributed to every endpoint that references it.
+  const resolvedOldSpec = resolveRefs(oldSpec)
+  const resolvedNewSpec = resolveRefs(newSpec)
+
+  compareInfo(oldSpec, newSpec, changes)
+  compareTags(oldSpec, newSpec, changes)
+  compareSecurity(oldSpec, newSpec, changes)
+  comparePaths(resolvedOldSpec, resolvedNewSpec, changes)
+  // Schema-level comparison runs against the raw (unresolved) schemas so that
+  // property-level detail stays clean and is reported once per schema.
+  compareSchemas(oldSpec, newSpec, changes)
+
+  return changes
+}
+
+export function formatChangeSummary(change) {
+  switch (change.type) {
+    case "info-changed":
+      return `Info ${change.field} changed`
+    case "tag-added":
+      return `Tag "${change.name}" added`
+    case "tag-removed":
+      return `Tag "${change.name}" removed`
+    case "security-changed":
+      return "Global security requirements changed"
+    case "endpoint-added":
+      return `${change.method} ${change.path} added`
+    case "endpoint-removed":
+      return `${change.method} ${change.path} removed`
+    case "endpoint-modified":
+      return `${change.method} ${change.path} modified (${change.fields.join(", ")})`
+    case "endpoint-tags-changed":
+      return `${change.method} ${change.path}: tags changed`
+    case "endpoint-security-changed":
+      return `${change.method} ${change.path}: security changed`
+    case "parameter-added":
+      return `${change.method} ${change.path}: parameter "${change.parameter}" added (${change.location})`
+    case "parameter-removed":
+      return `${change.method} ${change.path}: parameter "${change.parameter}" removed (${change.location})`
+    case "parameter-modified":
+      return `${change.method} ${change.path}: parameter "${change.parameter}" modified (${change.fields.join(", ")})`
+    case "request-body-modified":
+      return `${change.method} ${change.path}: request body modified`
+    case "response-added":
+      return `${change.method} ${change.path}: response ${change.statusCode} added`
+    case "response-removed":
+      return `${change.method} ${change.path}: response ${change.statusCode} removed`
+    case "response-modified":
+      return `${change.method} ${change.path}: response ${change.statusCode} modified`
+    case "response-content-added":
+      return `${change.method} ${change.path}: response ${change.statusCode} added media type "${change.mediaType}"`
+    case "response-content-removed":
+      return `${change.method} ${change.path}: response ${change.statusCode} removed media type "${change.mediaType}"`
+    case "schema-added":
+      return `Schema "${change.name}" added`
+    case "schema-removed":
+      return `Schema "${change.name}" removed`
+    case "schema-modified":
+      return `Schema "${change.name}" modified`
+    case "schema-property-added":
+      return `Schema "${change.name}": property "${change.property}" added`
+    case "schema-property-removed":
+      return `Schema "${change.name}": property "${change.property}" removed`
+    case "schema-property-modified":
+      return `Schema "${change.name}": property "${change.property}" modified`
+    case "schema-required-added":
+      return `Schema "${change.name}": "${change.property}" is now required`
+    case "schema-required-removed":
+      return `Schema "${change.name}": "${change.property}" is no longer required`
+    case "schema-type-changed":
+      return `Schema "${change.name}": type changed (${change.oldValue} → ${change.newValue})`
+    default:
+      return "Unknown change"
+  }
+}
+
+export const STORAGE_PREFIX = "swagger-ui-change-history"
+export const SNAPSHOT_PREFIX = "swagger-ui-change-snapshot"
+export const VIEWED_PREFIX = "swagger-ui-change-history-viewed"

--- a/src/core/plugins/change-history/index.js
+++ b/src/core/plugins/change-history/index.js
@@ -1,0 +1,35 @@
+import * as actions from "./actions"
+import * as specActions from "./spec-actions"
+import reducers from "./reducers"
+import * as selectors from "./selectors"
+import * as wrapActions from "./wrap-actions"
+import ChangeHistoryContainer from "core/containers/change-history"
+import * as fn from "./fn"
+
+const ChangeHistoryPlugin = () => ({
+  statePlugins: {
+    changeHistory: {
+      actions: { ...actions, ...specActions },
+      reducers,
+      selectors,
+    },
+    spec: {
+      wrapActions: {
+        updateJsonSpec: wrapActions.updateJsonSpec,
+      },
+    },
+    configs: {
+      wrapActions: {
+        loaded: wrapActions.loaded,
+      },
+    },
+  },
+  components: {
+    ChangeHistoryContainer,
+  },
+  fn: {
+    ...fn,
+  },
+})
+
+export default ChangeHistoryPlugin

--- a/src/core/plugins/change-history/reducers.js
+++ b/src/core/plugins/change-history/reducers.js
@@ -1,0 +1,29 @@
+import { fromJS } from "immutable"
+
+import {
+  SET_HISTORY,
+  SET_PANEL_OPEN,
+  SET_UNSEEN_CHANGES,
+  SET_STORAGE_KEY,
+} from "./actions"
+
+const defaultState = fromJS({
+  history: [],
+  isPanelOpen: false,
+  hasUnseenChanges: false,
+  storageKey: null,
+})
+
+export default {
+  [SET_HISTORY]: (state, action) =>
+    state.set("history", fromJS(action.payload)),
+
+  [SET_PANEL_OPEN]: (state, action) => state.set("isPanelOpen", action.payload),
+
+  [SET_UNSEEN_CHANGES]: (state, action) =>
+    state.set("hasUnseenChanges", action.payload),
+
+  [SET_STORAGE_KEY]: (state, action) => state.set("storageKey", action.payload),
+}
+
+export { defaultState }

--- a/src/core/plugins/change-history/selectors.js
+++ b/src/core/plugins/change-history/selectors.js
@@ -1,0 +1,29 @@
+export function history(state) {
+  return state.get("history")
+}
+
+export function isPanelOpen(state) {
+  return state.get("isPanelOpen")
+}
+
+export function hasUnseenChanges(state) {
+  return state.get("hasUnseenChanges")
+}
+
+export function storageKey(state) {
+  return state.get("storageKey")
+}
+
+export function latestEntry(state) {
+  const entries = history(state)
+  if (!entries || !entries.size) {
+    return null
+  }
+
+  return entries.get(0)
+}
+
+export function hasHistory(state) {
+  const entries = history(state)
+  return Boolean(entries && entries.size)
+}

--- a/src/core/plugins/change-history/spec-actions.js
+++ b/src/core/plugins/change-history/spec-actions.js
@@ -1,10 +1,18 @@
 import {
+  canPersistSnapshot,
   compareSpecs,
+  DEFAULT_MAX_SNAPSHOT_BYTES,
+  DEFAULT_TTL_MS,
+  filterHistoryByTtl,
   getStorageKey,
   hashSpec,
+  isOversizedSnapshotMarker,
   SNAPSHOT_PREFIX,
   STORAGE_PREFIX,
+  unwrapSnapshot,
   VIEWED_PREFIX,
+  wrapOversizedSnapshotMarker,
+  wrapSnapshot,
 } from "./fn"
 
 function readJson(key, fallback) {
@@ -17,7 +25,27 @@ function readJson(key, fallback) {
 }
 
 function writeJson(key, value) {
-  localStorage.setItem(key, JSON.stringify(value))
+  try {
+    localStorage.setItem(key, JSON.stringify(value))
+    return true
+  } catch (err) {
+    console.warn(
+      "Swagger UI: unable to persist change history to localStorage",
+      err
+    )
+    return false
+  }
+}
+
+function removeKey(key) {
+  try {
+    localStorage.removeItem(key)
+  } catch (err) {
+    console.warn(
+      "Swagger UI: unable to remove change history from localStorage",
+      err
+    )
+  }
 }
 
 function getHistoryStorageKey(storageKey) {
@@ -30,6 +58,12 @@ function getSnapshotStorageKey(storageKey) {
 
 function getViewedStorageKey(storageKey) {
   return `${VIEWED_PREFIX}:${storageKey}`
+}
+
+function clearPersistedHistory(storageKey) {
+  removeKey(getHistoryStorageKey(storageKey))
+  removeKey(getSnapshotStorageKey(storageKey))
+  removeKey(getViewedStorageKey(storageKey))
 }
 
 export const recordSpecLoad = () => (system) => {
@@ -54,6 +88,10 @@ export const recordSpecLoad = () => (system) => {
   const storageKey = getStorageKey(url, spec)
   const specHash = hashSpec(spec)
   const maxEntries = configs.changeHistoryMaxEntries || 20
+  const maxSnapshotBytes =
+    configs.changeHistoryMaxSnapshotBytes ?? DEFAULT_MAX_SNAPSHOT_BYTES
+  const ttlMs = configs.changeHistoryTtlMs ?? DEFAULT_TTL_MS
+  const now = Date.now()
 
   changeHistoryActions.setStorageKey(storageKey)
 
@@ -61,15 +99,40 @@ export const recordSpecLoad = () => (system) => {
   const snapshotKey = getSnapshotStorageKey(storageKey)
   const viewedKey = getViewedStorageKey(storageKey)
 
-  const existingHistory = readJson(historyKey, [])
-  const previousSnapshot = readJson(snapshotKey, null)
+  const existingHistory = filterHistoryByTtl(
+    readJson(historyKey, []),
+    ttlMs,
+    now
+  )
+  const rawSnapshot = readJson(snapshotKey, null)
+  const previousSnapshotPayload = unwrapSnapshot(rawSnapshot, {
+    ttlMs,
+    now,
+  })
+  const previousSnapshot = previousSnapshotPayload
+    ? previousSnapshotPayload.spec
+    : null
   const lastViewedAt = readJson(viewedKey, 0)
+  const oversizedMarker = isOversizedSnapshotMarker(rawSnapshot, {
+    ttlMs,
+    now,
+  })
 
-  if (previousSnapshot && hashSpec(previousSnapshot) === specHash) {
+  // Drop expired / invalid snapshot payloads from disk
+  if (rawSnapshot && !previousSnapshotPayload && !oversizedMarker) {
+    removeKey(snapshotKey)
+  }
+
+  if (
+    (previousSnapshot && hashSpec(previousSnapshot) === specHash) ||
+    (oversizedMarker && rawSnapshot.specHash === specHash)
+  ) {
     changeHistoryActions.setHistory(existingHistory)
     changeHistoryActions.setUnseenChanges(
       existingHistory.some((entry) => entry.timestamp > lastViewedAt)
     )
+    // Keep history pruned on disk even when the snapshot is unchanged
+    writeJson(historyKey, existingHistory)
     return
   }
 
@@ -81,8 +144,8 @@ export const recordSpecLoad = () => (system) => {
 
   if (!previousSnapshot || changes.length) {
     const entry = {
-      id: `${Date.now()}`,
-      timestamp: Date.now(),
+      id: `${now}`,
+      timestamp: now,
       version: spec?.info?.version || null,
       title: spec?.info?.title || null,
       specHash,
@@ -92,7 +155,16 @@ export const recordSpecLoad = () => (system) => {
 
     const nextHistory = [entry, ...existingHistory].slice(0, maxEntries)
     writeJson(historyKey, nextHistory)
-    writeJson(snapshotKey, spec)
+
+    if (canPersistSnapshot(spec, maxSnapshotBytes, now)) {
+      writeJson(snapshotKey, wrapSnapshot(spec, now))
+    } else {
+      console.warn(
+        "Swagger UI: change-history snapshot exceeds size limit; skipping localStorage snapshot persistence"
+      )
+      // Keep a tiny marker so we do not re-baseline on every reload
+      writeJson(snapshotKey, wrapOversizedSnapshotMarker(specHash, now))
+    }
 
     changeHistoryActions.setHistory(nextHistory)
 
@@ -102,6 +174,7 @@ export const recordSpecLoad = () => (system) => {
     }
   } else {
     changeHistoryActions.setHistory(existingHistory)
+    writeJson(historyKey, existingHistory)
   }
 }
 
@@ -118,10 +191,29 @@ export const restoreHistory = () => (system) => {
     return
   }
 
+  const ttlMs = configs.changeHistoryTtlMs ?? DEFAULT_TTL_MS
+  const now = Date.now()
   const historyKey = getHistoryStorageKey(storageKey)
+  const snapshotKey = getSnapshotStorageKey(storageKey)
   const viewedKey = getViewedStorageKey(storageKey)
-  const existingHistory = readJson(historyKey, [])
+  const existingHistory = filterHistoryByTtl(
+    readJson(historyKey, []),
+    ttlMs,
+    now
+  )
   const lastViewedAt = readJson(viewedKey, 0)
+  const rawSnapshot = readJson(snapshotKey, null)
+
+  if (
+    rawSnapshot &&
+    !unwrapSnapshot(rawSnapshot, { ttlMs, now }) &&
+    !isOversizedSnapshotMarker(rawSnapshot, { ttlMs, now })
+  ) {
+    removeKey(snapshotKey)
+  }
+
+  // Persist pruned history so expired entries don't linger
+  writeJson(historyKey, existingHistory)
 
   changeHistoryActions.setHistory(existingHistory)
   changeHistoryActions.setUnseenChanges(
@@ -163,9 +255,7 @@ export const clearHistory = () => (system) => {
     return
   }
 
-  localStorage.removeItem(getHistoryStorageKey(storageKey))
-  localStorage.removeItem(getSnapshotStorageKey(storageKey))
-  localStorage.removeItem(getViewedStorageKey(storageKey))
+  clearPersistedHistory(storageKey)
 
   changeHistoryActions.setHistory([])
   changeHistoryActions.setUnseenChanges(false)

--- a/src/core/plugins/change-history/spec-actions.js
+++ b/src/core/plugins/change-history/spec-actions.js
@@ -1,0 +1,172 @@
+import {
+  compareSpecs,
+  getStorageKey,
+  hashSpec,
+  SNAPSHOT_PREFIX,
+  STORAGE_PREFIX,
+  VIEWED_PREFIX,
+} from "./fn"
+
+function readJson(key, fallback) {
+  try {
+    const value = localStorage.getItem(key)
+    return value ? JSON.parse(value) : fallback
+  } catch {
+    return fallback
+  }
+}
+
+function writeJson(key, value) {
+  localStorage.setItem(key, JSON.stringify(value))
+}
+
+function getHistoryStorageKey(storageKey) {
+  return `${STORAGE_PREFIX}:${storageKey}`
+}
+
+function getSnapshotStorageKey(storageKey) {
+  return `${SNAPSHOT_PREFIX}:${storageKey}`
+}
+
+function getViewedStorageKey(storageKey) {
+  return `${VIEWED_PREFIX}:${storageKey}`
+}
+
+export const recordSpecLoad = () => (system) => {
+  const {
+    specSelectors,
+    changeHistoryActions,
+    changeHistorySelectors,
+    getConfigs,
+  } = system
+  const configs = getConfigs()
+
+  if (configs.changeHistory === false) {
+    return
+  }
+
+  const spec = specSelectors.specJS()
+  if (!spec || !Object.keys(spec).length) {
+    return
+  }
+
+  const url = specSelectors.url()
+  const storageKey = getStorageKey(url, spec)
+  const specHash = hashSpec(spec)
+  const maxEntries = configs.changeHistoryMaxEntries || 20
+
+  changeHistoryActions.setStorageKey(storageKey)
+
+  const historyKey = getHistoryStorageKey(storageKey)
+  const snapshotKey = getSnapshotStorageKey(storageKey)
+  const viewedKey = getViewedStorageKey(storageKey)
+
+  const existingHistory = readJson(historyKey, [])
+  const previousSnapshot = readJson(snapshotKey, null)
+  const lastViewedAt = readJson(viewedKey, 0)
+
+  if (previousSnapshot && hashSpec(previousSnapshot) === specHash) {
+    changeHistoryActions.setHistory(existingHistory)
+    changeHistoryActions.setUnseenChanges(
+      existingHistory.some((entry) => entry.timestamp > lastViewedAt)
+    )
+    return
+  }
+
+  let changes = []
+
+  if (previousSnapshot) {
+    changes = compareSpecs(previousSnapshot, spec)
+  }
+
+  if (!previousSnapshot || changes.length) {
+    const entry = {
+      id: `${Date.now()}`,
+      timestamp: Date.now(),
+      version: spec?.info?.version || null,
+      title: spec?.info?.title || null,
+      specHash,
+      changes,
+      isBaseline: !previousSnapshot,
+    }
+
+    const nextHistory = [entry, ...existingHistory].slice(0, maxEntries)
+    writeJson(historyKey, nextHistory)
+    writeJson(snapshotKey, spec)
+
+    changeHistoryActions.setHistory(nextHistory)
+
+    if (changes.length) {
+      const isPanelOpen = changeHistorySelectors.isPanelOpen()
+      changeHistoryActions.setUnseenChanges(!isPanelOpen)
+    }
+  } else {
+    changeHistoryActions.setHistory(existingHistory)
+  }
+}
+
+export const restoreHistory = () => (system) => {
+  const { changeHistoryActions, changeHistorySelectors, getConfigs } = system
+  const configs = getConfigs()
+
+  if (configs.changeHistory === false) {
+    return
+  }
+
+  const storageKey = changeHistorySelectors.storageKey()
+  if (!storageKey) {
+    return
+  }
+
+  const historyKey = getHistoryStorageKey(storageKey)
+  const viewedKey = getViewedStorageKey(storageKey)
+  const existingHistory = readJson(historyKey, [])
+  const lastViewedAt = readJson(viewedKey, 0)
+
+  changeHistoryActions.setHistory(existingHistory)
+  changeHistoryActions.setUnseenChanges(
+    existingHistory.some((entry) => entry.timestamp > lastViewedAt)
+  )
+}
+
+export const togglePanel = () => (system) => {
+  const { changeHistoryActions, changeHistorySelectors } = system
+  const isOpen = changeHistorySelectors.isPanelOpen()
+
+  if (isOpen) {
+    changeHistoryActions.setPanelOpen(false)
+    return
+  }
+
+  changeHistoryActions.setPanelOpen(true)
+  changeHistoryActions.markAsViewed()
+}
+
+export const markAsViewed = () => (system) => {
+  const { changeHistoryActions, changeHistorySelectors } = system
+  const storageKey = changeHistorySelectors.storageKey()
+
+  if (!storageKey) {
+    return
+  }
+
+  const viewedKey = getViewedStorageKey(storageKey)
+  writeJson(viewedKey, Date.now())
+  changeHistoryActions.setUnseenChanges(false)
+}
+
+export const clearHistory = () => (system) => {
+  const { changeHistoryActions, changeHistorySelectors } = system
+  const storageKey = changeHistorySelectors.storageKey()
+
+  if (!storageKey) {
+    return
+  }
+
+  localStorage.removeItem(getHistoryStorageKey(storageKey))
+  localStorage.removeItem(getSnapshotStorageKey(storageKey))
+  localStorage.removeItem(getViewedStorageKey(storageKey))
+
+  changeHistoryActions.setHistory([])
+  changeHistoryActions.setUnseenChanges(false)
+}

--- a/src/core/plugins/change-history/wrap-actions.js
+++ b/src/core/plugins/change-history/wrap-actions.js
@@ -1,0 +1,23 @@
+export const updateJsonSpec =
+  (ori, system) =>
+  (...args) => {
+    const result = ori(...args)
+
+    setTimeout(() => {
+      system.changeHistoryActions.recordSpecLoad()
+    }, 0)
+
+    return result
+  }
+
+export const loaded =
+  (ori, system) =>
+  (...args) => {
+    const result = ori(...args)
+
+    setTimeout(() => {
+      system.changeHistoryActions.restoreHistory()
+    }, 0)
+
+    return result
+  }

--- a/src/core/presets/base/index.js
+++ b/src/core/presets/base/index.js
@@ -22,6 +22,7 @@ import DownloadUrlPlugin from "core/plugins/download-url"
 import SyntaxHighlightingPlugin from "core/plugins/syntax-highlighting"
 import VersionsPlugin from "core/plugins/versions"
 import SafeRenderPlugin from "core/plugins/safe-render"
+import ChangeHistoryPlugin from "core/plugins/change-history"
 // ad-hoc plugins
 import CoreComponentsPlugin from "core/presets/base/plugins/core-components"
 import FormComponentsPlugin from "core/presets/base/plugins/form-components"
@@ -49,6 +50,7 @@ const BasePreset = () => [
   RequestSnippetsPlugin,
   SyntaxHighlightingPlugin,
   VersionsPlugin,
+  ChangeHistoryPlugin,
   SafeRenderPlugin(),
 ]
 

--- a/src/standalone/plugins/stadalone-layout/components/StandaloneLayout.jsx
+++ b/src/standalone/plugins/stadalone-layout/components/StandaloneLayout.jsx
@@ -21,6 +21,7 @@ class StandaloneLayout extends React.Component {
     const Topbar = getComponent("Topbar", true)
     const BaseLayout = getComponent("BaseLayout", true)
     const OnlineValidatorBadge = getComponent("onlineValidatorBadge", true)
+    const ChangeHistoryContainer = getComponent("ChangeHistoryContainer", true)
 
     return (
       <Container className='swagger-ui'>
@@ -31,6 +32,7 @@ class StandaloneLayout extends React.Component {
             <OnlineValidatorBadge />
           </Col>
         </Row>
+        {ChangeHistoryContainer ? <ChangeHistoryContainer /> : null}
       </Container>
     )
   }

--- a/src/standalone/plugins/top-bar/assets/history-icon.svg
+++ b/src/standalone/plugins/top-bar/assets/history-icon.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo
+Mixer Tools -->
+<svg width="30px" height="90px" viewBox="0 0 24 24" role="img" xmlns="http://www.w3.org/2000/svg"
+  aria-labelledby="historyIconTitle" stroke="#000000" stroke-width="1" stroke-linecap="square"
+  stroke-linejoin="miter" fill="none" color="#000000">
+  <title id="historyIconTitle">History</title>
+  <polyline points="1 12 3 14 5 12" />
+  <polyline points="12 7 12 12 15 15" />
+  <path
+    d="M12,21 C16.9705627,21 21,16.9705627 21,12 C21,7.02943725 16.9705627,3 12,3 C7.02943725,3 3,7.02943725 3,12 C3,11.975305 3,12.3086383 3,13" />
+</svg>

--- a/src/standalone/plugins/top-bar/components/ChangeHistoryToggle.jsx
+++ b/src/standalone/plugins/top-bar/components/ChangeHistoryToggle.jsx
@@ -1,0 +1,50 @@
+import React, { Component } from "react"
+import PropTypes from "prop-types"
+
+import HistoryIcon from "../assets/history-icon.svg"
+
+class ChangeHistoryToggle extends Component {
+  static propTypes = {
+    changeHistoryActions: PropTypes.object.isRequired,
+    changeHistorySelectors: PropTypes.object.isRequired,
+    specSelectors: PropTypes.object.isRequired,
+    getConfigs: PropTypes.func.isRequired,
+  }
+
+  onClick = () => {
+    this.props.changeHistoryActions.togglePanel()
+  }
+
+  render() {
+    const { changeHistorySelectors, specSelectors, getConfigs } = this.props
+    const configs = getConfigs()
+
+    if (configs.changeHistory === false) {
+      return null
+    }
+
+    if (specSelectors.loadingStatus() === "loading") {
+      return null
+    }
+
+    const hasUnseenChanges = changeHistorySelectors.hasUnseenChanges()
+
+    return (
+      <div className="change-history-toggle">
+        <button
+          type="button"
+          onClick={this.onClick}
+          aria-label="API change history"
+          title="API change history"
+        >
+          <HistoryIcon height="24" />
+          {hasUnseenChanges ? (
+            <span className="change-history-badge" aria-label="New changes" />
+          ) : null}
+        </button>
+      </div>
+    )
+  }
+}
+
+export default ChangeHistoryToggle

--- a/src/standalone/plugins/top-bar/components/TopBar.jsx
+++ b/src/standalone/plugins/top-bar/components/TopBar.jsx
@@ -114,6 +114,7 @@ class TopBar extends React.Component {
     const Link = getComponent("Link")
     const Logo = getComponent("Logo")
     const DarkModeToggle = getComponent("DarkModeToggle")
+    const ChangeHistoryToggle = getComponent("ChangeHistoryToggle", true)
 
     let isLoading = specSelectors.loadingStatus() === "loading"
     let isFailed = specSelectors.loadingStatus() === "failed"
@@ -165,7 +166,10 @@ class TopBar extends React.Component {
             <form className="download-url-wrapper" onSubmit={formOnSubmit}>
               {control.map((el, i) => cloneElement(el, { key: i }))}
             </form>
-            <DarkModeToggle />
+            <div>
+              <ChangeHistoryToggle />
+              <DarkModeToggle />
+            </div>
           </div>
         </div>
       </div>

--- a/src/standalone/plugins/top-bar/index.js
+++ b/src/standalone/plugins/top-bar/index.js
@@ -4,9 +4,10 @@
 import TopBar from "./components/TopBar"
 import Logo from "./components/Logo"
 import DarkModeToggle from "./components/DarkModeToggle"
+import ChangeHistoryToggle from "./components/ChangeHistoryToggle"
 
 const TopBarPlugin = () => ({
-  components: { Topbar: TopBar, Logo, DarkModeToggle },
+  components: { Topbar: TopBar, Logo, DarkModeToggle, ChangeHistoryToggle },
 })
 
 export default TopBarPlugin

--- a/src/style/_change-history.scss
+++ b/src/style/_change-history.scss
@@ -1,0 +1,128 @@
+@use "variables" as *;
+
+.change-history-backdrop {
+  background: rgba(0, 0, 0, 0.35);
+  inset: 0;
+  position: fixed;
+  z-index: 9998;
+}
+
+.change-history-sidebar {
+  background: #fff;
+  border-left: 1px solid #e8e8e8;
+  box-shadow: -4px 0 24px rgba(0, 0, 0, 0.12);
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  max-width: 100%;
+  position: fixed;
+  right: 0;
+  top: 0;
+  width: 420px;
+  z-index: 9999;
+}
+
+.change-history-sidebar-header {
+  align-items: center;
+  border-bottom: 1px solid #ebebeb;
+  display: flex;
+  flex-shrink: 0;
+  justify-content: space-between;
+  padding: 20px;
+
+  h4 {
+    font-size: 18px;
+    margin: 0;
+  }
+}
+
+.change-history-sidebar-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.change-history-clear-btn,
+.change-history-close-btn {
+  color: #000;
+  font-size: 13px;
+  padding: 4px 12px;
+}
+
+.change-history-empty {
+  color: #888;
+  font-size: 14px;
+  margin: 0;
+  padding: 20px;
+}
+
+.change-history-entries {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 16px;
+  overflow-y: auto;
+  padding: 20px;
+}
+
+.change-history-entry {
+  background: #fafafa;
+  border: 1px solid #ebebeb;
+  border-radius: 4px;
+  padding: 12px 16px;
+}
+
+.change-history-entry-header {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 13px;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.change-history-entry-time {
+  font-weight: 600;
+}
+
+.change-history-entry-version {
+  background: #eef6ff;
+  border-radius: 3px;
+  color: $color-get;
+  padding: 2px 6px;
+}
+
+.change-history-entry-title {
+  color: #666;
+}
+
+.change-history-baseline,
+.change-history-no-changes {
+  color: #888;
+  font-size: 13px;
+  margin: 0;
+}
+
+.change-history-changes {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.change-history-item {
+  border-left: 3px solid #ccc;
+  font-size: 13px;
+  margin-bottom: 6px;
+  padding: 4px 0 4px 10px;
+
+  &.change-added {
+    border-left-color: $color-post;
+  }
+
+  &.change-removed {
+    border-left-color: $color-delete;
+  }
+
+  &.change-modified {
+    border-left-color: $color-put;
+  }
+}

--- a/src/style/_dark-mode.scss
+++ b/src/style/_dark-mode.scss
@@ -203,6 +203,43 @@ html.dark-mode {
           }
         }
       }
+
+      .change-history-toggle {
+        button svg {
+          stroke: $neutral-20;
+        }
+
+        .change-history-badge {
+          border-color: $neutral-95;
+        }
+      }
+    }
+
+    .change-history-sidebar {
+      background: $neutral-95;
+      border-left-color: $neutral-80;
+      color: $neutral-20;
+    }
+
+    .change-history-sidebar-header {
+      border-bottom-color: $neutral-80;
+    }
+
+    .change-history-clear-btn,
+    .change-history-close-btn {
+      color: #fff;
+    }
+
+    .change-history-entry {
+      background: $neutral-98;
+      border-color: $neutral-80;
+    }
+
+    .change-history-empty,
+    .change-history-baseline,
+    .change-history-no-changes,
+    .change-history-entry-title {
+      color: $neutral-40;
     }
 
     // ------ MODAL ------

--- a/src/style/_topbar.scss
+++ b/src/style/_topbar.scss
@@ -1,16 +1,27 @@
-@use "variables" as *;
+@use "variables"as *;
 @use "type";
 
 .topbar {
   padding: 10px 0;
 
   background-color: $topbar-background-color;
+
   .topbar-wrapper {
     display: flex;
     align-items: center;
     flex-wrap: wrap;
     gap: 10px;
+
+
+    div {
+      width: fit-content;
+      display: flex;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
   }
+
   @container swagger-ui (max-width: 550px) {
     .topbar-wrapper {
       flex-direction: column;
@@ -63,6 +74,7 @@
       max-width: 600px;
       margin: 0;
       color: #f0f0f0;
+
       span {
         font-size: 16px;
 
@@ -97,6 +109,7 @@
       @include type.text_headline($topbar-download-url-button-font-color);
     }
   }
+
   @container swagger-ui (max-width: 550px) {
     .download-url-wrapper {
       width: 100%;
@@ -117,6 +130,41 @@
       svg {
         fill: #e4e6e6;
       }
+    }
+
+    &:hover {
+      opacity: 1;
+    }
+  }
+
+  .change-history-toggle {
+    margin-left: 10px;
+    opacity: 0.8;
+    position: relative;
+    transition: all 0.2s;
+    cursor: pointer;
+
+    button {
+      background: none;
+      border: none;
+      padding: 0;
+      position: relative;
+
+      svg {
+        stroke: #e4e6e6;
+        fill: none;
+      }
+    }
+
+    .change-history-badge {
+      background: $color-delete;
+      border: 2px solid $topbar-background-color;
+      border-radius: 50%;
+      height: 10px;
+      position: absolute;
+      right: -2px;
+      top: -2px;
+      width: 10px;
     }
 
     &:hover {

--- a/src/style/main.scss
+++ b/src/style/main.scss
@@ -20,6 +20,7 @@
   @include meta.load-css("topbar");
   @include meta.load-css("information");
   @include meta.load-css("authorize");
+  @include meta.load-css("change-history");
   @include meta.load-css("errors");
   @include meta.load-css("split-pane-mode");
   @include meta.load-css("markdown");

--- a/test/unit/core/plugins/change-history/container.jsx
+++ b/test/unit/core/plugins/change-history/container.jsx
@@ -1,0 +1,75 @@
+import React from "react"
+import { shallow } from "enzyme"
+
+import ChangeHistoryContainer from "core/containers/change-history"
+
+describe("<ChangeHistoryContainer />", () => {
+  const Button = ({ children, ...props }) => <button {...props}>{children}</button>
+
+  const makeProps = (overrides = {}) => ({
+    getComponent: (name) => (name === "Button" ? Button : () => null),
+    getConfigs: () => ({ changeHistory: true }),
+    specSelectors: {
+      loadingStatus: () => "success",
+    },
+    changeHistorySelectors: {
+      isPanelOpen: () => false,
+      hasUnseenChanges: () => false,
+      hasHistory: () => true,
+      history: () => [],
+    },
+    changeHistoryActions: {
+      togglePanel: jest.fn(),
+      setPanelOpen: jest.fn(),
+      clearHistory: jest.fn(),
+    },
+    ...overrides,
+  })
+
+  it("does not render while the panel is closed", () => {
+    const wrapper = shallow(<ChangeHistoryContainer {...makeProps()} />)
+    expect(wrapper.isEmptyRender()).toEqual(true)
+  })
+
+  it("renders the sidebar and backdrop when the panel is open", () => {
+    const props = makeProps({
+      changeHistorySelectors: {
+        isPanelOpen: () => true,
+        hasUnseenChanges: () => false,
+        hasHistory: () => true,
+        history: () => [],
+      },
+    })
+    const wrapper = shallow(<ChangeHistoryContainer {...props} />)
+    expect(wrapper.find(".change-history-backdrop").length).toEqual(1)
+    expect(wrapper.find("ChangeHistorySidebar").length).toEqual(1)
+  })
+
+  it("does not render while the spec is loading", () => {
+    const props = makeProps({
+      specSelectors: { loadingStatus: () => "loading" },
+      changeHistorySelectors: {
+        isPanelOpen: () => true,
+        hasUnseenChanges: () => false,
+        hasHistory: () => true,
+        history: () => [],
+      },
+    })
+    const wrapper = shallow(<ChangeHistoryContainer {...props} />)
+    expect(wrapper.isEmptyRender()).toEqual(true)
+  })
+
+  it("hides itself when changeHistory config is disabled", () => {
+    const props = makeProps({
+      getConfigs: () => ({ changeHistory: false }),
+      changeHistorySelectors: {
+        isPanelOpen: () => true,
+        hasUnseenChanges: () => false,
+        hasHistory: () => true,
+        history: () => [],
+      },
+    })
+    const wrapper = shallow(<ChangeHistoryContainer {...props} />)
+    expect(wrapper.isEmptyRender()).toEqual(true)
+  })
+})

--- a/test/unit/core/plugins/change-history/fn.test.js
+++ b/test/unit/core/plugins/change-history/fn.test.js
@@ -1,10 +1,16 @@
 import {
+  canPersistSnapshot,
   compareSpecs,
+  filterHistoryByTtl,
   formatChangeSummary,
   getStorageKey,
   hashSpec,
+  isOversizedSnapshotMarker,
   resolveRefs,
   stableStringify,
+  unwrapSnapshot,
+  wrapOversizedSnapshotMarker,
+  wrapSnapshot,
 } from "core/plugins/change-history/fn"
 
 describe("change-history fn", () => {
@@ -447,6 +453,58 @@ describe("change-history fn", () => {
           newValue: "array",
         })
       ).toEqual('Schema "Pet": type changed (object → array)')
+    })
+  })
+
+  describe("snapshot retention helpers", () => {
+    it("wraps and unwraps snapshots with savedAt", () => {
+      const wrapped = wrapSnapshot(baseSpec, 1000)
+      expect(wrapped).toEqual({ savedAt: 1000, spec: baseSpec })
+      expect(unwrapSnapshot(wrapped, { ttlMs: 5000, now: 2000 })).toEqual({
+        savedAt: 1000,
+        spec: baseSpec,
+      })
+    })
+
+    it("supports legacy plain-spec snapshots", () => {
+      expect(unwrapSnapshot(baseSpec, { ttlMs: 1, now: Date.now() })).toEqual({
+        savedAt: null,
+        spec: baseSpec,
+      })
+    })
+
+    it("expires wrapped snapshots past TTL", () => {
+      const wrapped = wrapSnapshot(baseSpec, 1000)
+      expect(unwrapSnapshot(wrapped, { ttlMs: 100, now: 2000 })).toBeNull()
+    })
+
+    it("filters history entries older than TTL", () => {
+      const history = [
+        { id: "1", timestamp: 1000 },
+        { id: "2", timestamp: 5000 },
+      ]
+      expect(filterHistoryByTtl(history, 2000, 6000)).toEqual([
+        { id: "2", timestamp: 5000 },
+      ])
+    })
+
+    it("rejects oversized snapshots and keeps a hash marker", () => {
+      expect(canPersistSnapshot(baseSpec, 10, 1000)).toBe(false)
+      expect(canPersistSnapshot(baseSpec, 1024 * 1024, 1000)).toBe(true)
+
+      const marker = wrapOversizedSnapshotMarker("abc", 1000)
+      expect(marker).toEqual({
+        savedAt: 1000,
+        oversized: true,
+        specHash: "abc",
+      })
+      expect(unwrapSnapshot(marker, { ttlMs: 5000, now: 2000 })).toBeNull()
+      expect(isOversizedSnapshotMarker(marker, { ttlMs: 5000, now: 2000 })).toBe(
+        true
+      )
+      expect(isOversizedSnapshotMarker(marker, { ttlMs: 100, now: 2000 })).toBe(
+        false
+      )
     })
   })
 })

--- a/test/unit/core/plugins/change-history/fn.test.js
+++ b/test/unit/core/plugins/change-history/fn.test.js
@@ -1,0 +1,452 @@
+import {
+  compareSpecs,
+  formatChangeSummary,
+  getStorageKey,
+  hashSpec,
+  resolveRefs,
+  stableStringify,
+} from "core/plugins/change-history/fn"
+
+describe("change-history fn", () => {
+  const baseSpec = {
+    openapi: "3.0.0",
+    info: {
+      title: "Petstore",
+      version: "1.0.0",
+      description: "A sample API",
+    },
+    tags: [{ name: "pets" }],
+    paths: {
+      "/pets": {
+        get: {
+          summary: "List pets",
+          operationId: "listPets",
+          responses: {
+            200: { description: "OK" },
+          },
+        },
+      },
+    },
+    components: {
+      schemas: {
+        Pet: {
+          type: "object",
+          properties: {
+            id: { type: "integer" },
+          },
+        },
+      },
+    },
+  }
+
+  it("creates stable hashes for equivalent specs", () => {
+    const reordered = {
+      components: baseSpec.components,
+      info: baseSpec.info,
+      openapi: baseSpec.openapi,
+      paths: baseSpec.paths,
+      tags: baseSpec.tags,
+    }
+
+    expect(hashSpec(baseSpec)).toEqual(hashSpec(reordered))
+  })
+
+  it("detects different hashes for changed specs", () => {
+    const updated = {
+      ...baseSpec,
+      info: { ...baseSpec.info, version: "2.0.0" },
+    }
+
+    expect(hashSpec(baseSpec)).not.toEqual(hashSpec(updated))
+  })
+
+  it("builds storage keys from url or title", () => {
+    expect(getStorageKey("https://example.com/openapi.json", baseSpec)).toEqual(
+      "https://example.com/openapi.json"
+    )
+    expect(getStorageKey("", baseSpec)).toEqual("inline:Petstore")
+    expect(getStorageKey("", {})).toEqual("inline")
+  })
+
+  it("detects added endpoints", () => {
+    const updated = {
+      ...baseSpec,
+      paths: {
+        ...baseSpec.paths,
+        "/pets/{id}": {
+          get: {
+            summary: "Get pet",
+            responses: { 200: { description: "OK" } },
+          },
+        },
+      },
+    }
+
+    const changes = compareSpecs(baseSpec, updated)
+    expect(changes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "endpoint-added",
+          path: "/pets/{id}",
+          method: "GET",
+        }),
+      ])
+    )
+  })
+
+  it("detects removed endpoints", () => {
+    const updated = {
+      ...baseSpec,
+      paths: {},
+    }
+
+    const changes = compareSpecs(baseSpec, updated)
+    expect(changes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "endpoint-removed",
+          path: "/pets",
+          method: "GET",
+        }),
+      ])
+    )
+  })
+
+  it("detects info version changes", () => {
+    const updated = {
+      ...baseSpec,
+      info: { ...baseSpec.info, version: "2.0.0" },
+    }
+
+    const changes = compareSpecs(baseSpec, updated)
+    expect(changes).toEqual([
+      expect.objectContaining({
+        type: "info-changed",
+        field: "version",
+        oldValue: "1.0.0",
+        newValue: "2.0.0",
+      }),
+    ])
+  })
+
+  it("detects schema additions", () => {
+    const updated = {
+      ...baseSpec,
+      components: {
+        schemas: {
+          ...baseSpec.components.schemas,
+          NewPet: { type: "object" },
+        },
+      },
+    }
+
+    const changes = compareSpecs(baseSpec, updated)
+    expect(changes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "schema-added",
+          name: "NewPet",
+        }),
+      ])
+    )
+  })
+
+  it("formats change summaries", () => {
+    expect(
+      formatChangeSummary({
+        type: "endpoint-added",
+        method: "POST",
+        path: "/pets",
+      })
+    ).toEqual("POST /pets added")
+
+    expect(
+      formatChangeSummary({
+        type: "info-changed",
+        field: "version",
+      })
+    ).toEqual("Info version changed")
+  })
+
+  it("stableStringify sorts object keys", () => {
+    expect(stableStringify({ b: 1, a: 2 })).toEqual(
+      stableStringify({ a: 2, b: 1 })
+    )
+  })
+
+  describe("property-level schema diffs", () => {
+    it("detects added, removed and modified properties", () => {
+      const updated = {
+        ...baseSpec,
+        components: {
+          schemas: {
+            Pet: {
+              type: "object",
+              properties: {
+                id: { type: "string" },
+                name: { type: "string" },
+              },
+            },
+          },
+        },
+      }
+
+      const changes = compareSpecs(baseSpec, updated)
+      expect(changes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "schema-property-added",
+            name: "Pet",
+            property: "name",
+          }),
+          expect.objectContaining({
+            type: "schema-property-modified",
+            name: "Pet",
+            property: "id",
+          }),
+        ])
+      )
+      expect(changes).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ type: "schema-modified", name: "Pet" }),
+        ])
+      )
+    })
+
+    it("detects required-field changes", () => {
+      const withRequired = {
+        ...baseSpec,
+        components: {
+          schemas: {
+            Pet: {
+              type: "object",
+              required: ["id"],
+              properties: { id: { type: "integer" } },
+            },
+          },
+        },
+      }
+
+      const changes = compareSpecs(baseSpec, withRequired)
+      expect(changes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "schema-required-added",
+            name: "Pet",
+            property: "id",
+          }),
+        ])
+      )
+    })
+
+    it("detects schema type changes", () => {
+      const retyped = {
+        ...baseSpec,
+        components: {
+          schemas: {
+            Pet: { type: "array", properties: {} },
+          },
+        },
+      }
+
+      const changes = compareSpecs(baseSpec, retyped)
+      expect(changes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "schema-type-changed",
+            name: "Pet",
+            oldValue: "object",
+            newValue: "array",
+          }),
+        ])
+      )
+    })
+  })
+
+  describe("$ref resolution", () => {
+    const refSpec = {
+      openapi: "3.0.0",
+      info: { title: "Refs", version: "1.0.0" },
+      paths: {
+        "/pets": {
+          get: {
+            responses: {
+              200: {
+                description: "OK",
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/Pet" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          Pet: {
+            type: "object",
+            properties: { id: { type: "integer" } },
+          },
+        },
+      },
+    }
+
+    it("resolves internal refs so schema changes attribute to endpoints", () => {
+      const updated = JSON.parse(JSON.stringify(refSpec))
+      updated.components.schemas.Pet.properties.name = { type: "string" }
+
+      const changes = compareSpecs(refSpec, updated)
+
+      // schema-level detail
+      expect(changes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "schema-property-added",
+            name: "Pet",
+            property: "name",
+          }),
+        ])
+      )
+      // endpoint attribution (blast radius) via resolved refs
+      expect(changes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "response-modified",
+            method: "GET",
+            path: "/pets",
+            statusCode: "200",
+          }),
+        ])
+      )
+    })
+
+    it("does not infinitely recurse on circular refs", () => {
+      const circular = {
+        openapi: "3.0.0",
+        info: { title: "Circular", version: "1.0.0" },
+        paths: {},
+        components: {
+          schemas: {
+            Node: {
+              type: "object",
+              properties: {
+                child: { $ref: "#/components/schemas/Node" },
+              },
+            },
+          },
+        },
+      }
+
+      // Should terminate; the cycle is broken by leaving the repeated ref intact.
+      const resolved = resolveRefs(circular)
+      expect(
+        resolved.components.schemas.Node.properties.child.properties.child
+      ).toEqual({
+        $ref: "#/components/schemas/Node",
+      })
+    })
+  })
+
+  describe("broader coverage", () => {
+    it("detects operation tag changes", () => {
+      const oldOp = {
+        openapi: "3.0.0",
+        info: { title: "T", version: "1.0.0" },
+        paths: {
+          "/pets": { get: { tags: ["pets"], responses: {} } },
+        },
+      }
+      const newOp = {
+        ...oldOp,
+        paths: {
+          "/pets": { get: { tags: ["animals"], responses: {} } },
+        },
+      }
+
+      const changes = compareSpecs(oldOp, newOp)
+      expect(changes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "endpoint-tags-changed",
+            method: "GET",
+            path: "/pets",
+          }),
+        ])
+      )
+    })
+
+    it("detects global security changes", () => {
+      const oldSec = {
+        openapi: "3.0.0",
+        info: { title: "T", version: "1.0.0" },
+        paths: {},
+        security: [],
+      }
+      const newSec = { ...oldSec, security: [{ apiKey: [] }] }
+
+      const changes = compareSpecs(oldSec, newSec)
+      expect(changes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ type: "security-changed" }),
+        ])
+      )
+    })
+
+    it("detects response media type additions", () => {
+      const oldMt = {
+        openapi: "3.0.0",
+        info: { title: "T", version: "1.0.0" },
+        paths: {
+          "/pets": {
+            get: {
+              responses: {
+                200: {
+                  description: "OK",
+                  content: { "application/json": { schema: {} } },
+                },
+              },
+            },
+          },
+        },
+      }
+      const newMt = JSON.parse(JSON.stringify(oldMt))
+      newMt.paths["/pets"].get.responses[200].content["application/xml"] = {
+        schema: {},
+      }
+
+      const changes = compareSpecs(oldMt, newMt)
+      expect(changes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "response-content-added",
+            method: "GET",
+            path: "/pets",
+            statusCode: "200",
+            mediaType: "application/xml",
+          }),
+        ])
+      )
+    })
+
+    it("formats new change summaries", () => {
+      expect(
+        formatChangeSummary({
+          type: "schema-property-added",
+          name: "Pet",
+          property: "tag",
+        })
+      ).toEqual('Schema "Pet": property "tag" added')
+
+      expect(
+        formatChangeSummary({
+          type: "schema-type-changed",
+          name: "Pet",
+          oldValue: "object",
+          newValue: "array",
+        })
+      ).toEqual('Schema "Pet": type changed (object → array)')
+    })
+  })
+})

--- a/test/unit/core/plugins/change-history/sidebar.jsx
+++ b/test/unit/core/plugins/change-history/sidebar.jsx
@@ -1,0 +1,55 @@
+import React from "react"
+import { fromJS } from "immutable"
+import { shallow } from "enzyme"
+
+import ChangeHistorySidebar from "core/plugins/change-history/components/ChangeHistorySidebar"
+
+describe("<ChangeHistorySidebar />", () => {
+  const Button = ({ children, ...props }) => <button {...props}>{children}</button>
+
+  const makeProps = (history) => ({
+    history,
+    onClose: jest.fn(),
+    onClear: jest.fn(),
+    getComponent: (name) => (name === "Button" ? Button : () => null),
+  })
+
+  const entries = [
+    {
+      id: "2",
+      timestamp: 1710000000000,
+      version: "2.0.0",
+      title: "Petstore",
+      isBaseline: false,
+      changes: [
+        { type: "endpoint-added", method: "POST", path: "/pets" },
+        { type: "info-changed", field: "version" },
+      ],
+    },
+    {
+      id: "1",
+      timestamp: 1700000000000,
+      version: "1.0.0",
+      title: "Petstore",
+      isBaseline: true,
+      changes: [],
+    },
+  ]
+
+  it("renders entries from an Immutable history without throwing", () => {
+    const wrapper = shallow(<ChangeHistorySidebar {...makeProps(fromJS(entries))} />)
+    expect(wrapper.find(".change-history-entry").length).toEqual(2)
+    expect(wrapper.find(".change-history-item").length).toEqual(2)
+    expect(wrapper.find(".change-history-baseline").length).toEqual(1)
+  })
+
+  it("renders entries from a plain-JS history without throwing", () => {
+    const wrapper = shallow(<ChangeHistorySidebar {...makeProps(entries)} />)
+    expect(wrapper.find(".change-history-entry").length).toEqual(2)
+  })
+
+  it("renders an empty state when there is no history", () => {
+    const wrapper = shallow(<ChangeHistorySidebar {...makeProps(fromJS([]))} />)
+    expect(wrapper.find(".change-history-empty").length).toEqual(1)
+  })
+})

--- a/test/unit/standalone/plugins/top-bar/ChangeHistoryToggle.jsx
+++ b/test/unit/standalone/plugins/top-bar/ChangeHistoryToggle.jsx
@@ -1,0 +1,75 @@
+import React from "react"
+import { shallow } from "enzyme"
+
+import ChangeHistoryToggle from "standalone/plugins/top-bar/components/ChangeHistoryToggle"
+
+jest.mock("standalone/plugins/top-bar/assets/history-icon.svg", () => () => (
+  <div>HistoryIcon</div>
+))
+
+describe("ChangeHistoryToggle", () => {
+  const makeProps = (overrides = {}) => ({
+    getConfigs: () => ({ changeHistory: true }),
+    specSelectors: {
+      loadingStatus: () => "success",
+    },
+    changeHistorySelectors: {
+      hasUnseenChanges: () => false,
+    },
+    changeHistoryActions: {
+      togglePanel: jest.fn(),
+    },
+    ...overrides,
+  })
+
+  it("renders the history icon button", () => {
+    const wrapper = shallow(<ChangeHistoryToggle {...makeProps()} />)
+    expect(wrapper.find(".change-history-toggle button").length).toEqual(1)
+    expect(wrapper.find("button").prop("aria-label")).toEqual(
+      "API change history"
+    )
+  })
+
+  it("calls togglePanel when clicked", () => {
+    const changeHistoryActions = { togglePanel: jest.fn() }
+    const wrapper = shallow(
+      <ChangeHistoryToggle {...makeProps({ changeHistoryActions })} />
+    )
+
+    wrapper.find(".change-history-toggle button").simulate("click")
+    expect(changeHistoryActions.togglePanel).toHaveBeenCalled()
+  })
+
+  it("shows a badge when there are unseen changes", () => {
+    const wrapper = shallow(
+      <ChangeHistoryToggle
+        {...makeProps({
+          changeHistorySelectors: { hasUnseenChanges: () => true },
+        })}
+      />
+    )
+    expect(wrapper.find(".change-history-badge").length).toEqual(1)
+  })
+
+  it("does not render while the spec is loading", () => {
+    const wrapper = shallow(
+      <ChangeHistoryToggle
+        {...makeProps({
+          specSelectors: { loadingStatus: () => "loading" },
+        })}
+      />
+    )
+    expect(wrapper.isEmptyRender()).toEqual(true)
+  })
+
+  it("hides itself when changeHistory config is disabled", () => {
+    const wrapper = shallow(
+      <ChangeHistoryToggle
+        {...makeProps({
+          getConfigs: () => ({ changeHistory: false }),
+        })}
+      />
+    )
+    expect(wrapper.isEmptyRender()).toEqual(true)
+  })
+})


### PR DESCRIPTION
### Description
This PR adds an API Change History feature to Swagger UI so users can quickly see what changed between OpenAPI spec reloads.

Implemented:

- New change-history core plugin with Redux state/actions/selectors
- Local snapshot persistence in localStorage (keyed by spec URL)
- Spec diff engine for:
    - endpoint add/remove/modify
    - parameter/request/response changes
    - schema add/remove and property-level schema diffs
    - tags/info/security changes
    - media-type changes
- History UI moved to a right sidebar
- History trigger moved to top bar as a history icon (next to dark mode toggle), with unseen-change badge
- Light/dark mode styling for the sidebar and controls



### Motivation and Context
When backend teams update the OpenAPI document, frontend/API consumers currently have no native way in Swagger UI to track what changed. They must manually compare specs.
This feature adds built-in change visibility by capturing snapshots and presenting a readable history timeline of changes after reloads.
Fixes #10951 


### How Has This Been Tested?
- Manual testing:
    - Ran local dev server and loaded specs from local/dev sources
    - Verified baseline snapshot is created on first load
    - Reloaded modified specs and verified history entries update correctly
    - Verified history icon badge appears for unseen changes
    - Verified sidebar open/close behavior (button, backdrop, close button)
    - Verified light/dark mode color behavior for sidebar controls

- Automated testing:
    - Ran targeted unit tests for change-history:
    - test/unit/core/plugins/change-history/fn.test.js
    - test/unit/core/plugins/change-history/container.jsx
    - test/unit/core/plugins/change-history/sidebar.jsx
    - test/unit/standalone/plugins/top-bar/ChangeHistoryToggle.jsx
Result: all relevant tests passed


### Screenshots (if appropriate):
<img width="1680" height="1050" alt="Screenshot 2026-07-08 at 11 50 30" src="https://github.com/user-attachments/assets/a58ea83d-b8be-4cd7-b04c-d015564ec098" />
<img width="1680" height="1050" alt="Screenshot 2026-07-08 at 11 50 33" src="https://github.com/user-attachments/assets/03309824-3eca-4ee2-872b-73c5fe96ed69" />
<img width="1680" height="1050" alt="Screenshot 2026-07-08 at 12 10 29" src="https://github.com/user-attachments/assets/a643e0c3-106f-46c7-bf0d-5bc587f0218b" />



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [x] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [x] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [x] All new and existing tests passed.
