### PR TITLE
fix(ci): fix Trivy security scan and add dependency vulnerability scan

### DIFF
--- a/.github/workflows/docker-image-check.yml
+++ b/.github/workflows/docker-image-check.yml
@@ -12,6 +12,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Log in to DockerHub
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f
+        with:
+          username: ${{ secrets.DOCKERHUB_SB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_SB_PASSWORD }}
+
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@2736533278103862a861f4a35ebac3e97854d956
         with:

--- a/.github/workflows/docker-image-check.yml
+++ b/.github/workflows/docker-image-check.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@2736533278103862a861f4a35ebac3e97854d956
         with:
-          image-ref: 'docker.swagger.io/swaggerapi/swagger-ui:unstable'
+          image-ref: 'swaggerapi/swagger-ui:unstable'
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,4 +1,4 @@
-name: Security scan for docker image
+name: Security scan for docker image and dependencies
 
 on:
   workflow_dispatch:
@@ -9,16 +9,18 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  security-scan:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v7
+
       - name: Log in to DockerHub
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f
         with:
           username: ${{ secrets.DOCKERHUB_SB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_SB_PASSWORD }}
 
-      - name: Run Trivy vulnerability scanner
+      - name: Run Trivy vulnerability scanner on docker image
         uses: aquasecurity/trivy-action@2736533278103862a861f4a35ebac3e97854d956
         with:
           image-ref: 'swaggerapi/swagger-ui:unstable'
@@ -27,3 +29,14 @@ jobs:
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
+
+      - name: Run Trivy vulnerability scanner on dependencies
+        uses: aquasecurity/trivy-action@2736533278103862a861f4a35ebac3e97854d956
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'library'
+          severity: 'CRITICAL,HIGH,MEDIUM'


### PR DESCRIPTION
## Summary
- Fixed the scheduled Trivy security scan, which was failing with `TOOMANYREQUESTS` unauthenticated pull rate limit errors
  - Added a DockerHub login step before the scan (reusing the existing `DOCKERHUB_SB_USERNAME`/`DOCKERHUB_SB_PASSWORD` secrets, same pattern as `docker-build-push.yml`)
  - Fixed the image ref: it pointed at `docker.swagger.io/swaggerapi/swagger-ui:unstable`, but the `:unstable` tag is actually pushed to `swaggerapi/swagger-ui` on `docker.io` (per `docker-build-push-unstable.yml`), and `docker/login-action` stores credentials keyed to the `docker.io` host by default — so the stale ref meant login had no effect
- Added a second Trivy scan (`scan-type: fs`) against the checked-out repo to catch npm dependency vulnerabilities (CRITICAL/HIGH/MEDIUM), since the runtime image is nginx-alpine with no `node_modules`/lockfile, so the image scan alone never covers app dependencies
- Renamed `docker-image-check.yml` → `security-scan.yml` and the job name (`build` → `security-scan`) to reflect that it now scans both the image and dependencies

## Test plan
- [x] Manually ran the workflow (`workflow_dispatch`) on this branch after the login/image-ref fix — Trivy image scan passed
- [x] Manually run the workflow again after the fs-scan addition to confirm both scan steps pass

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>