### PR TITLE
fix(oas3): auto-generate per-variant examples for `oneOf`/`anyOf` request bodies (#10765)

### DIFF
--- a/src/core/plugins/oas3/components/request-body.jsx
+++ b/src/core/plugins/oas3/components/request-body.jsx
@@ -30,6 +30,57 @@ export const getDefaultRequestBodyValue = (requestBody, mediaType, activeExample
   return stringify(exampleValue)
 }
 
+/**
+ * When a schema uses `oneOf` or `anyOf` and the media type has no explicit
+ * `examples` object, synthesize one example entry per subschema so that the
+ * existing ExamplesSelect dropdown can be used to switch between them.
+ *
+ * Returns an Immutable OrderedMap shaped like the `examples` object from the
+ * OpenAPI spec (each entry has at least a `summary` and a `value`), or `null`
+ * when the schema does not use `oneOf`/`anyOf`.
+ */
+export const getOneOfExamples = (requestBody, mediaType, fn) => {
+  const mediaTypeValue = requestBody.getIn(["content", mediaType]) ?? OrderedMap()
+
+  const hasExamplesKey = mediaTypeValue.get("examples") !== undefined
+  if (hasExamplesKey)
+    return null
+
+  const schema = mediaTypeValue.get("schema", OrderedMap())
+  const schemaJS = typeof schema.toJS === "function" ? schema.toJS() : schema
+
+  const variants = schemaJS.oneOf ?? schemaJS.anyOf ?? null
+  if (!Array.isArray(variants) || variants.length < 2)
+    return null
+
+  const keyword = schemaJS.oneOf ? "oneOf" : "anyOf"
+
+  // Build a parent schema that omits the oneOf/anyOf key so that
+  // getSampleSchema generates a sample for each individual variant.
+  const { [keyword]: _omitted, ...parentWithoutVariants } = schemaJS
+
+  const entries = variants.map((variant, index) => {
+    const variantSchema = fn.mergeJsonSchema
+      ? fn.mergeJsonSchema(parentWithoutVariants, variant)
+      : variant
+
+    const nameFromRef = variant["$$ref"]
+      ?.replace(/^.*#\/components\/schemas\//, "")
+      ?.replace(/^.*#\/definitions\//, "")
+    const summary =
+      variant.title ?? variant["x-summary"] ?? nameFromRef ?? `${keyword}[${index}]`
+    const value = fn.getSampleSchema(
+      fromJS(variantSchema),
+      mediaType,
+      { includeWriteOnly: true }
+    )
+
+    return [summary, Map({ summary, value: stringify(value) })]
+  })
+
+  return OrderedMap(entries)
+}
+
 
 
 const RequestBody = ({
@@ -85,18 +136,23 @@ const RequestBody = ({
   const mediaTypeValue = requestBodyContent.get(contentType) ?? OrderedMap()
   const schemaForMediaType = mediaTypeValue.get("schema", OrderedMap())
   const rawExamplesOfMediaType = mediaTypeValue.get("examples", null)
-  const sampleForMediaType = rawExamplesOfMediaType?.map((container, key) => {
-    const val = container?.get("value", null)
-    if(val) {
-      container = container.set("value", getDefaultRequestBodyValue(
-        requestBody,
-        contentType,
-        key,
-        fn,
-      ), val)
-    }
-    return container
-  })
+  const oneOfExamples = rawExamplesOfMediaType
+    ? null
+    : getOneOfExamples(requestBody, contentType, fn)
+  const sampleForMediaType = rawExamplesOfMediaType
+    ? rawExamplesOfMediaType.map((container, key) => {
+        const val = container?.get("value", null)
+        if(val) {
+          container = container.set("value", getDefaultRequestBodyValue(
+            requestBody,
+            contentType,
+            key,
+            fn,
+          ), val)
+        }
+        return container
+      })
+    : oneOfExamples
 
   const handleExamplesSelect = (key /*, { isSyntheticChange } */) => {
     updateActiveExamplesKey(key)

--- a/src/core/plugins/oas3/components/request-body.jsx
+++ b/src/core/plugins/oas3/components/request-body.jsx
@@ -57,7 +57,8 @@ export const getOneOfExamples = (requestBody, mediaType, fn) => {
 
   // Build a parent schema that omits the oneOf/anyOf key so that
   // getSampleSchema generates a sample for each individual variant.
-  const { [keyword]: _omitted, ...parentWithoutVariants } = schemaJS
+  const parentWithoutVariants = { ...schemaJS }
+  delete parentWithoutVariants[keyword]
 
   const entries = variants.map((variant, index) => {
     const variantSchema = fn.mergeJsonSchema
@@ -307,12 +308,14 @@ const RequestBody = ({
     </div>
   }
 
-  const sampleRequestBody = getDefaultRequestBodyValue(
-    requestBody,
-    contentType,
-    activeExamplesKey,
-    fn,
-  )
+  const sampleRequestBody = oneOfExamples
+    ? (oneOfExamples.get(activeExamplesKey) ?? oneOfExamples.first())?.get("value") ?? ""
+    : getDefaultRequestBodyValue(
+        requestBody,
+        contentType,
+        activeExamplesKey,
+        fn,
+      )
   let language = null
   let testValueForJson = getKnownSyntaxHighlighterLanguage(sampleRequestBody)
   if (testValueForJson) {

--- a/test/unit/core/plugins/oas3/request-body.js
+++ b/test/unit/core/plugins/oas3/request-body.js
@@ -1,0 +1,237 @@
+/**
+ * @prettier
+ */
+import { fromJS, OrderedMap } from "immutable"
+import { getOneOfExamples } from "core/plugins/oas3/components/request-body"
+import {
+  sampleFromSchema,
+  mergeJsonSchema,
+  memoizedSampleFromSchema,
+  memoizedCreateXMLExample,
+} from "core/plugins/json-schema-5-samples/fn/index"
+import makeGetSampleSchema from "core/plugins/json-schema-5-samples/fn/get-sample-schema"
+import makeGetJsonSampleSchema from "core/plugins/json-schema-5-samples/fn/get-json-sample-schema"
+import makeGetYamlSampleSchema from "core/plugins/json-schema-5-samples/fn/get-yaml-sample-schema"
+import makeGetXmlSampleSchema from "core/plugins/json-schema-5-samples/fn/get-xml-sample-schema"
+
+const getSystem = () => ({
+  fn: {
+    memoizedSampleFromSchema,
+    memoizedCreateXMLExample,
+    mergeJsonSchema,
+    sampleFromSchema,
+    getJsonSampleSchema: makeGetJsonSampleSchema(getSystem),
+    getYamlSampleSchema: makeGetYamlSampleSchema(getSystem),
+    getXmlSampleSchema: makeGetXmlSampleSchema(getSystem),
+    getSampleSchema: makeGetSampleSchema(getSystem),
+  },
+})
+
+const buildRequestBody = (schema, extras = {}) =>
+  fromJS({
+    content: {
+      "application/json": {
+        schema,
+        ...extras,
+      },
+    },
+  })
+
+describe("getOneOfExamples", () => {
+  const { fn } = getSystem()
+  const mediaType = "application/json"
+
+  describe("when schema has oneOf with multiple variants", () => {
+    const schema = {
+      oneOf: [
+        {
+          title: "RegisteredUser",
+          type: "object",
+          properties: {
+            userType: { type: "string", example: "registered" },
+            username: { type: "string", example: "john_doe" },
+          },
+        },
+        {
+          title: "GuestUser",
+          type: "object",
+          properties: {
+            userType: { type: "string", example: "guest" },
+            displayName: { type: "string", example: "Guest-42" },
+          },
+        },
+      ],
+    }
+    const requestBody = buildRequestBody(schema)
+
+    it("returns an OrderedMap with one entry per variant", () => {
+      const result = getOneOfExamples(requestBody, mediaType, fn)
+      expect(OrderedMap.isOrderedMap(result)).toBe(true)
+      expect(result.size).toBe(2)
+    })
+
+    it("uses the variant title as the map key and summary", () => {
+      const result = getOneOfExamples(requestBody, mediaType, fn)
+      expect(result.has("RegisteredUser")).toBe(true)
+      expect(result.has("GuestUser")).toBe(true)
+      expect(result.getIn(["RegisteredUser", "summary"])).toBe("RegisteredUser")
+      expect(result.getIn(["GuestUser", "summary"])).toBe("GuestUser")
+    })
+
+    it("generates a distinct value for each variant", () => {
+      const result = getOneOfExamples(requestBody, mediaType, fn)
+      const registeredValue = result.getIn(["RegisteredUser", "value"])
+      const guestValue = result.getIn(["GuestUser", "value"])
+      expect(registeredValue).not.toEqual(guestValue)
+    })
+
+    it("each value contains the properties of its variant", () => {
+      const result = getOneOfExamples(requestBody, mediaType, fn)
+      const registered = JSON.parse(result.getIn(["RegisteredUser", "value"]))
+      const guest = JSON.parse(result.getIn(["GuestUser", "value"]))
+      expect(registered).toHaveProperty("username")
+      expect(guest).toHaveProperty("displayName")
+    })
+  })
+
+  describe("when variant has no title but has a resolved $$ref", () => {
+    const schema = {
+      oneOf: [
+        {
+          "$$ref": "#/components/schemas/RegisteredUser",
+          type: "object",
+          properties: { username: { type: "string" } },
+        },
+        {
+          "$$ref": "#/components/schemas/GuestUser",
+          type: "object",
+          properties: { displayName: { type: "string" } },
+        },
+      ],
+    }
+    const requestBody = buildRequestBody(schema)
+
+    it("extracts the schema name from $$ref as the key", () => {
+      const result = getOneOfExamples(requestBody, mediaType, fn)
+      expect(result.has("RegisteredUser")).toBe(true)
+      expect(result.has("GuestUser")).toBe(true)
+    })
+  })
+
+  describe("when variant has no title and no $$ref", () => {
+    const schema = {
+      oneOf: [
+        { type: "object", properties: { a: { type: "string" } } },
+        { type: "object", properties: { b: { type: "integer" } } },
+      ],
+    }
+    const requestBody = buildRequestBody(schema)
+
+    it("falls back to 'oneOf[index]' as the key", () => {
+      const result = getOneOfExamples(requestBody, mediaType, fn)
+      expect(result.has("oneOf[0]")).toBe(true)
+      expect(result.has("oneOf[1]")).toBe(true)
+    })
+  })
+
+  describe("when variant has x-summary extension", () => {
+    const schema = {
+      anyOf: [
+        { "x-summary": "Option A", type: "object", properties: { a: { type: "string" } } },
+        { "x-summary": "Option B", type: "object", properties: { b: { type: "string" } } },
+      ],
+    }
+    const requestBody = buildRequestBody(schema)
+
+    it("uses x-summary as the key when no title is present", () => {
+      const result = getOneOfExamples(requestBody, mediaType, fn)
+      expect(result.has("Option A")).toBe(true)
+      expect(result.has("Option B")).toBe(true)
+    })
+  })
+
+  describe("when schema has anyOf with multiple variants", () => {
+    it("falls back to 'anyOf[index]' keys when no titles are present", () => {
+      const schema = {
+        anyOf: [
+          { type: "object", properties: { a: { type: "string" } } },
+          { type: "object", properties: { b: { type: "string" } } },
+        ],
+      }
+      const result = getOneOfExamples(buildRequestBody(schema), mediaType, fn)
+      expect(result.has("anyOf[0]")).toBe(true)
+      expect(result.has("anyOf[1]")).toBe(true)
+    })
+  })
+
+  describe("when schema has only one variant", () => {
+    it("returns null (no dropdown needed for a single option)", () => {
+      const schema = {
+        oneOf: [
+          { title: "OnlyOne", type: "object", properties: { a: { type: "string" } } },
+        ],
+      }
+      const result = getOneOfExamples(buildRequestBody(schema), mediaType, fn)
+      expect(result).toBeNull()
+    })
+  })
+
+  describe("when schema has no oneOf or anyOf", () => {
+    it("returns null", () => {
+      const schema = {
+        type: "object",
+        properties: { name: { type: "string" } },
+      }
+      const result = getOneOfExamples(buildRequestBody(schema), mediaType, fn)
+      expect(result).toBeNull()
+    })
+  })
+
+  describe("when explicit examples are already present on the media type", () => {
+    it("returns null and defers to the spec-defined examples", () => {
+      const schema = {
+        oneOf: [
+          { title: "A", type: "object", properties: { a: { type: "string" } } },
+          { title: "B", type: "object", properties: { b: { type: "string" } } },
+        ],
+      }
+      const requestBody = buildRequestBody(schema, {
+        examples: {
+          myExample: { summary: "My example", value: { a: "hello" } },
+        },
+      })
+      const result = getOneOfExamples(requestBody, mediaType, fn)
+      expect(result).toBeNull()
+    })
+  })
+
+  describe("when parent schema has shared properties alongside oneOf", () => {
+    it("merges parent properties into each variant's generated sample", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          id: { type: "integer", example: 42 },
+        },
+        oneOf: [
+          {
+            title: "TypeA",
+            type: "object",
+            properties: { kindA: { type: "string", example: "a" } },
+          },
+          {
+            title: "TypeB",
+            type: "object",
+            properties: { kindB: { type: "string", example: "b" } },
+          },
+        ],
+      }
+      const result = getOneOfExamples(buildRequestBody(schema), mediaType, fn)
+      const typeA = JSON.parse(result.getIn(["TypeA", "value"]))
+      const typeB = JSON.parse(result.getIn(["TypeB", "value"]))
+      expect(typeA).toHaveProperty("id", 42)
+      expect(typeB).toHaveProperty("id", 42)
+      expect(typeA).toHaveProperty("kindA")
+      expect(typeB).toHaveProperty("kindB")
+    })
+  })
+})

--- a/test/unit/core/plugins/oas3/request-body.js
+++ b/test/unit/core/plugins/oas3/request-body.js
@@ -98,12 +98,12 @@ describe("getOneOfExamples", () => {
     const schema = {
       oneOf: [
         {
-          "$$ref": "#/components/schemas/RegisteredUser",
+          $$ref: "#/components/schemas/RegisteredUser",
           type: "object",
           properties: { username: { type: "string" } },
         },
         {
-          "$$ref": "#/components/schemas/GuestUser",
+          $$ref: "#/components/schemas/GuestUser",
           type: "object",
           properties: { displayName: { type: "string" } },
         },
@@ -137,8 +137,16 @@ describe("getOneOfExamples", () => {
   describe("when variant has x-summary extension", () => {
     const schema = {
       anyOf: [
-        { "x-summary": "Option A", type: "object", properties: { a: { type: "string" } } },
-        { "x-summary": "Option B", type: "object", properties: { b: { type: "string" } } },
+        {
+          "x-summary": "Option A",
+          type: "object",
+          properties: { a: { type: "string" } },
+        },
+        {
+          "x-summary": "Option B",
+          type: "object",
+          properties: { b: { type: "string" } },
+        },
       ],
     }
     const requestBody = buildRequestBody(schema)
@@ -168,7 +176,11 @@ describe("getOneOfExamples", () => {
     it("returns null (no dropdown needed for a single option)", () => {
       const schema = {
         oneOf: [
-          { title: "OnlyOne", type: "object", properties: { a: { type: "string" } } },
+          {
+            title: "OnlyOne",
+            type: "object",
+            properties: { a: { type: "string" } },
+          },
         ],
       }
       const result = getOneOfExamples(buildRequestBody(schema), mediaType, fn)


### PR DESCRIPTION
### Description
> **Not sure if feat or fix (?)**

When a `requestBody` schema uses `oneOf` or `anyOf` and has no explicit `examples` object, Swagger UI now generates one example per variant and lets you switch between them from the existing Examples dropdown — for both JSON and XML.

- **`getOneOfExamples()`** (`src/core/plugins/oas3/components/request-body.jsx`):
builds one example per `oneOf`/`anyOf` variant, merging shared parent schema keywords into each variant so nothing is lost. Each entry is labeled from the variant's `title`, `x-summary`, or `$ref` name (falling back to `oneOf[n]`/`anyOf[n]`). Returns `null` (no-op) when the media type already declares its own `examples`, so hand-written examples are never overridden.
- Wired into `RequestBody` as the source for the Examples dropdown whenever no explicit `examples` exist.
- **XML fix:** on first render, the body was built independently of the new per-variant examples and briefly showed `<notagname>` instead of the actual element name for the first variant. The body now reads directly from the generated example, so the correct root element name shows immediately.

### Motivation and Context
Fixes #10765

Reported issue: with a `oneOf` requestBody schema, Swagger UI only ever generated an example from the first variant, even though every variant is a valid payload. The only workaround was a hand-written `examples` object, which has to be kept in sync with the schema manually.

### How Has This Been Tested?
Manually tested locally (`npm run dev`) with a spec covering both `oneOf` and `anyOf`, each with JSON and XML media types:
- Dropdown lists one entry per variant, correctly labeled.
- Selecting an entry regenerates the body from that variant's schema.
- XML now shows the correct root element on first render (previously `<notagname>`).
- Media types with an explicit `examples` object are unaffected.

### Example
```json
  ...
    "/orders": {
      "post": {
        ...
        "requestBody": {
          "description": "One of: submit a new order or update an existing order.",
          "required": true,
          "content": {
            "application/json": {
              "schema": {
                "oneOf": [
                  { "$ref": "#/components/schemas/OrderSubmitPayload" },
                  { "$ref": "#/components/schemas/OrderUpdatePayload" }
                ]
              }
            },
            "application/xml": { ...
         ...
    "/shapes": {
      "post": {
        ...
        "requestBody": {
          "description": "Any of: a circle (kind + radius) or a rectangle (kind + width + height).",
          "required": true,
          "content": {
            "application/json": {
              "schema": {
                "anyOf": [
                  {
                    "title": "Circle",
                    "type": "object",
                    "properties": {
                      "kind": { "type": "string", "enum": ["circle"] },
                      "radius": { "type": "number" }
                    },
                    "required": ["kind", "radius"]
                  },
                  {
                    "title": "Rectangle",
                    ...
                  }
                ]
              }
            },
            "application/xml": {
            ...
            }
        }
    }
```

### Screenshots:
| Before OneOf | After OneOf |
|:------:|:-----:|
| <img width="337" height="217" alt="oneof-json" src="https://github.com/user-attachments/assets/dbf06976-a127-476a-a6ec-ce376adb3651" /> | <img width="336" height="285" alt="oneof-json-new" src="https://github.com/user-attachments/assets/a1f224b6-608c-4f27-99c1-9077cc61958a" /> |
| <img width="336" height="203" alt="oneof-xml" src="https://github.com/user-attachments/assets/7d541208-fb11-40cb-a079-c4fe61110da8" /> | <img width="335" height="266" alt="oneof-xml-new" src="https://github.com/user-attachments/assets/4c3e277f-4a95-425c-8c24-2fce4f0176c7" /> |

| Before AnyOf | After AnyOf |
|:------:|:-----:|
| <img width="195" height="144" alt="anyof-json" src="https://github.com/user-attachments/assets/fc734102-f9a5-4500-8540-8f53449fea69" /> | <img width="433" height="203" alt="anyof-json-new" src="https://github.com/user-attachments/assets/553e3359-05a5-46c4-9611-7ccbaba390ef" /> |
| <img width="283" height="149" alt="anyof-xml" src="https://github.com/user-attachments/assets/6476164a-9764-4ce9-9fc0-4dbfba669f84" /> | <img width="436" height="216" alt="anyof-xml-new" src="https://github.com/user-attachments/assets/f8558535-c7ea-4a4e-9d24-43433e479af3" /> |

## Checklist

### My PR contains...
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [x] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [x] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [x] are not breaking changes.

### Documentation
- [x] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [x] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.