### PR TITLE
fix(oas3): stop nesting select inside label in Servers component

### DIFF
--- a/src/core/plugins/oas3/components/servers.jsx
+++ b/src/core/plugins/oas3/components/servers.jsx
@@ -71,23 +71,22 @@ const Servers = ({
 
   return (
     <div className="servers">
-      <label htmlFor="servers">
-        <select
-          onChange={handleServerChange}
-          value={currentServer}
-          id="servers"
-        >
-          {servers
-            .valueSeq()
-            .map((server) => (
-              <option value={server.get("url")} key={server.get("url")}>
-                {server.get("url")}
-                {server.get("description") && ` - ${server.get("description")}`}
-              </option>
-            ))
-            .toArray()}
-        </select>
-      </label>
+      <select
+        aria-label="Servers"
+        onChange={handleServerChange}
+        value={currentServer}
+        id="servers"
+      >
+        {servers
+          .valueSeq()
+          .map((server) => (
+            <option value={server.get("url")} key={server.get("url")}>
+              {server.get("url")}
+              {server.get("description") && ` - ${server.get("description")}`}
+            </option>
+          ))
+          .toArray()}
+      </select>
       {shouldShowVariableUI && (
         <div>
           <div className={"computed-url"}>

--- a/src/style/_servers.scss
+++ b/src/style/_servers.scss
@@ -2,18 +2,16 @@
 @use "type";
 
 .servers {
-  > label {
+  > select {
     font-size: 12px;
 
     margin: -20px 15px 0 0;
 
     @include type.text_headline();
 
-    select {
-      min-width: 130px;
-      max-width: 100%;
-      width: 100%;
-    }
+    min-width: 130px;
+    max-width: 100%;
+    width: 100%;
   }
 
   h4.message {

--- a/test/e2e-cypress/e2e/features/oas3-multiple-servers.cy.js
+++ b/test/e2e-cypress/e2e/features/oas3-multiple-servers.cy.js
@@ -5,7 +5,7 @@
 describe("OpenAPI 3.0 Multiple Servers", () => {
   it("should render and execute for server '/test-url-1'", () => {
     cy.visit("/?url=/documents/features/oas3-multiple-servers.yaml")
-      .get(".scheme-container .schemes .servers label > select")
+      .get(".scheme-container .schemes .servers select")
       .select("/test-url-1")
       .get("#operations-default-get_")
       .click()
@@ -20,7 +20,7 @@ describe("OpenAPI 3.0 Multiple Servers", () => {
   })
   it("should render and execute for server '/test-url-2'", () => {
     cy.visit("/?url=/documents/features/oas3-multiple-servers.yaml")
-      .get(".scheme-container .schemes .servers label > select")
+      .get(".scheme-container .schemes .servers select")
       .select("/test-url-2")
       .get("#operations-default-get_")
       .click()
@@ -35,7 +35,7 @@ describe("OpenAPI 3.0 Multiple Servers", () => {
   })
   it("should render and execute for server '/test-url-1' after sequence: select '/test-url-2' -> Try-It-Out -> select '/test-url-1'", () => {
     cy.visit("/?url=/documents/features/oas3-multiple-servers.yaml")
-      .get(".scheme-container .schemes .servers label > select")
+      .get(".scheme-container .schemes .servers select")
       .select("/test-url-2")
       .get("#operations-default-get_")
       .click()
@@ -43,7 +43,7 @@ describe("OpenAPI 3.0 Multiple Servers", () => {
       .get(".try-out__btn")
       .click()
       // Select a different server
-      .get(".scheme-container .schemes .servers label > select")
+      .get(".scheme-container .schemes .servers select")
       .select("/test-url-1")
       // Execute
       .get(".execute.opblock-control__btn")
@@ -53,10 +53,10 @@ describe("OpenAPI 3.0 Multiple Servers", () => {
   })
   it("should render and execute for server '/test-url-switch-1' after changing api definition", () => {
     cy.visit("/?url=/documents/features/oas3-multiple-servers.yaml")
-      .get(".scheme-container .schemes .servers label > select")
+      .get(".scheme-container .schemes .servers select")
       .select("/test-url-2")
     cy.visit("/?url=/documents/features/oas3-multiple-servers-switch.yaml")
-      .get(".scheme-container .schemes .servers label > select")
+      .get(".scheme-container .schemes .servers select")
       .select("/test-url-switch-2")
       .get("#operations-default-get_")
       .click()

--- a/test/e2e-cypress/e2e/features/urls.cy.js
+++ b/test/e2e-cypress/e2e/features/urls.cy.js
@@ -58,7 +58,7 @@ describe("urls with server variables", () => {
       .should("have.text", "basePath")
       .get("input")
       .should("have.value", "/oneFirstUrl")
-      .get(".servers > label > select")
+      .get(".servers > select")
       .eq(0)
       .select(1)
       .get("input")
@@ -96,7 +96,7 @@ describe("urls with server variables", () => {
   })
   it("should change server variables, then select second url, and maintain server variables index", () => {
     cy.visit("/?configUrl=/configs/urls-server-variables.yaml")
-      .get(".servers > label >select")
+      .get(".servers > select")
       .eq(0)
       .select(1)
       .get("input")


### PR DESCRIPTION
## Description

The OAS3 `Servers` dropdown renders a `<select>` nested inside a `<label for="servers">`:

```html
<label for="servers">
  <select id="servers">...</select>
</label>
```

This combines an explicit label association (`for`/`id`) with an implicit one (wrapping), which is redundant and produces invalid/inconsistent semantics that some screen readers don't handle well.

This PR un-nests the elements and adds `aria-label="Servers"` directly on the `<select>`, following the same pattern already used by `ContentType` (`src/core/components/content-type.jsx`) for a select whose visible caption lives in a sibling element rather than a native `<label>`. That pattern fits here because the parent `ServersContainer` component already renders a visible "Servers" title (`<span className="servers-title">`) right before this component — so adding a second visible label with the same text would have duplicated it on screen.

## Motivation and Context

Fixes #10957. The issue was originally surfaced via the Backstage project, which embeds Swagger UI and hit this markup while investigating an accessibility report (see backstage/backstage#34696).

## How Has This Been Tested?

- `npm run test:unit` — full `oas3` plugin suite passes (14 suites / 74 tests).
- `npm run lint` / `npm run lint-styles` — clean on all changed files.
- `npm run build:core` / `npm run build-stylesheets` — production build compiles cleanly.
- Manually loaded a multi-server spec in the dev server and confirmed via DOM inspection that the `<select>` is no longer inside a `<label>`, exposes `aria-label="Servers"`, and that switching servers still updates state correctly.
- Updated the two Cypress e2e specs (`oas3-multiple-servers.cy.js`, `urls.cy.js`) whose selectors assumed the old `label > select` nesting.

## Screenshots

No visual change — the rendered "Servers" title and dropdown look identical; only the underlying DOM structure and accessible name changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)