### PR TITLE
fix(json-schema): handle scientific multipleOf values

### DIFF
--- a/src/core/plugins/json-schema-2020-12/fn.js
+++ b/src/core/plugins/json-schema-2020-12/fn.js
@@ -244,9 +244,11 @@ const stringifyConstraintMultipleOf = (schema) => {
     return `multiple of ${multipleOf}`
   }
 
-  const decimalPlaces = multipleOf.toString().split(".")[1].length
+  const [coefficient, exponent = "0"] = multipleOf.toString().split("e")
+  const decimalPlaces =
+    (coefficient.split(".")[1]?.length ?? 0) - Number(exponent)
   const factor = 10 ** decimalPlaces
-  const numerator = multipleOf * factor
+  const numerator = Number(coefficient.replace(".", ""))
   const denominator = factor
   return `multiple of ${numerator}/${denominator}`
 }

--- a/test/unit/core/plugins/oas31/fn.js
+++ b/test/unit/core/plugins/oas31/fn.js
@@ -1,5 +1,6 @@
 import { fromJS } from "immutable"
 import { isOAS31 } from "core/plugins/oas31/fn"
+import { stringifyConstraints } from "core/plugins/json-schema-2020-12/fn"
 
 const isOAS31Shorthand = (version) => isOAS31(fromJS({
   openapi: version
@@ -34,5 +35,16 @@ describe("isOAS30", function () {
       openApi: "3.1.0"
     }))).toEqual(false)
     expect(isOAS31Shorthand(null)).toEqual(false)
+  })
+})
+
+describe("stringifyConstraints", function () {
+  it.each([
+    [1e-7, "1/10000000"],
+    [1.2e-7, "12/100000000"]
+  ])("handles a scientific-notation multipleOf", function (multipleOf, ratio) {
+    expect(stringifyConstraints({ multipleOf })).toEqual([
+      { scope: "number", value: `multiple of ${ratio}` }
+    ])
   })
 })


### PR DESCRIPTION
### Description

Handle scientific-notation `multipleOf` values when rendering JSON Schema 2020-12 constraints.

The current decimal-place calculation assumes a decimal point is present in `Number#toString()`. Small valid values such as `1e-7` are rendered in scientific notation, causing an `undefined.length` exception. Multiplying the floating-point value also produces inaccurate numerators for values such as `1.2e-7`.

This separates the coefficient and exponent and derives the numerator from the coefficient digits, preserving the existing fraction display without floating-point multiplication artifacts.

### Motivation and Context

Valid OpenAPI 3.1/3.2 schemas using a small `multipleOf` can fail while rendering their constraints. No public API or configuration behavior changes.

### How Has This Been Tested?

- Focused regression test: 6 passed
- Full unit suite: 76 suites and 848 tests passed
- `npm run lint-errors`
- `npm run type-check`
- `npm run build`
- `npm run test:artifact`: 3 suites and 3 tests passed

`npm run cy:ci` was attempted, but the mock server exited before Cypress started because this host had exhausted its file-watcher limit (`ENOSPC`).

### Screenshots (if appropriate):

Not applicable; this prevents an exception and preserves the existing text format.

## Checklist

### My PR contains...

- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...

- [ ] are breaking changes to a public API (config options, System API, major UI change, etc.).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation

- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests

- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [x] If yes to above: I have added tests to cover my changes.
- [x] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
