### PR TITLE
feat(oas3): make OpenAPI Links interactive via a "Follow Link" action

### DIFF
--- a/src/core/components/response.jsx
+++ b/src/core/components/response.jsx
@@ -44,12 +44,21 @@ export default class Response extends React.Component {
     contentType: PropTypes.string,
     activeExamplesKey: PropTypes.string,
     controlsAcceptHeader: PropTypes.bool,
-    onContentTypeChange: PropTypes.func
+    onContentTypeChange: PropTypes.func,
+    // The live "Try it out" response (an Immutable Map with at least a
+    // "body" key), scoped by the parent (see responses.jsx) to only the
+    // response row whose status code actually matches what came back.
+    // null/undefined for every other row, and always for every row before
+    // "Try it out" has been executed at all. Forwarded to OperationLink so
+    // a link's `$response.body#/...` parameters have something real to
+    // resolve against; see executeLink in oas3/actions.js.
+    responseContext: PropTypes.instanceOf(Iterable),
   }
 
   static defaultProps = {
     response: fromJS({}),
-    onContentTypeChange: () => {}
+    onContentTypeChange: () => {},
+    responseContext: null,
   }
 
   _onContentTypeChange = (value) => {
@@ -87,6 +96,7 @@ export default class Response extends React.Component {
       contentType,
       controlsAcceptHeader,
       oas3Actions,
+      responseContext,
     } = this.props
 
     let { inferSchema, getSampleSchema } = fn
@@ -266,7 +276,7 @@ export default class Response extends React.Component {
         {isOAS3 ? <td className="response-col_links">
           { links ?
             links.toSeq().entrySeq().map(([key, link]) => {
-              return <OperationLink key={key} name={key} link={ link } getComponent={getComponent}/>
+              return <OperationLink key={key} name={key} link={ link } getComponent={getComponent} oas3Actions={oas3Actions} responseContext={responseContext} />
             })
           : <i>No links</i>}
         </td> : null}

--- a/src/core/components/responses.jsx
+++ b/src/core/components/responses.jsx
@@ -134,7 +134,14 @@ export default class Responses extends React.Component {
               {
                 nonExtensionResponses.entrySeq().map( ([code, response]) => {
 
-                  let className = tryItOutResponse && tryItOutResponse.get("status") == code ? "response_current" : ""
+                  // Only the response row whose status code matches what
+                  // "Try it out" actually returned should have a live
+                  // responseContext, so an OperationLink's
+                  // `$response.body#/...` parameters resolve against the
+                  // real result, not against an unrelated documented
+                  // response row that merely happens to render below it.
+                  let isCurrentResponse = tryItOutResponse && tryItOutResponse.get("status") == code
+                  let className = isCurrentResponse ? "response_current" : ""
                   return (
                     <Response key={ code }
                               path={path}
@@ -156,6 +163,7 @@ export default class Responses extends React.Component {
                                 "responses",
                                 code
                               )}
+                              responseContext={ isCurrentResponse ? tryItOutResponse : null }
                               oas3Actions={oas3Actions}
                               getComponent={ getComponent }/>
                     )

--- a/src/core/plugins/oas3/actions.js
+++ b/src/core/plugins/oas3/actions.js
@@ -1,6 +1,8 @@
 // Actions conform to FSA (flux-standard-actions)
 // {type: string,payload: Any|Error, meta: obj, error: bool}
 
+import { escapeDeepLinkPath } from "core/utils"
+
 export const UPDATE_SELECTED_SERVER = "oas3_set_servers"
 export const UPDATE_REQUEST_BODY_VALUE = "oas3_set_request_body_value"
 export const UPDATE_REQUEST_BODY_VALUE_RETAIN_FLAG = "oas3_set_request_body_retain_flag"
@@ -96,4 +98,100 @@ export const clearRequestBodyValue = ({ pathMethod }) => {
     type:  CLEAR_REQUEST_BODY_VALUE,
     payload: { pathMethod }
   }
+}
+
+// Resolves an RFC 6901 JSON Pointer against an Immutable structure.
+// "$response.body#/data/id" arrives here as pointer === "/data/id".
+// Handles multi-segment pointers and the '~1'/'~0' escaping rules, unlike
+// a naive single-segment string-key lookup.
+function resolveJsonPointer(obj, pointer) {
+  if (!pointer || obj == null) {
+    return obj
+  }
+  const segments = pointer
+    .split("/")
+    .filter(Boolean)
+    .map(seg => seg.replace(/~1/g, "/").replace(/~0/g, "~"))
+
+  if (typeof obj.getIn === "function") {
+    return obj.getIn(segments)
+  }
+
+  return segments.reduce((acc, seg) => (acc == null ? undefined : acc[seg]), obj)
+}
+
+export const executeLink = ({ operationId, parameters, responseContext }) => (system) => {
+  const { specSelectors, specActions, layoutActions } = system
+
+  if (!operationId) {
+    console.warn("OperationLink: link has no operationId (operationRef targets aren't supported yet)")
+    return
+  }
+
+  const operationMap = specSelectors.operationById(operationId)
+  if (!operationMap) {
+    console.warn(`OperationLink: no operation found with operationId "${operationId}"`)
+    return
+  }
+
+  const path = operationMap.get("path")
+  const method = operationMap.get("method")
+
+  // Tags live directly on the operation object; an operation with none
+  // falls under Swagger UI's own "default" tag grouping.
+  const tags = operationMap.getIn(["operation", "tags"])
+  const tag = (tags && tags.size > 0) ? tags.first() : "default"
+  const showKey = ["operations", tag, operationId]
+
+  layoutActions.show(showKey, true)
+
+  if (parameters) {
+    const paramsObj = typeof parameters.toJS === "function" ? parameters.toJS() : parameters
+    const declaredParams = operationMap.getIn(["operation", "parameters"]) || []
+    const responseBody = responseContext && typeof responseContext.get === "function"
+      ? responseContext.get("body")
+      : responseContext?.body
+
+    Object.entries(paramsObj).forEach(([paramName, paramExpr]) => {
+      let resolvedValue = paramExpr
+
+      if (typeof paramExpr === "string" && paramExpr.startsWith("$response.body#")) {
+        const pointer = paramExpr.replace("$response.body#", "")
+        const resolved = resolveJsonPointer(responseBody, pointer)
+        resolvedValue = resolved !== undefined ? resolved : paramExpr
+      }
+
+      if (resolvedValue !== null && resolvedValue !== undefined) {
+        if (typeof resolvedValue === "object") {
+          resolvedValue = JSON.stringify(resolvedValue)
+        } else if (typeof resolvedValue !== "string") {
+          resolvedValue = String(resolvedValue)
+        }
+      }
+
+      const isPathParam = path.indexOf(`{${paramName}}`) !== -1
+      const declared = typeof declaredParams.find === "function"
+        ? declaredParams.find(p => p.get("name") === paramName)
+        : undefined
+      const paramIn = isPathParam ? "path" : (declared ? declared.get("in") : "query")
+
+      specActions.changeParam([path, method], paramName, paramIn, resolvedValue, false)
+    })
+  }
+
+  // Same id operation.jsx itself sets on its root element
+  // (id={escapeDeepLinkPath(isShownKey.join("-"))}), so this finds the
+  // real, already-rendered DOM node directly, no reliance on
+  // readyToScroll's mount-time-only ref registration, which doesn't fire
+  // again for an operation that's already mounted on an already-loaded
+  // page (our case, vs. deep-linking's page-load-with-hash case).
+  const elementId = escapeDeepLinkPath(showKey.join("-"))
+  // A React re-render needs to happen (to reflect the just-dispatched
+  // 'show') before the now-expanded content exists to scroll to.
+  setTimeout(() => {
+    const element = document.getElementById(elementId)
+    if (element) {
+      element.scrollIntoView({ behavior: "smooth", block: "start" })
+    }
+  }, 0)
 }

--- a/src/core/plugins/oas3/components/operation-link.jsx
+++ b/src/core/plugins/oas3/components/operation-link.jsx
@@ -3,6 +3,22 @@ import PropTypes from "prop-types"
 import ImPropTypes from "react-immutable-proptypes"
 
 class OperationLink extends Component {
+  handleFollowLink = (e) => {
+    e.preventDefault()
+    const { link, oas3Actions, responseContext } = this.props
+
+    const operationId = link.get("operationId")
+    const parameters = link.get("parameters")
+
+    if (oas3Actions && oas3Actions.executeLink) {
+      oas3Actions.executeLink({
+        operationId,
+        parameters,
+        responseContext,
+      })
+    }
+  }
+
   render() {
     const { link, name, getComponent } = this.props
 
@@ -12,18 +28,37 @@ class OperationLink extends Component {
     let parameters = link.get("parameters") && link.get("parameters").toJS()
     let description = link.get("description")
 
-    return <div className="operation-link">
-      <div className="description">
-        <b><code>{name}</code></b>
-        { description ? <Markdown source={description}></Markdown> : null }
+    return (
+      <div className="operation-link" style={{ marginBottom: "14px" }}>
+        <div className="description" style={{ display: "flex", flexDirection: "column", gap: "6px" }}>
+          <div style={{ wordBreak: "keep-all", overflowWrap: "normal", whiteSpace: "normal" }}>
+            <b style={{ wordBreak: "keep-all" }}>
+              <code style={{ wordBreak: "keep-all", overflowWrap: "normal", display: "inline" }}>
+                {name}
+              </code>
+            </b>
+            { description ? <Markdown source={description}></Markdown> : null }
+          </div>
+          {link.get("operationId") && (
+          <div>
+            <button
+              type="button"
+              className="btn btn-sm execute"
+              onClick={this.handleFollowLink}
+              style={{ width: "100%", whiteSpace: "nowrap" }}
+            >
+              Follow Link
+            </button>
+          </div>
+          )}
+        </div>
+        <pre style={{ marginTop: "6px", wordBreak: "break-word" }}>
+          Operation `{targetOp}`<br /><br />
+          Parameters {padString(0, JSON.stringify(parameters, null, 2)) || "{}"}<br />
+        </pre>
       </div>
-      <pre>
-        Operation `{targetOp}`<br /><br />
-        Parameters {padString(0, JSON.stringify(parameters, null, 2)) || "{}"}<br />
-      </pre>
-    </div>
+    )
   }
-
 }
 
 function padString(n, string) {
@@ -37,7 +72,13 @@ function padString(n, string) {
 OperationLink.propTypes = {
   getComponent: PropTypes.func.isRequired,
   link: ImPropTypes.orderedMap.isRequired,
-  name: PropTypes.String
+  name: PropTypes.string,
+  oas3Actions: PropTypes.object,
+  // The live "Try it out" response for this operation (an Immutable Map
+  // with at least a "body" key), when this link's response row is the
+  // one that actually matches what came back -- see responseContext in
+  // response.jsx/responses.jsx, and executeLink in oas3/actions.js.
+  responseContext: ImPropTypes.iterable,
 }
 
 export default OperationLink

--- a/src/core/plugins/spec/selectors.js
+++ b/src/core/plugins/spec/selectors.js
@@ -152,6 +152,32 @@ export const operations = createSelector(
   }
 )
 
+// Finds an operation's flattened entry (path, method, operation, id,
+// specPath -- same shape `operations` already produces) by its
+// declared operationId. Used by oas3/actions.js's executeLink to resolve
+// an OpenAPI Link Object's `operationId` to a real, navigable operation.
+//
+// NOTE: this is deliberately a plain (state, operationId) function, NOT
+// a curried createSelector (e.g. createSelector(operations, (operations)
+// => (operationId) => {...})). The plugin system's selector binding
+// (see getBoundSelectors in core/system.js) calls a bound selector as
+// fn(state, ...args); if the RESULT of that call is itself a function,
+// the system assumes it's a getSystem-consuming selector and invokes it
+// with the whole system object, not with the caller's original args.
+// A curried createSelector here returns exactly such a function as its
+// result, so specSelectors.operationById(operationId) would silently
+// receive the system object in place of operationId instead. Matching
+// the plain-function pattern already used by responseFor/requestFor/
+// findDefinition/tagDetails elsewhere in this file avoids that entirely.
+export const operationById = (state, operationId) => {
+  if (!operationId) {
+    return undefined
+  }
+  return operations(state).find(
+    op => op.getIn(["operation", "operationId"]) === operationId
+  )
+}
+
 export const consumes = createSelector(
   spec,
   spec => Set(spec.get("consumes"))

--- a/test/unit/core/plugins/oas3/actions.js
+++ b/test/unit/core/plugins/oas3/actions.js
@@ -1,0 +1,215 @@
+import { fromJS } from "immutable"
+import { executeLink } from "core/plugins/oas3/actions"
+
+function buildSystem({ operationMap, warnSpy } = {}) {
+  const mockSpecSelectors = {
+    operationById: jest.fn().mockReturnValue(operationMap),
+  }
+  const mockSpecActions = {
+    changeParam: jest.fn(),
+  }
+  const mockLayoutActions = {
+    show: jest.fn(),
+  }
+  const system = {
+    specSelectors: mockSpecSelectors,
+    specActions: mockSpecActions,
+    layoutActions: mockLayoutActions,
+  }
+  return { system, mockSpecSelectors, mockSpecActions, mockLayoutActions }
+}
+
+describe("oas3 actions: executeLink", () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    document.body.innerHTML = ""
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it("looks up the target operation and expands it under ITS OWN tag, not [path, method]", () => {
+    // This is the actual bug this whole feature broke on: the real
+    // expand/collapse state key is ["operations", tag, operationId] (see
+    // OperationContainer.jsx's isShownKey / toggleShown), not
+    // ["operations", path, method]. The wrong key silently wrote to an
+    // unrelated, unread piece of layout state -- the panel never opened,
+    // with no error to indicate why.
+    const operationMap = fromJS({
+      path: "/users/{id}",
+      method: "get",
+      operation: { operationId: "getUserById", tags: ["Users"] },
+    })
+    const { system, mockSpecSelectors, mockLayoutActions } = buildSystem({ operationMap })
+
+    executeLink({ operationId: "getUserById", parameters: null, responseContext: null })(system)
+
+    expect(mockSpecSelectors.operationById).toHaveBeenCalledWith("getUserById")
+    expect(mockLayoutActions.show).toHaveBeenCalledWith(["operations", "Users", "getUserById"], true)
+  })
+
+  it("falls back to the 'default' tag for an untagged operation", () => {
+    const operationMap = fromJS({
+      path: "/",
+      method: "get",
+      operation: { operationId: "get_root" }, // no tags at all
+    })
+    const { system, mockLayoutActions } = buildSystem({ operationMap })
+
+    executeLink({ operationId: "get_root", parameters: null, responseContext: null })(system)
+
+    expect(mockLayoutActions.show).toHaveBeenCalledWith(["operations", "default", "get_root"], true)
+  })
+
+  it("resolves a path parameter from the response body and calls changeParam POSITIONALLY", () => {
+    // The other real bug: changeParam's actual signature (spec/actions.js)
+    // is (pathMethod, paramName, paramIn, value, isXml) -- a positional
+    // call, not an options object, and with no isOas3 flag at all.
+    // Calling it with an object instead threw deep inside the reducer
+    // ("i is not iterable") because it tried to array-destructure the
+    // object as if it were the [path, method] tuple it expected.
+    const operationMap = fromJS({
+      path: "/widgets/{id}",
+      method: "get",
+      operation: { operationId: "get_widgets_id", tags: ["Widgets"] },
+    })
+    const { system, mockSpecActions } = buildSystem({ operationMap })
+
+    const linkPayload = {
+      operationId: "get_widgets_id",
+      parameters: fromJS({ id: "$response.body#/id" }),
+      responseContext: fromJS({ body: { id: 2, name: "test2" } }),
+    }
+
+    executeLink(linkPayload)(system)
+
+    expect(mockSpecActions.changeParam).toHaveBeenCalledWith(
+      ["/widgets/{id}", "get"], "id", "path", "2", false
+    )
+  })
+
+  it("coerces a resolved JSON number to a string before calling changeParam", () => {
+    // Swagger UI's parameter state is always driven from text inputs;
+    // handing it a raw JS number (as $response.body#/id resolves to,
+    // straight out of JSON) breaks the same reducer the positional-args
+    // fix above addresses. Isolated here since it's a genuinely separate
+    // failure mode from the positional-args bug, even though both
+    // produced the exact same "not iterable" error and had to be told
+    // apart carefully.
+    const operationMap = fromJS({
+      path: "/widgets/{id}",
+      method: "delete",
+      operation: { operationId: "archiveWidgetLegacy", tags: ["Widgets"] },
+    })
+    const { system, mockSpecActions } = buildSystem({ operationMap })
+
+    executeLink({
+      operationId: "archiveWidgetLegacy",
+      parameters: fromJS({ id: "$response.body#/id" }),
+      responseContext: fromJS({ body: { id: 42 } }),
+    })(system)
+
+    const [, , , value] = mockSpecActions.changeParam.mock.calls[0]
+    expect(typeof value).toBe("string")
+    expect(value).toBe("42")
+  })
+
+  it("resolves a query parameter (not present in the path template) as paramIn 'query'", () => {
+    const operationMap = fromJS({
+      path: "/widgets",
+      method: "get",
+      operation: { operationId: "get_widgets", tags: ["Widgets"] },
+    })
+    const { system, mockSpecActions } = buildSystem({ operationMap })
+
+    executeLink({
+      operationId: "get_widgets",
+      parameters: fromJS({ status: "active" }),
+      responseContext: fromJS({ body: {} }),
+    })(system)
+
+    expect(mockSpecActions.changeParam).toHaveBeenCalledWith(
+      ["/widgets", "get"], "status", "query", "active", false
+    )
+  })
+
+  it("resolves a multi-segment JSON pointer against the response body", () => {
+    const operationMap = fromJS({
+      path: "/orders/{id}",
+      method: "get",
+      operation: { operationId: "getOrder", tags: ["Orders"] },
+    })
+    const { system, mockSpecActions } = buildSystem({ operationMap })
+
+    executeLink({
+      operationId: "getOrder",
+      parameters: fromJS({ id: "$response.body#/data/id" }),
+      responseContext: fromJS({ body: { data: { id: 42 } } }),
+    })(system)
+
+    expect(mockSpecActions.changeParam).toHaveBeenCalledWith(
+      ["/orders/{id}", "get"], "id", "path", "42", false
+    )
+  })
+
+  it("scrolls to the real DOM element operation.jsx itself renders (id via escapeDeepLinkPath)", () => {
+    const operationMap = fromJS({
+      path: "/widgets",
+      method: "get",
+      operation: { operationId: "get_widgets", tags: ["Widgets"] },
+    })
+    const { system } = buildSystem({ operationMap })
+
+    // Matches exactly what operation.jsx sets:
+    // id={escapeDeepLinkPath(isShownKey.join("-"))}
+    const el = document.createElement("div")
+    el.id = "operations-Widgets-get_widgets"
+    el.scrollIntoView = jest.fn()
+    document.body.appendChild(el)
+
+    executeLink({ operationId: "get_widgets", parameters: null, responseContext: null })(system)
+    jest.runAllTimers()
+
+    expect(el.scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "start" })
+  })
+
+  it("does not throw when the target element is not yet in the DOM", () => {
+    const operationMap = fromJS({
+      path: "/widgets",
+      method: "get",
+      operation: { operationId: "get_widgets", tags: ["Widgets"] },
+    })
+    const { system } = buildSystem({ operationMap })
+
+    executeLink({ operationId: "get_widgets", parameters: null, responseContext: null })(system)
+    expect(() => jest.runAllTimers()).not.toThrow()
+  })
+
+  it("warns and does nothing when the link has no operationId", () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {})
+    const { system, mockSpecSelectors, mockLayoutActions, mockSpecActions } = buildSystem({})
+
+    executeLink({ operationId: null, parameters: null, responseContext: null })(system)
+
+    expect(warnSpy).toHaveBeenCalled()
+    expect(mockSpecSelectors.operationById).not.toHaveBeenCalled()
+    expect(mockLayoutActions.show).not.toHaveBeenCalled()
+    expect(mockSpecActions.changeParam).not.toHaveBeenCalled()
+
+    warnSpy.mockRestore()
+  })
+
+  it("warns and does nothing when the operationId does not resolve to a real operation", () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {})
+    const { system, mockLayoutActions, mockSpecActions } = buildSystem({ operationMap: undefined })
+
+    executeLink({ operationId: "doesNotExist", parameters: null, responseContext: null })(system)
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("doesNotExist"))
+    expect(mockLayoutActions.show).not.toHaveBeenCalled()
+    expect(mockSpecActions.changeParam).not.toHaveBeenCalled()
+
+    warnSpy.mockRestore()
+  })
+})

--- a/test/unit/core/plugins/spec/selectors.js
+++ b/test/unit/core/plugins/spec/selectors.js
@@ -7,6 +7,7 @@ import {
   operationScheme,
   specJsonWithResolvedSubtrees,
   operations,
+  operationById,
   producesOptionsFor,
   operationWithMeta,
   parameterWithMeta,
@@ -1238,6 +1239,120 @@ describe("taggedOperations", function () {
     const result = operations(state)
 
     expect(result.toJS()).toEqual([])
+  })
+})
+describe("operationById", () => {
+  it("is a plain (state, operationId) function, not a curried selector", () => {
+    // The actual regression this selector broke on: a curried
+    // createSelector(operations, (operations) => (operationId) => {...})
+    // returns a FUNCTION as its own result, which the plugin system's
+    // selector binding (getBoundSelectors, core/system.js) then invokes
+    // with the whole system object instead of the caller's real
+    // argument. Asserting the exported value's arity here catches a
+    // regression back to that shape before any behavioral test below
+    // would even need to run.
+    expect(typeof operationById).toBe("function")
+    expect(operationById.length).toBe(2)
+  })
+
+  it("finds a real operation by its declared operationId", () => {
+    const state = fromJS({
+      json: {
+        paths: {
+          "/widgets": {
+            get: { operationId: "get_widgets", tags: ["Widgets"] },
+            post: { operationId: "post_widgets", tags: ["Widgets"] }
+          },
+          "/widgets/{id}": {
+            get: { operationId: "get_widgets_id", tags: ["Widgets"], summary: "Fetch one widget" }
+          }
+        }
+      }
+    })
+
+    const result = operationById(state, "get_widgets_id")
+
+    expect(result.get("path")).toEqual("/widgets/{id}")
+    expect(result.get("method")).toEqual("get")
+    expect(result.getIn(["operation", "summary"])).toEqual("Fetch one widget")
+  })
+
+  it("finds operations across multiple paths and methods by operationId", () => {
+    const state = fromJS({
+      json: {
+        paths: {
+          "/widgets": {
+            get: { operationId: "get_widgets" },
+            post: { operationId: "post_widgets" }
+          },
+          "/widgets/{id}": {
+            get: { operationId: "get_widgets_id" }
+          }
+        }
+      }
+    })
+
+    expect(operationById(state, "get_widgets").get("method")).toEqual("get")
+    expect(operationById(state, "post_widgets").get("method")).toEqual("post")
+    expect(operationById(state, "get_widgets_id").get("path")).toEqual("/widgets/{id}")
+  })
+
+  it("returns undefined for an operationId that does not exist", () => {
+    const state = fromJS({
+      json: {
+        paths: {
+          "/widgets": {
+            get: { operationId: "get_widgets" }
+          }
+        }
+      }
+    })
+
+    expect(operationById(state, "totally_made_up")).toEqual(undefined)
+  })
+
+  it("returns undefined when operationId is falsy, without throwing", () => {
+    const state = fromJS({
+      json: {
+        paths: {
+          "/widgets": {
+            get: { operationId: "get_widgets" }
+          }
+        }
+      }
+    })
+
+    expect(operationById(state, "")).toEqual(undefined)
+    expect(operationById(state, null)).toEqual(undefined)
+    expect(operationById(state, undefined)).toEqual(undefined)
+  })
+
+  it("does not throw on an untagged, operationId-less operation mixed in with tagged ones", () => {
+    const state = fromJS({
+      json: {
+        paths: {
+          "/": {
+            get: { summary: "Landing page" } // no operationId, no tags
+          },
+          "/widgets": {
+            get: { operationId: "get_widgets", tags: ["Widgets"] }
+          }
+        }
+      }
+    })
+
+    expect(() => operationById(state, "get_widgets")).not.toThrow()
+    expect(operationById(state, "get_widgets").get("path")).toEqual("/widgets")
+  })
+
+  it("works against the real Petstore fixture used elsewhere in this file", () => {
+    const state = fromJSOrdered({ json: Petstore })
+
+    const result = operationById(state, "addPet")
+
+    expect(result).toBeDefined()
+    expect(result.get("path")).toEqual("/pet")
+    expect(result.get("method")).toEqual("post")
   })
 })
 describe("getOAS3RequiredRequestBodyContentType", () => {


### PR DESCRIPTION
# Make OpenAPI Links interactive via a "Follow Link" action

Closes #7533

## Summary

`links` on an OpenAPI response are currently rendered as inert text, a name, a description, the target `operationId`, and a raw JSON dump of `parameters` -- with no way to actually act on them. This PR adds a **"Follow Link"** button that expands the linked operation, scrolls to it, and resolves + pre-fills its parameters using the response that was just received, matching what the OpenAPI Link Object was designed to enable.

## What changed

| File | Change |
|---|---|
| `src/core/plugins/spec/selectors.js` | New `operationById(state, operationId)` selector |
| `src/core/plugins/oas3/actions.js` | New `executeLink(payload)` thunk action |
| `src/core/plugins/oas3/components/operation-link.jsx` | `responseContext` prop typed as `ImPropTypes.iterable` |
| `src/core/components/response.jsx` | Forwards `oas3Actions` / `responseContext` to `OperationLink` |
| `src/core/components/responses.jsx` | Computes `responseContext`, scoped to the matching response row |
| `test/unit/core/plugins/spec/selectors.js` | New `operationById` suite |
| `test/unit/core/plugins/oas3/actions.js` | New file, full `executeLink` suite |

## Design notes

A few of these decisions aren't obvious from the diff alone, and each one corresponds to a real bug that only surfaced under live testing in a browser, documenting them here so a review doesn't have to rediscover the same ground.

**`operationById` is a plain function, not a curried selector.** The natural-looking implementation is `createSelector(operations, (operations) => (operationId) => {...})`. That's wrong in this codebase specifically: the plugin system's selector binding (`getBoundSelectors` in `core/system.js`) calls a bound selector as `fn(state, ...args)`, and if the *result* of that call is itself a function, the system assumes it's a getSystem-consuming selector and invokes that returned function with the whole system object, not the caller's original arguments. A curried selector's inner function is exactly such a "result that is a function," so `specSelectors.operationById(operationId)` would silently receive the system object in place of `operationId`, with no error. `operationById` is written as a plain `(state, operationId)` function instead, matching the existing `responseFor`/`requestFor`/ `findDefinition` pattern already in this file.

**The expand/scroll target key is `["operations", tag, operationId]`, not `[path, method]`.** The tag-based key is what
`OperationContainer`'s own `isShownKey`/`toggleShown` and `operation.jsx`'s rendered element `id` both actually use. A
`[path, method]`-based key looks equally plausible but writes to a piece of layout state nothing else reads, so the operation panel never opens and nothing indicates why.

**Scrolling uses the real rendered DOM id, not the deep-linking plugin's `scrollTo`/`readyToScroll`.** That mechanism is a one-shot check: each operation's wrapping `ref` callback fires once, at mount, and checks whether the *current* scroll target already matches its own key -- designed for the "page loads with a URL hash already set" case. It does not re-fire for an operation that's already mounted on an already-loaded page, which is always the case for a click-driven navigation like this one. Instead, `executeLink` looks up the operation's real DOM node directly via `escapeDeepLinkPath(["operations", tag, operationId].join("-"))`, the same id `operation.jsx` sets on its own root element -- and calls `scrollIntoView` on it after a `setTimeout(0)` to let the just-dispatched `show` action's re-render complete first.

**`changeParam` is called positionally, not with an options object.** Its real signature is `changeParam(pathMethod, paramName, paramIn, value, isXml)`, and there is no `isOas3` flag on it at all, plain parameter editing is shared between OAS2 and OAS3 specs in this codebase. Calling it with an options object instead threw deep inside the parameter-update reducer (`TypeError: i is not iterable`), since the reducer destructures its first argument as the `[path, method]` tuple it expects.

**Resolved parameter values are coerced to strings.** Parameter state is always driven from text inputs, so it's string-typed regardless of what a resolved runtime expression naturally is (a `$response.body#/id` pointer into `{"id": 2}` resolves to the JS number `2`). Numbers, booleans, and objects are coerced (`String(...)` / `JSON.stringify(...)` respectively) before being handed to `changeParam`.

## What's intentionally out of scope

- **`operationRef` targets.** Only `operationId`-based links render a "Follow Link" button; `operationRef` links still render as text-only, same as before this change.
- **Runtime expressions other than `$response.body#/...`.**  `$request.*`, `$url`, `$method`, `$statusCode`, and   `$response.header.*` are valid per spec but not resolved here; they pass through as their literal, unresolved expression string. 
- **Path-item-level shared parameters.** A parameter declared once at the path-item level and shared across multiple HTTP methods, rather than redeclared per-operation, isn't currently merged in by the  `operations` selector this is built on. The path-template check  (`{paramName}` presence) still correctly identifies it as a path parameter in that case; only the fallback lookup into an operation's *own* declared parameter list would miss it.

Any of these would be reasonable, separable follow-ups if there's interest.

## Testing

- `test/unit/core/plugins/spec/selectors.js`: new `operationById` suite runs against the real `operations` -> `paths` ->
  `specJsonWithResolvedSubtrees` selector chain (no mocking of the selector's own dependencies), plus an explicit assertion on the exported function's arity (`operationById.length === 2`) as a standing regression guard against the curried-selector bug described above. Includes a case against the repo's own Petstore fixture.
- `test/unit/core/plugins/oas3/actions.js`: new file. Covers the tag-based expand key and its `"default"` fallback, the positional  `changeParam` call, value coercion, JSON Pointer resolution (including a multi-segment case), path- vs. query-parameter inference, the real scroll-target DOM id (via a live `jsdom` element), and both `console.warn` failure branches.
- Manually verified end-to-end against a locally running API with a real OpenAPI document containing `operationId`-based links with both empty and non-empty `parameters` maps, including a link targeting a path parameter with a `$response.body#/id` runtime expression: clicking "Follow Link" correctly expands and scrolls to
  the target operation and pre-fills its parameter field with the real value from the response.

## Checklist

- [x] New behavior covered by unit tests
- [x] Existing unit tests unaffected (`npm run test:unit`)